### PR TITLE
Fix visible edit button for builtin objects

### DIFF
--- a/frontend/src/routes/(app)/[model=urlmodel]/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/[model=urlmodel]/[id=uuid]/+page.svelte
@@ -109,7 +109,7 @@
 		return (
 			canEditObject &&
 			!['Accepted', 'Rejected', 'Revoked'].includes(data.data.state) &&
-			!data.data.urn
+			!data.data.urn && !data.data.builtin
 		);
 	};
 	$: Object.entries(data.relatedModels).forEach(([key, value]) => {


### PR DESCRIPTION
This solution seems good as long as the "builtin" attribute keep the same meaning for all the models using it.
