### PR TITLE
CA-258 sort requirements correctly

### DIFF
--- a/backend/core/helpers.py
+++ b/backend/core/helpers.py
@@ -204,8 +204,6 @@ def get_sorted_requirement_nodes(
     for req in requirement_nodes:
         if req.order_id is None:
             req.order_id = req.created_at
-            if req.order_id is None:
-                print("arghh", req)
 
     requirement_assessment_from_requirement_id = (
         {str(ra.requirement_id): ra for ra in requirements_assessed}

--- a/backend/core/helpers.py
+++ b/backend/core/helpers.py
@@ -199,11 +199,20 @@ def get_sorted_requirement_nodes(
     Values are correctly sorted based on order_id
     If order_id is missing, sorting is based on created_at
     """
+
+    # cope for old version not creating order_id correctly
+    for req in requirement_nodes:
+        if req.order_id is None:
+            req.order_id = req.created_at
+            if req.order_id is None:
+                print("arghh", req)
+
     requirement_assessment_from_requirement_id = (
-        {str(ra.requirement.id): ra for ra in requirements_assessed}
+        {str(ra.requirement_id): ra for ra in requirements_assessed}
         if requirements_assessed
         else {}
     )
+
 
     def get_sorted_requirement_nodes_rec(
         requirement_nodes: list,
@@ -278,19 +287,12 @@ def get_sorted_requirement_nodes(
                     )
         return result
 
-    # cope for old version not creating order_id correctly
-    requirement_nodes_with_order_id = list(requirement_nodes.all())
-    for req in requirement_nodes_with_order_id:
-        if req.order_id is None:
-            req.order_id = req.created_at
-
     tree = get_sorted_requirement_nodes_rec(
-        requirement_nodes_with_order_id,
+        requirement_nodes,
         requirements_assessed,
-        sorted([rg for rg in requirement_nodes_with_order_id if not rg.parent_urn],
+        sorted([rn for rn in requirement_nodes if not rn.parent_urn],
                key=lambda x: x.order_id),
     )
-
     return tree
 
 

--- a/backend/core/helpers.py
+++ b/backend/core/helpers.py
@@ -196,6 +196,8 @@ def get_sorted_requirement_nodes(
     requirement_nodes: the list of all requirement_nodes
     requirements_assessed: the list of all requirements_assessed
     Returns a dictionary containing key=name and value={"description": description, "style": "leaf|node"}}
+    Values are correctly sorted based on order_id
+    If order_id is missing, sorting is based on created_at
     """
     requirement_assessment_from_requirement_id = (
         {str(ra.requirement.id): ra for ra in requirements_assessed}
@@ -209,7 +211,7 @@ def get_sorted_requirement_nodes(
         start: list,
     ) -> dict:
         """
-        Recursive function to build framework groups tree, within get_sorted_requirements_and_groups
+        Recursive function to build framework groups tree, within get_sorted_requirements_nodes
         start: the initial list
         """
         result = {}
@@ -231,11 +233,12 @@ def get_sorted_requirement_nodes(
                     requirement_nodes, requirements_assessed, children
                 ),
             }
-            for req in [
+            for req in sorted([
                 requirement_node
                 for requirement_node in requirement_nodes
                 if requirement_node.parent_urn == node.urn
-            ]:
+            ], key=lambda x: x.order_id):
+
                 if requirements_assessed:
                     req_as = requirement_assessment_from_requirement_id[str(req.id)]
                     result[str(node.id)]["children"][str(req.id)].update(
@@ -275,10 +278,17 @@ def get_sorted_requirement_nodes(
                     )
         return result
 
+    # cope for old version not creating order_id correctly
+    requirement_nodes_with_order_id = list(requirement_nodes.all())
+    for req in requirement_nodes_with_order_id:
+        if req.order_id is None:
+            req.order_id = req.created_at
+
     tree = get_sorted_requirement_nodes_rec(
-        requirement_nodes,
+        requirement_nodes_with_order_id,
         requirements_assessed,
-        [rg for rg in requirement_nodes if not rg.parent_urn],
+        sorted([rg for rg in requirement_nodes_with_order_id if not rg.parent_urn],
+               key=lambda x: x.order_id),
     )
 
     return tree

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -284,17 +284,6 @@ class Framework(ReferentialObjectMixin):
         verbose_name = _("Framework")
         verbose_name_plural = _("Frameworks")
 
-    def get_next_order_id(self, obj_type: models.Model, _parent_urn: str = None) -> int:
-        """
-        Returns the next order id for a given object type
-        """
-        if _parent_urn:
-            return (
-                obj_type.objects.filter(framework=self, parent_urn=_parent_urn).count()
-                + 1
-            )
-        else:
-            return obj_type.objects.filter(framework=self).count() + 1
 
     def is_deletable(self) -> bool:
         """

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1015,7 +1015,7 @@ class FrameworkViewSet(BaseModelViewSet):
         _framework = Framework.objects.get(id=pk)
         return Response(
             get_sorted_requirement_nodes(
-                RequirementNode.objects.filter(framework=_framework), None
+                RequirementNode.objects.filter(framework=_framework).all(), None
             )
         )
 
@@ -1181,10 +1181,10 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
         _framework = self.get_object().framework
         return Response(
             get_sorted_requirement_nodes(
-                RequirementNode.objects.filter(framework=_framework),
+                RequirementNode.objects.filter(framework=_framework).all(),
                 RequirementAssessment.objects.filter(
                     compliance_assessment=self.get_object()
-                ),
+                ).all(),
             )
         )
 

--- a/backend/library/helpers.py
+++ b/backend/library/helpers.py
@@ -10,7 +10,9 @@ def preview_library(library) -> dict[str, list]:
     preview = {}
     requirement_nodes_list = []
     if library["objects"]["framework"].get("requirement_nodes"):
+        index=0
         for requirement_node in library["objects"]["framework"]["requirement_nodes"]:
+            index+=1
             requirement_nodes_list.append(
                 RequirementNode(
                     description=requirement_node.get("description"),
@@ -18,6 +20,7 @@ def preview_library(library) -> dict[str, list]:
                     name=requirement_node.get("name"),
                     urn=requirement_node["urn"],
                     parent_urn=requirement_node.get("parent_urn"),
+                    order_id=index,
                 )
             )
     preview["requirement_nodes"] = requirement_nodes_list

--- a/backend/library/utils.py
+++ b/backend/library/utils.py
@@ -103,8 +103,9 @@ def get_library_items(library, type: str) -> list[dict]:
 class RequirementNodeImporter:
     REQUIRED_FIELDS = {"urn"}
 
-    def __init__(self, requirement_data: dict):
+    def __init__(self, requirement_data: dict, index: int):
         self.requirement_data = requirement_data
+        self.index = index
 
     def is_valid(self) -> Union[str, None]:
         if missing_fields := self.REQUIRED_FIELDS - set(self.requirement_data.keys()):
@@ -121,7 +122,7 @@ class RequirementNodeImporter:
             ref_id=self.requirement_data.get("ref_id"),
             annotation=self.requirement_data.get("annotation"),
             provider=framework_object.provider,
-            order_id=self.requirement_data.get("order_id"),
+            order_id=self.index,
             level=self.requirement_data.get("level"),
             name=self.requirement_data.get("name"),
             description=self.requirement_data.get("description"),
@@ -154,7 +155,7 @@ class FrameworkImporter:
         requirement_node_importers = []
         import_errors = []
         for index, requirement_node_data in enumerate(requirement_nodes):
-            requirement_node_importer = RequirementNodeImporter(requirement_node_data)
+            requirement_node_importer = RequirementNodeImporter(requirement_node_data, index)
             requirement_node_importers.append(requirement_node_importer)
             if (
                 requirement_node_error := requirement_node_importer.is_valid()


### PR DESCRIPTION
fill order_id at library loading
Use order_id for sorting
When order_id is missing, use created_at instead