### PR TITLE
Fix security measure's category resetting during edition

### DIFF
--- a/frontend/src/lib/components/Forms/ModelForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm.svelte
@@ -22,6 +22,7 @@
 
 	export let form: SuperValidated<AnyZodObject>;
 	export let model: ModelInfo;
+	export let origin: string = "default";
 	export let closeModal = false;
 	export let parent: any;
 	export let suggestions: { [key: string]: any } = {};
@@ -76,6 +77,9 @@
 						.then((r) => r.json())
 						.then((r) => {
 							form.form.update((currentData) => {
+								if (origin === "edit") {
+									return currentData; // Keep the current values in the edit form.
+								}
 								return { ...currentData, category: r.category };
 							});
 						});

--- a/frontend/src/routes/(app)/[model=urlmodel]/[id=uuid]/edit/+page.svelte
+++ b/frontend/src/routes/(app)/[model=urlmodel]/[id=uuid]/edit/+page.svelte
@@ -14,4 +14,5 @@
 	selectOptions={data.selectOptions}
 	foreignKeys={data.foreignKeys}
 	model={data.model}
+	origin="edit"
 />


### PR DESCRIPTION
I added the "origin" props to ModelForm.svelte so that we can easily create conditional statements based from where the ModelForm component is has been instantiated.