### PR TITLE
set Node env to production in Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -16,6 +16,6 @@ COPY --from=builder /app/server server/
 COPY --from=builder /app/node_modules node_modules/
 COPY package.json .
 EXPOSE 3000
-ENV NODE_ENV=development
+ENV NODE_ENV=production
 ENV BODY_SIZE_LIMIT=20000000
 CMD [ "node", "server" ]


### PR DESCRIPTION
This is better for a production-grade deployment