### PR TITLE
Show an error modal when trying to access the scoring assistant without an imported risk matrix

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -65,7 +65,7 @@
 	"roleAssignments": "Role assignments",
 	"xRays": "X-rays",
 	"scoringAssistant": "Scoring assistant",
-	"scoringAssistantNoMatrixError": "Error: Your must import a risk matrix in order to access this page !",
+	"scoringAssistantNoMatrixError": "Please import a risk matrix from the library to get access to this page",
 	"libraries": "Libraries",
 	"backupRestore": "Backup & restore",
 	"myProfile": "My profile",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -65,6 +65,7 @@
 	"roleAssignments": "Role assignments",
 	"xRays": "X-rays",
 	"scoringAssistant": "Scoring assistant",
+	"scoringAssistantNoMatrixError": "Error: Your must import a risk matrix in order to access this page !",
 	"libraries": "Libraries",
 	"backupRestore": "Backup & restore",
 	"myProfile": "My profile",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -65,7 +65,7 @@
 	"roleAssignments": "Affectations de rôle",
 	"xRays": "X-rays",
 	"scoringAssistant": "Assistant d'évaluation",
-	"scoringAssistantNoMatrixError": "Erreur: Vous devez importer une matrice de risque pour pouvoir d'accéder à cette page !",
+	"scoringAssistantNoMatrixError": "Veuillez importer une matrice de risque dans la bibliothèque pour pouvoir accéder à cette page",
 	"libraries": "Bibliothèques",
 	"backupRestore": "Sauvegarde et restauration",
 	"myProfile": "Mon profil",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -65,6 +65,7 @@
 	"roleAssignments": "Affectations de rôle",
 	"xRays": "X-rays",
 	"scoringAssistant": "Assistant d'évaluation",
+	"scoringAssistantNoMatrixError": "Erreur: Vous devez importer une matrice de risque pour pouvoir d'accéder à cette page !",
 	"libraries": "Bibliothèques",
 	"backupRestore": "Sauvegarde et restauration",
 	"myProfile": "Mon profil",

--- a/frontend/src/lib/components/SideBar/SideBarItem.svelte
+++ b/frontend/src/lib/components/SideBar/SideBarItem.svelte
@@ -1,13 +1,48 @@
 <script lang="ts">
 	import { page } from '$app/stores';
+	import type { ModalSettings } from '@skeletonlabs/skeleton';
+	import { getModalStore } from '@skeletonlabs/skeleton';
 	import { localItems } from '$lib/utils/locales';
 	import { languageTag } from '$paraglide/runtime';
+	import * as m from '$paraglide/messages';
+
 	export let item: any; // TODO: type this
+
+	const modalStore = getModalStore();
 
 	$: classesActive = (href: string) =>
 		href === $page.url.pathname
 			? 'bg-primary-100 text-primary-800'
 			: 'hover:bg-primary-50 text-gray-800 ';
+
+	async function onClickScoringAssistant(event) {
+		const req = await fetch(`/risk-matrices`);
+		const risk_matrices = await req.json();
+
+		if (risk_matrices.length === 0) {
+			const modal: ModalSettings = {
+				type: 'component',
+				component: 'displayJSONModal',
+				title: m.scoringAssistantNoMatrixError(),
+				body: JSON.stringify({})
+			};
+			modalStore.trigger(modal);
+		} else {
+			const clickEvent = new MouseEvent('click', {
+				bubbles: true,
+				cancelable: false
+			});
+			event.target.dispatchEvent(clickEvent);
+		}
+	}
+
+	function onClick(event,item) {
+		if (item.name === "scoringAssistant") {
+			if (!event.cancelable) { return; }
+			event.preventDefault();
+			return onClickScoringAssistant(event);
+		}
+	}
 </script>
 
 {#each item as item}
@@ -17,6 +52,7 @@
 			item.href ?? ''
 		)}"
 		data-testid={'accordion-item-' + item.href.substring(1)}
+		on:click={(event) => onClick(event,item)}
 	>
 		<span class="px-4 flex items-center w-full space-x-2 text-xs">
 			<i class="{item.fa_icon} w-1/12" />

--- a/frontend/src/routes/(app)/risk-matrices/[id=uuid]/+server.ts
+++ b/frontend/src/routes/(app)/risk-matrices/[id=uuid]/+server.ts
@@ -1,0 +1,14 @@
+import { BASE_API_URL } from "$lib/utils/constants";
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ fetch }) => {
+	const req  = await fetch(`${BASE_API_URL}/risk-matrices/`);
+	const data = await req.json();
+
+	return new Response(JSON.stringify(data), {
+		headers: {
+			'Content-Type': 'application/json'
+		}
+	});
+}
+

--- a/frontend/tests/functional/nav.test.ts
+++ b/frontend/tests/functional/nav.test.ts
@@ -15,7 +15,14 @@ test('sidebar navigation tests', async ({ logedPage, analyticsPage, sideBar, pag
 		const locals = localItems(languageTag());
     	for await (const [key, value] of sideBar.items) {            
 			for await (const item of value) {
-				if (item.href !== '/role-assignments') {
+				if (item.href === '/scoring-assistant') {
+					await sideBar.click(key, item.href, false);
+					await expect(logedPage.modalTitle).toBeVisible();
+					await expect(logedPage.modalTitle).toHaveText('Please import a risk matrix from the library to get access to this page');
+					await page.mouse.click(20, 20); // click outside the modal to close it
+					await expect(logedPage.modalTitle).not.toBeVisible();
+				}
+				else if (item.href !== '/role-assignments') {
 					await sideBar.click(key, item.href);
 					await expect(page).toHaveURL(item.href);
 					await logedPage.hasTitle(locals[item.name]);

--- a/frontend/tests/functional/nav.test.ts
+++ b/frontend/tests/functional/nav.test.ts
@@ -15,15 +15,15 @@ test('sidebar navigation tests', async ({ logedPage, analyticsPage, sideBar, pag
 		const locals = localItems(languageTag());
     	for await (const [key, value] of sideBar.items) {            
 			for await (const item of value) {
-				if (item.href === '/scoring-assistant') {
+				if (item.href !== '/role-assignments') {
 					await sideBar.click(key, item.href, false);
-					await expect(logedPage.modalTitle).toBeVisible();
-					await expect(logedPage.modalTitle).toHaveText('Please import a risk matrix from the library to get access to this page');
-					await page.mouse.click(20, 20); // click outside the modal to close it
-					await expect(logedPage.modalTitle).not.toBeVisible();
-				}
-				else if (item.href !== '/role-assignments') {
-					await sideBar.click(key, item.href);
+					if (item.href === '/scoring-assistant' && await logedPage.modalTitle.isVisible()) {
+						await expect(logedPage.modalTitle).toBeVisible();
+						await expect(logedPage.modalTitle).toHaveText('Please import a risk matrix from the library to get access to this page');
+						await page.mouse.click(20, 20); // click outside the modal to close it
+						await expect(logedPage.modalTitle).not.toBeVisible();
+						continue;
+					}
 					await expect(page).toHaveURL(item.href);
 					await logedPage.hasTitle(locals[item.name]);
 					await logedPage.hasBreadcrumbPath([locals[item.name]]);

--- a/frontend/tests/functional/user-route.test.ts
+++ b/frontend/tests/functional/user-route.test.ts
@@ -95,7 +95,7 @@ test('user usual routine actions are working correctly', async ({
 		//TODO assert that the reference control data are displayed in the table
 	});
 
-	await test.step('user can create a applied control', async () => {
+	await test.step('user can create an applied control', async () => {
 		await sideBar.click('Context', pages.appliedControlsPage.url);
 		await pages.appliedControlsPage.hasUrl();
 		await pages.appliedControlsPage.hasTitle();

--- a/frontend/tests/utils/sidebar.ts
+++ b/frontend/tests/utils/sidebar.ts
@@ -33,13 +33,13 @@ export class SideBar {
 		this.toggleButton = this.page.getByTestId('sidebar-toggle-btn');
 	}
 
-	async click(parent: string, tab: string) {
+	async click(parent: string, tab: string, waitForURL: boolean = true) {
 		if (!(await this.page.getByTestId('accordion-item-' + tab.substring(1)).isVisible())) {
 			await this.page.locator('#' + parent.toLowerCase().replace(' ', '-')).click();
 		}
 		await expect(this.page.getByTestId('accordion-item-' + tab.substring(1))).toBeVisible();
 		await this.page.getByTestId('accordion-item-' + tab.substring(1)).click();
-		await this.page.waitForURL(tab);
+		waitForURL ? await this.page.waitForURL(tab) : null;
 	}
 
 	async goto(page: PageContent) {


### PR DESCRIPTION
Things we can do in the future :

- Improve the appearance of the modal. (the 'displayJSONModal' modal type is not meant to dispay a single string).
- We could store a boolean value in the sessionStorage to track if the user has an imported risk matrix available or not in the future in order to make the load time of the scoring assistant faster (because there will be no need to fetch each time we click on the link of the scoring assistant)