### PR TITLE
Fix the error when submitting a threat edit form with a null value for the provider

### DIFF
--- a/frontend/src/lib/utils/schemas.ts
+++ b/frontend/src/lib/utils/schemas.ts
@@ -70,7 +70,7 @@ export const RiskAssessmentSchema = baseNamedObject({
 
 export const ThreatSchema = baseNamedObject({
 	folder: z.string(),
-	provider: z.string().optional()
+	provider: z.string().optional().nullable()
 });
 
 export const RiskScenarioSchema = baseNamedObject({


### PR DESCRIPTION
I just changed the provider field to a nullable field in the zod schema used by superform since the provider field is declared as nullable in the backend :
```
provider = models.CharField(
    max_length=200, blank=True, null=True, verbose_name=_("Provider")
)
```