### PR TITLE
Fix the requirement assessment blank status field

### DIFF
--- a/frontend/src/lib/components/Forms/ModelForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm.svelte
@@ -122,6 +122,7 @@
 			options={model.selectOptions['status']}
 			field="status"
 			label={m.status()}
+			{origin}
 		/>
 		<AutocompleteSelect
 			{form}

--- a/frontend/src/lib/components/Forms/Select.svelte
+++ b/frontend/src/lib/components/Forms/Select.svelte
@@ -10,6 +10,7 @@
 	export let label: string | undefined = undefined;
 	export let field: string;
 	export let helpText: string | undefined = undefined;
+	export let origin: string = "default";
 
 	export let color_map = {};
 
@@ -26,6 +27,11 @@
 
 	$: classesTextField = (errors: string[] | undefined) =>
 		errors && errors.length > 0 ? 'input-error' : '';
+
+	const hasBlankField = !$constraints?.required && !options.find((o) => o.label === '--');
+	let defaultOption: Element | null = null;
+
+	$: if (defaultOption && origin === "default") { defaultOption.setAttribute("selected","true"); }
 </script>
 
 <div>
@@ -57,19 +63,36 @@
 			{...$constraints}
 			{...$$restProps}
 		>
-			{#if !$constraints?.required && !options.find((o) => o.label === '--')}
+			{#if hasBlankField}
 				<option value={null} selected>--</option>
 			{/if}
-			{#each options as option}
-				<option value={option.value} style="background-color: {color_map[option.value]}"
+
+			{#each options as option, index}
+				<!-- The legend has it that one day Svelte 5 snippets will clean this horrible code repetition. -->
+				{#if index === 0 && !hasBlankField}
+					<option
+						value={option.value}
+						style="background-color: {color_map[option.value]}"
+						bind:this={defaultOption}
 					>
-					{#if localItems(languageTag())[toCamelCase(option.label)]}
-						{localItems(languageTag())[toCamelCase(option.label)]}
-					{:else}
-						{option.label}
-					{/if}
-					</option
-				>
+						{#if localItems(languageTag())[toCamelCase(option.label)]}
+							{localItems(languageTag())[toCamelCase(option.label)]}
+						{:else}
+							{option.label}
+						{/if}
+					</option>
+				{:else}
+					<option
+						value={option.value}
+						style="background-color: {color_map[option.value]}"
+					>
+						{#if localItems(languageTag())[toCamelCase(option.label)]}
+							{localItems(languageTag())[toCamelCase(option.label)]}
+						{:else}
+							{option.label}
+						{/if}
+					</option>
+				{/if}
 			{/each}
 		</select>
 	</div>

--- a/frontend/src/lib/utils/schemas.ts
+++ b/frontend/src/lib/utils/schemas.ts
@@ -60,7 +60,7 @@ export const LibraryUploadSchema = z.object({
 export const RiskAssessmentSchema = baseNamedObject({
 	version: z.string().optional().default('0.1'),
 	project: z.string(),
-	status: z.string().optional(),
+	status: z.string(),
 	risk_matrix: z.string(),
 	eta: z.string().optional().nullable(),
 	due_date: z.string().optional().nullable(),


### PR DESCRIPTION
The usage of bind:this to set the "select" attribute to the <option> element representing the default value is normal, i couldn't find any way to set the "select" attribute in a normal basic conditional block.
The select attribute was always disappearing once the component was rendered in the browser.