### PR TITLE
Clicking on the keyboard don't close the creation modal

### DIFF
--- a/frontend/src/lib/components/Forms/ModelForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
+
 	import Checkbox from '$lib/components/Forms/Checkbox.svelte';
 	import SuperForm from '$lib/components/Forms/Form.svelte';
 	import TextArea from '$lib/components/Forms/TextArea.svelte';
@@ -41,6 +43,15 @@
 	}
 	$: shape = schema.shape || schema._def.schema.shape;
 	let updated_fields = new Set();
+
+	const modelFormId = `${Math.floor(Math.random()*Math.pow(10,16))}`;
+
+	onMount(() => {
+		const form = document.querySelector(`form[model-form-id="${modelFormId}"]`);
+		const first_input = form?.querySelector(`input:not([type]), input[type="password"], input[type="tel"], input[type="email"]`);
+		console.log(first_input);
+		first_input?.focus();
+	})
 </script>
 
 <SuperForm
@@ -51,6 +62,7 @@
 	let:form
 	let:data
 	let:initialData
+	model-form-id={modelFormId}
 	validators={schema}
 	{...$$restProps}
 >


### PR DESCRIPTION
When the creation modal is opened it will automatically make the user focus on the first text-like input, it makes things a little faster for the user and the user will never have the pain to have a modal closed because he typed on his keyboard before clicking on the input.