### PR TITLE
feat: temporary hide my profile edit button for non-admin

### DIFF
--- a/frontend/src/routes/(app)/my-profile/+page.svelte
+++ b/frontend/src/routes/(app)/my-profile/+page.svelte
@@ -20,6 +20,9 @@
 
 		return filtered;
 	}
+
+	const user = $page.data.user;
+	const canEditObject: boolean = Object.hasOwn(user.permissions, `change_user`);
 </script>
 
 <div class="flex flex-col bg-white rounded-lg shadow-lg px-2 pb-4">
@@ -29,9 +32,11 @@
 			<a href="my-profile/change-password" class="btn variant-filled-primary h-fit"
 				><i class="fa-solid fa-key mr-2" />{m.changePassword()}</a
 			>
-			<a href="/users/{$page.data.user.id}/edit?next=/my-profile" class="btn variant-filled-primary h-fit"
-				><i class="fa-solid fa-pen-to-square mr-2" />{m.edit()}</a
-			>
+			{#if canEditObject}
+				<a href="/users/{$page.data.user.id}/edit?next=/my-profile" class="btn variant-filled-primary h-fit"
+					><i class="fa-solid fa-pen-to-square mr-2" />{m.edit()}</a
+				>
+			{/if}
 		</div>
 	</div>
 	<div class="flex flex-row w-full space-x-2">


### PR DESCRIPTION
**Temporary feature**

Since a non-admin user hasn't `change_user` permission, he cannot edit its personal account and get a 403. I propose to hide this button in v1.0 as a user could only change his name (not too restrictive). We'll need to add an exception to be able to update the personal account without `change_user` permission.