### PR TITLE
Fix undefined risk-assessment status

### DIFF
--- a/frontend/src/routes/(app)/risk-assessments/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/risk-assessments/[id=uuid]/+page.svelte
@@ -212,7 +212,7 @@
 					<ul>
 						<li class="pb-1">
 							<span class="font-semibold">{m.status()}:</span>
-							{localItems(languageTag())[risk_assessment.status]}
+							{risk_assessment.status === null ? "--" : localItems(languageTag())[risk_assessment.status]}
 						</li>
 						<li class="pb-1">
 							<span class="font-semibold">{m.authors()}:</span>


### PR DESCRIPTION
The risk-assessment status field is nullable, but the null value can't be translated especially because paraglide refuse to store null in its message dictionary (Error: Cannot compile message with ID "null").
So my only option was to use a ternary operator to translate null into "--".
You can change it to a better text before merging this PR if you find one.
