### PR TITLE
Return an error message when an admin try to delete the only admin account

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -835,6 +835,14 @@ class UserViewSet(BaseModelViewSet):
         # TODO: Implement a proper filter for the queryset
         return User.objects.all()
 
+    def destroy(self, request, *args, **kwargs):
+        user = self.get_object()
+        if user.user_groups.filter(name="BI-UG-ADM").exists() :
+            number_of_admin_users = User.objects.filter(user_groups__name="BI-UG-ADM").distinct().count()
+            if number_of_admin_users == 1 :
+                return Response({"error":"You can't delete the only admin account of your application."},status=HTTP_403_FORBIDDEN)
+
+        return super().destroy(request,*args,**kwargs)
 
 class UserGroupViewSet(BaseModelViewSet):
     """

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -843,7 +843,7 @@ class UserViewSet(BaseModelViewSet):
             if number_of_admin_users == 1 :
                 new_user_groups = set(request.data["user_groups"])
                 if str(admin_group.pk) not in new_user_groups :
-                    return Response({"error":"You can't remove the admin user group from the only admin user of the application."},status=HTTP_403_FORBIDDEN)
+                    return Response({"error":"attemptToRemoveOnlyAdminUserGroup"},status=HTTP_403_FORBIDDEN)
 
         return super().update(request, *args, **kwargs)
 
@@ -852,7 +852,7 @@ class UserViewSet(BaseModelViewSet):
         if user.is_admin() :
             number_of_admin_users = User.get_admin_users().count()
             if number_of_admin_users == 1 :
-                return Response({"error":"You can't delete the only admin account of your application."},status=HTTP_403_FORBIDDEN)
+                return Response({"error":"attemptToDeleteOnlyAdminAccountError"},status=HTTP_403_FORBIDDEN)
 
         return super().destroy(request,*args,**kwargs)
 

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -839,7 +839,7 @@ class UserViewSet(BaseModelViewSet):
         user = self.get_object()
         if user.is_admin() :
             number_of_admin_users = User.get_admin_users().count()
-            admin_group = UserGroup.get_admin_group()
+            admin_group = UserGroup.objects.get(name="BI-UG-ADM")
             if number_of_admin_users == 1 :
                 new_user_groups = set(request.data["user_groups"])
                 if str(admin_group.pk) not in new_user_groups :

--- a/backend/iam/models.py
+++ b/backend/iam/models.py
@@ -2,7 +2,7 @@
     Inspired from Azure IAM model """
 
 from collections import defaultdict
-from typing import Any, List, Self, Tuple
+from typing import Any, List, Self, Tuple, Self
 import uuid
 from django.utils import timezone
 from django.db import models
@@ -236,6 +236,9 @@ class UserGroup(NameDescriptionMixin, FolderMixin):
                 user_group_list.append(user_group)
         return user_group_list
 
+    @staticmethod
+    def get_admin_group():
+        return UserGroup.objects.get(name="BI-UG-ADM",builtin=True)
 
 class UserManager(BaseUserManager):
     use_in_migrations = True
@@ -290,7 +293,6 @@ class UserManager(BaseUserManager):
         superuser = self._create_user(email, password, **extra_fields)
         UserGroup.objects.get(name="BI-UG-ADM").user_set.add(superuser)
         return superuser
-
 
 class User(AbstractBaseUser, AbstractBaseModel, FolderMixin):
     """a user is a principal corresponding to a human"""
@@ -471,6 +473,12 @@ class User(AbstractBaseUser, AbstractBaseModel, FolderMixin):
     def set_username(self, username):
         self.email = username
 
+    @staticmethod
+    def get_admin_users() -> List[Self] :
+        return User.objects.filter(user_groups__name="BI-UG-ADM",user_groups__builtin=True)
+
+    def is_admin(self) -> bool :
+        return self.user_groups.filter(name="BI-UG-ADM",builtin=True).exists()
 
 class Role(NameDescriptionMixin, FolderMixin):
     """A role is a list of permissions"""

--- a/backend/iam/models.py
+++ b/backend/iam/models.py
@@ -2,7 +2,7 @@
     Inspired from Azure IAM model """
 
 from collections import defaultdict
-from typing import Any, List, Self, Tuple, Self
+from typing import Any, List, Self, Tuple
 import uuid
 from django.utils import timezone
 from django.db import models
@@ -235,10 +235,6 @@ class UserGroup(NameDescriptionMixin, FolderMixin):
             if user in user_group.user_set.all():
                 user_group_list.append(user_group)
         return user_group_list
-
-    @staticmethod
-    def get_admin_group():
-        return UserGroup.objects.get(name="BI-UG-ADM",builtin=True)
 
 class UserManager(BaseUserManager):
     use_in_migrations = True
@@ -475,10 +471,10 @@ class User(AbstractBaseUser, AbstractBaseModel, FolderMixin):
 
     @staticmethod
     def get_admin_users() -> List[Self] :
-        return User.objects.filter(user_groups__name="BI-UG-ADM",user_groups__builtin=True)
+        return User.objects.filter(user_groups__name="BI-UG-ADM")
 
     def is_admin(self) -> bool :
-        return self.user_groups.filter(name="BI-UG-ADM",builtin=True).exists()
+        return self.user_groups.filter(name="BI-UG-ADM").exists()
 
 class Role(NameDescriptionMixin, FolderMixin):
     """A role is a list of permissions"""

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -491,5 +491,7 @@
 	"libraryAlreadyImportedError": "This library has already been imported.",
 	"invalidLibraryFileError": "Invalid library file. Please make sure the format is correct.",
 	"taintedFormMessage": "Do you want to leave this page? Changes you made may not be saved.",
-	"riskScenariosStatus": "Risk scenarios status"
+	"riskScenariosStatus": "Risk scenarios status",
+	"attemptToDeleteOnlyAdminAccountError": "You can't delete the only admin account of your application.",
+	"attemptToRemoveOnlyAdminUserGroup": "You can't remove the only admin user of the application from the admin user group."
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -491,5 +491,7 @@
 	"libraryAlreadyImportedError": "Cette libairie a été déjà été importée.",
 	"invalidLibraryFileError": "Fichier de bibliothèque invalide. Veuillez vérifier le format du fichier.",
 	"taintedFormMessage": "Voulez-vous vraiment quitter cette page ? Toutes les données non enregistrées seront perdues.",
-	"riskScenariosStatus": "Statut des scénarios de risque"
+	"riskScenariosStatus": "Statut des scénarios de risque",
+	"attemptToDeleteOnlyAdminAccountError": "Vous ne pouvez pas supprimer votre unique compte administrateur de l'application.",
+	"attemptToRemoveOnlyAdminUserGroup": "Vous ne pouvez pas retirer le seul compte administrateur de l'application du groupe des administrateurs."
 }

--- a/frontend/src/lib/utils/locales.ts
+++ b/frontend/src/lib/utils/locales.ts
@@ -309,7 +309,9 @@ export function localItems(languageTag: string): LocalItems {
 		highSOK: m.highSOK({ languageTag: languageTag }),
 		libraryImportError: m.libraryImportError({ languageTag: languageTag }),
 		libraryAlreadyExistsError: m.libraryAlreadyImportedError({ languageTag: languageTag }),
-		invalidLibraryFileError: m.invalidLibraryFileError({ languageTag: languageTag })
+		invalidLibraryFileError: m.invalidLibraryFileError({ languageTag: languageTag }),
+		attemptToDeleteOnlyAdminAccountError: m.attemptToDeleteOnlyAdminAccountError({ languageTag: languageTag }),
+		attemptToRemoveOnlyAdminUserGroup: m.attemptToRemoveOnlyAdminUserGroup({ languageTag: languageTag })
 	};
 	return LOCAL_ITEMS;
 }

--- a/frontend/src/routes/(app)/[model=urlmodel]/+page.server.ts
+++ b/frontend/src/routes/(app)/[model=urlmodel]/+page.server.ts
@@ -156,7 +156,7 @@ export const actions: Actions = {
 				const response = await res.json();
 				console.log(response);
 				if (response.error) {
-					setFlash({ type: 'error', message: response.error }, event);
+					setFlash({ type: 'error', message: localItems(languageTag())[response.error] }, event);
 					return fail(403, { form: deleteForm });
 				}
 				if (response.non_field_errors) {

--- a/frontend/src/routes/(app)/[model=urlmodel]/+page.server.ts
+++ b/frontend/src/routes/(app)/[model=urlmodel]/+page.server.ts
@@ -155,6 +155,10 @@ export const actions: Actions = {
 			if (!res.ok) {
 				const response = await res.json();
 				console.log(response);
+				if (response.error) {
+					setFlash({ type: 'error', message: response.error }, event);
+					return fail(403, { form: deleteForm });
+				}
 				if (response.non_field_errors) {
 					setError(deleteForm, 'non_field_errors', response.non_field_errors);
 				}

--- a/frontend/src/routes/(app)/[model=urlmodel]/[id=uuid]/edit/+page.server.ts
+++ b/frontend/src/routes/(app)/[model=urlmodel]/[id=uuid]/edit/+page.server.ts
@@ -35,6 +35,10 @@ export const actions: Actions = {
 		if (!res.ok) {
 			const response = await res.json();
 			console.error('server response:', response);
+			if (response.error) {
+				setFlash({ type: 'error', message: response.error }, event);
+				return fail(403, { form: form });
+			}
 			if (response.non_field_errors) {
 				setError(form, 'non_field_errors', response.non_field_errors);
 			}

--- a/frontend/src/routes/(app)/users/[id=uuid]/edit/+page.server.ts
+++ b/frontend/src/routes/(app)/users/[id=uuid]/edit/+page.server.ts
@@ -2,8 +2,7 @@ import { BASE_API_URL } from '$lib/utils/constants';
 import { UserEditSchema } from '$lib/utils/schemas';
 import { setError, superValidate } from 'sveltekit-superforms/server';
 import type { PageServerLoad } from './$types';
-import { redirect, type Actions } from '@sveltejs/kit';
-import { fail } from 'assert';
+import { redirect, fail, type Actions } from '@sveltejs/kit';
 import { getModelInfo } from '$lib/utils/crud';
 import { setFlash } from 'sveltekit-flash-message/server';
 import * as m from '$paraglide/messages';
@@ -58,6 +57,10 @@ export const actions: Actions = {
 		if (!res.ok) {
 			const response = await res.json();
 			console.error('server response:', response);
+			if (response.error) {
+				setFlash({ type: 'error', message: response.error }, event);
+				return fail(403, { form: form });
+			}
 			if (response.non_field_errors) {
 				setError(form, 'non_field_errors', response.non_field_errors);
 			}

--- a/frontend/src/routes/(app)/users/[id=uuid]/edit/+page.server.ts
+++ b/frontend/src/routes/(app)/users/[id=uuid]/edit/+page.server.ts
@@ -6,6 +6,8 @@ import { redirect, fail, type Actions } from '@sveltejs/kit';
 import { getModelInfo } from '$lib/utils/crud';
 import { setFlash } from 'sveltekit-flash-message/server';
 import * as m from '$paraglide/messages';
+import { languageTag } from '$paraglide/runtime';
+import { localItems } from '$lib/utils/locales';
 
 export const load: PageServerLoad = async ({ params, fetch }) => {
 	const URLModel = 'users';
@@ -58,7 +60,7 @@ export const actions: Actions = {
 			const response = await res.json();
 			console.error('server response:', response);
 			if (response.error) {
-				setFlash({ type: 'error', message: response.error }, event);
+				setFlash({ type: 'error', message: localItems(languageTag())[response.error] }, event);
 				return fail(403, { form: form });
 			}
 			if (response.non_field_errors) {


### PR DESCRIPTION
I removed import { fail } from 'assert'; in "frontend/src/routes/(app)/users/[id=uuid]/edit/+page.server.ts", it seems like it was an error surely from someone who auto-imported the wrong fail function in a previous commit.

According to this Mixin definition the "name" field isn't unique which means there may multiple UserGroup object with the same name :

```
class NameDescriptionMixin(AbstractBaseModel):
    name = models.CharField(max_length=200, verbose_name=_("Name"), unique=False)
```

I am not sure having 2 user groups with the exact same name should be authorized by the application, is this normal ?
If some evil user could create a user group with the same name as the admin group and bypass some permission checks.
To address this potential issue in my code i always added builtin=True when fetching the admin group since builtin objects are meant to be immutable.
