### PR TITLE
Remove the user list from the navigation sidebar for non-admin users

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -832,6 +832,8 @@ class UserViewSet(BaseModelViewSet):
     search_fields = ["email", "first_name", "last_name"]
 
     def get_queryset(self):
+        if not self.request.user.is_admin() :
+            return User.objects.none()
         # TODO: Implement a proper filter for the queryset
         return User.objects.all()
 

--- a/frontend/src/lib/components/SideBar/SideBarNavigation.svelte
+++ b/frontend/src/lib/components/SideBar/SideBarNavigation.svelte
@@ -25,11 +25,19 @@
 	// }
 
 	const user = $page.data.user;
+	const user_groups = new Set(user.user_groups.map(user_group => user_group[0]));
 
 	const items = navData.items
 		.map((item) => {
 			// Check and filter the sub-items based on user permissions
 			const filteredSubItems = item.items.filter((subItem) => {
+				if (subItem.user_groups) {
+					if (!subItem.user_groups.some(
+						user_group => user_groups.has(user_group)
+					)) {
+						return false;
+					}
+				}
 				if (subItem.permissions) {
 					return subItem.permissions.some((permission) =>
 						Object.hasOwn(user.permissions, permission)

--- a/frontend/src/lib/components/SideBar/navData.ts
+++ b/frontend/src/lib/components/SideBar/navData.ts
@@ -137,7 +137,8 @@ export const navData = {
 				{
 					name: 'users',
 					fa_icon: 'fa-solid fa-user',
-					href: '/users'
+					href: '/users',
+					user_groups: ["Global - Administrator"]
 				},
 				{
 					name: 'userGroups',

--- a/frontend/src/lib/components/SideBar/navData.ts
+++ b/frontend/src/lib/components/SideBar/navData.ts
@@ -190,3 +190,10 @@ export const navData = {
 		}
 	]
 };
+
+export const modelNavData = navData.items.reduce((acc, navMenu) => {
+	return [...acc,...navMenu.items];
+}, []).reduce((acc, item) => {
+	acc[item.href.substring(1)] = item;
+	return acc;
+}, {});

--- a/frontend/src/lib/components/SideBar/navData.ts
+++ b/frontend/src/lib/components/SideBar/navData.ts
@@ -143,7 +143,8 @@ export const navData = {
 				{
 					name: 'userGroups',
 					fa_icon: 'fa-solid fa-users',
-					href: '/user-groups'
+					href: '/user-groups',
+					user_groups: ["Global - Administrator"]
 				},
 				{
 					name: 'roleAssignments',

--- a/frontend/src/routes/(app)/[model=urlmodel]/+layout.server.ts
+++ b/frontend/src/routes/(app)/[model=urlmodel]/+layout.server.ts
@@ -1,12 +1,24 @@
 import { BASE_API_URL } from '$lib/utils/constants';
 import { listViewFields } from '$lib/utils/table';
 import { tableSourceMapper, type TableSource } from '@skeletonlabs/skeleton';
-
+import { modelNavData } from '$lib/components/SideBar/navData';
+import { error } from '@sveltejs/kit';
 import { CUSTOM_MODEL_FETCH_MAP } from '$lib/utils/crud';
 import type { urlModel } from '$lib/utils/types';
 import type { LayoutServerLoad } from './$types';
 
-export const load = (async ({ fetch, params }) => {
+export const load = (async ({ fetch, params, locals }) => {
+	const modelData = modelNavData[params.model];
+
+	if (locals.user && modelData.user_groups) {
+		const user_groups = new Set(locals.user.user_groups.map(user_group => user_group[0]));
+		if (!modelData.user_groups.some(
+			user_group => user_groups.has(user_group)
+		)) {
+			return error(403, "You are not allowed to access this page.");
+		}
+	}
+
 	let data = null;
 	if (Object.prototype.hasOwnProperty.call(CUSTOM_MODEL_FETCH_MAP, params.model)) {
 		const fetch_function = CUSTOM_MODEL_FETCH_MAP[params.model];


### PR DESCRIPTION
A non-admin can still access the user list going to the /users page by manually modifying its URL in the browser, so this is not a security fix at all.
This is just a simple frontend fix so that non-admin users don't have access to a page that is useless for them.