### PR TITLE
Fix pagination overlow when changing the number of rows per page by a bigger value

### DIFF
--- a/frontend/src/lib/components/ModelTable/RowsPerPage.svelte
+++ b/frontend/src/lib/components/ModelTable/RowsPerPage.svelte
@@ -3,7 +3,12 @@
 	import * as m from '$paraglide/messages';
 	export let handler: DataHandler;
 	const rowsPerPage = handler.getRowsPerPage();
+	const rowCount = handler.getRowCount();
 	const options = [5, 10, 20, 50, 100];
+
+	$: if ($rowCount.start >= $rowCount.total && $rowsPerPage) {
+		handler.setPage(Math.ceil($rowCount.total / $rowsPerPage));
+	}
 </script>
 
 <aside class="flex items-center">


### PR DESCRIPTION
When the pagination overflows e.g: "Showing 101 to 25 of 25" it will automatically the current page number to the last (non-empty) page.