### PR TITLE
Remove login_required decorator

### DIFF
--- a/backend/ciso_assistant/urls.py
+++ b/backend/ciso_assistant/urls.py
@@ -13,6 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.urls import include, path
 from drf_spectacular.views import (
     SpectacularAPIView,

--- a/backend/core/base_models.py
+++ b/backend/core/base_models.py
@@ -92,9 +92,9 @@ class AbstractBaseModel(models.Model):
         if not self.is_unique_in_scope(scope=scope, fields_to_check=_fields_to_check):
             for field in _fields_to_check:
                 if not self.is_unique_in_scope(scope=scope, fields_to_check=[field]):
-                    field_errors[
-                        field
-                    ] = f"{getattr(self, field)} is already used in this scope. Please choose another value."
+                    field_errors[field] = (
+                        f"{getattr(self, field)} is already used in this scope. Please choose another value."
+                    )
         super().clean()
         if field_errors:
             raise ValidationError(field_errors)

--- a/backend/core/forms.py
+++ b/backend/core/forms.py
@@ -80,9 +80,9 @@ class SearchableSelect(Select):
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)
         if self.recommended_reference_controls:
-            context[
-                "recommended_reference_controls"
-            ] = self.recommended_reference_controls
+            context["recommended_reference_controls"] = (
+                self.recommended_reference_controls
+            )
         return context
 
 
@@ -127,31 +127,31 @@ class StyledModelForm(ModelForm):
                 f.widget.attrs["id"] = (
                     f"id_{model_name}_{fname}" if model_name else f"id_{fname}"
                 )
-                f.widget.attrs[
-                    "class"
-                ] = "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5"
+                f.widget.attrs["class"] = (
+                    "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5"
+                )
             if input_type in select_inputs:
                 f.widget.attrs["id"] = f"id_{model_name}_{fname}"
-                f.widget.attrs[
-                    "autocomplete"
-                ] = "off"  # workaround for Firefox behavior: https://stackoverflow.com/questions/4831848/firefox-ignores-option-selected-selected
-                f.widget.attrs[
-                    "class"
-                ] = "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 disabled:opacity-50"
+                f.widget.attrs["autocomplete"] = (
+                    "off"  # workaround for Firefox behavior: https://stackoverflow.com/questions/4831848/firefox-ignores-option-selected-selected
+                )
+                f.widget.attrs["class"] = (
+                    "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 disabled:opacity-50"
+                )
             if input_type == Textarea:
-                f.widget.attrs[
-                    "class"
-                ] = "block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500"
+                f.widget.attrs["class"] = (
+                    "block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500"
+                )
             if input_type == CheckboxInput:
                 f.widget.attrs["id"] = f"id_{model_name}_{fname}"
-                f.widget.attrs[
-                    "class"
-                ] = "w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500"
+                f.widget.attrs["class"] = (
+                    "w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500"
+                )
             if input_type == DefaultDateInput:
                 f.widget.attrs["id"] = f"id_{model_name}_{fname}"
-                f.widget.attrs[
-                    "class"
-                ] = "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5"
+                f.widget.attrs["class"] = (
+                    "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5"
+                )
             if input_type == Select:
                 self.default_if_one(fname)
 
@@ -181,9 +181,9 @@ class FirstConnexionConfirmForm(SetPasswordForm):
         super(__class__, self).__init__(*args, **kwargs)
         for password in self.fields.items():
             password[1].widget.attrs["class"] = style
-        self.fields["terms_service"].widget.attrs[
-            "class"
-        ] = "ml-2 rounded border-gray-300 shadow-sm focus:border-indigo-600 focus:ring focus:ring-indigo-500 focus:ring-opacity-50 text-indigo-500"
+        self.fields["terms_service"].widget.attrs["class"] = (
+            "ml-2 rounded border-gray-300 shadow-sm focus:border-indigo-600 focus:ring focus:ring-indigo-500 focus:ring-opacity-50 text-indigo-500"
+        )
         self.fields["terms_service"].widget.attrs["id"] = "terms_service"
 
     terms_service = forms.BooleanField(label=_("terms and conditions of use"))

--- a/backend/iam/forms.py
+++ b/backend/iam/forms.py
@@ -1,5 +1,5 @@
-""" this module contains forms related to iam app
-"""
+"""this module contains forms related to iam app"""
+
 from django.forms import (
     CheckboxInput,
     DateInput,
@@ -61,32 +61,33 @@ class StyledModelForm(ModelForm):
                 f.widget.attrs["id"] = (
                     f"id_{model_name}_{fname}" if model_name else f"id_{fname}"
                 )
-                f.widget.attrs[
-                    "class"
-                ] = "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5"
+                f.widget.attrs["class"] = (
+                    "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5"
+                )
             if input_type in select_inputs:
                 f.widget.attrs["id"] = f"id_{model_name}_{fname}"
-                f.widget.attrs[
-                    "class"
-                ] = "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5"
+                f.widget.attrs["class"] = (
+                    "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5"
+                )
             if input_type == Textarea:
-                f.widget.attrs[
-                    "class"
-                ] = "block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500"
+                f.widget.attrs["class"] = (
+                    "block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500"
+                )
             if input_type == CheckboxInput:
                 f.widget.attrs["id"] = f"id_{model_name}_{fname}"
-                f.widget.attrs[
-                    "class"
-                ] = "w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500"
+                f.widget.attrs["class"] = (
+                    "w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500"
+                )
             if input_type == DefaultDateInput:
                 f.widget.attrs["id"] = f"id_{model_name}_{fname}"
-                f.widget.attrs[
-                    "class"
-                ] = "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5"
+                f.widget.attrs["class"] = (
+                    "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5"
+                )
 
 
 class FolderUpdateForm(StyledModelForm):
     """form to update a folder"""
+
     # pragma pylint: disable=no-member
 
     class Meta:
@@ -194,6 +195,7 @@ class UserUpdateForm(UserChangeForm, StyledModelForm):
 
 class MyProfileUpdateForm(UserChangeForm, StyledModelForm):
     """form for logged user"""
+
     # TODO: not sure this section is useful, self user could be in user list with a mention "me"
 
     def __init__(self, *args, user, **kwargs):
@@ -236,9 +238,9 @@ class UserPasswordChangeForm(AdminPasswordChangeForm):
     def __init__(self, user, *args, **kwargs):
         super().__init__(user, *args, **kwargs)
         for fname, f in self.fields.items():
-            f.widget.attrs[
-                "class"
-            ] = "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5"
+            f.widget.attrs["class"] = (
+                "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5"
+            )
             print("FNAME:", fname)
         self.fields.get("password1").widget.attrs["id"] = "password1"
         self.fields.get("password2").widget.attrs["id"] = "password2"

--- a/backend/iam/models.py
+++ b/backend/iam/models.py
@@ -1,5 +1,5 @@
-""" IAM model for CISO Assistant
-    Inspired from Azure IAM model """
+"""IAM model for CISO Assistant
+Inspired from Azure IAM model"""
 
 from collections import defaultdict
 from typing import Any, List, Self, Tuple

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 

--- a/backend/serdes/urls.py
+++ b/backend/serdes/urls.py
@@ -1,13 +1,12 @@
 from django.urls import path
-from django.contrib.auth.decorators import login_required
 
 from . import views
 
 urlpatterns = [
-    path("dump-db/", login_required(views.dump_db_view), name="dump-db"),
+    path("dump-db/", views.dump_db_view, name="dump-db"),
     path(
         "load-backup/",
-        login_required(views.LoadBackupView.as_view()),
+        views.LoadBackupView.as_view(),
         name="load-backup",
     ),
 ]

--- a/backend/serdes/views.py
+++ b/backend/serdes/views.py
@@ -26,9 +26,9 @@ def is_admin_check(user):
 def dump_db_view(request):
     response = HttpResponse(content_type="application/json")
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    response[
-        "Content-Disposition"
-    ] = f'attachment; filename="ciso-assistant-db-{timestamp}.json"'
+    response["Content-Disposition"] = (
+        f'attachment; filename="ciso-assistant-db-{timestamp}.json"'
+    )
 
     response.write(f'[{{"meta": [{{"media_version": "{VERSION}"}}]}},\n')
     # Here we dump th data to stdout


### PR DESCRIPTION
The login_required decorator was used before we switched to DRF to redirect to login page if there were no user authenticated. Since we were using session authentication up until recently, the decorator had no impact on the proper functioning of the view, even though it overlapped with the permission_classes.
It broke when we switched to token-based authentication, since it checks for session objects, which are no longer used.