### PR TITLE
Allow deletion of referential objects whose urn does not start with "…

### DIFF
--- a/frontend/src/lib/components/ModelTable/ModelTable.svelte
+++ b/frontend/src/lib/components/ModelTable/ModelTable.svelte
@@ -273,7 +273,7 @@
                 {row}
                 hasBody={$$slots.actionsBody}
                 {identifierField}
-                preventDelete={(row.meta.builtin || (row.meta.urn ?? false)) && !(row.meta.allowDeleteLibrary ?? false)}
+                preventDelete={(row.meta.builtin || (row.meta.urn.startsWith("urn:intuitem") ?? false)) && !(row.meta.allowDeleteLibrary ?? false)}
               >
                 <svelte:fragment slot="head">
                   {#if $$slots.actionsHead}


### PR DESCRIPTION
…urn:intuitem"

This is a quick and dirty way to allow deleting referential objects that are supplied by the user.

TODO: Come up with a better way to differentiate external referential objects from those packaged by intuitem.