### PR TITLE
Run functional test workflows on Ubuntu 20.04

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   functional-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       backend-directory: ./backend
       working-directory: ./frontend
@@ -27,10 +27,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       mailhog:
         image: mailhog/mailhog
-        ports: [
-          "1025:1025", 
-          "8025:8025"
-        ]
+        ports: ["1025:1025", "8025:8025"]
 
     strategy:
       max-parallel: 4

--- a/.github/workflows/startup-tests.yml
+++ b/.github/workflows/startup-tests.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   startup-functional-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     services:
       postgres:
@@ -92,7 +92,7 @@ jobs:
             ${{ env.working-directory }}/tests/reports/
           retention-days: 5
   startup-docker-compose-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       COMPOSE_TEST: True
     steps:


### PR DESCRIPTION
There seems to be an issue on Microsoft's side. See https://github.com/orgs/community/discussions/120966
Workflows fail because the runners are unable to `apt-get` packages from microsoft on `ubuntu-latest`. This PR fixes it running them on 20.04