### PR TITLE
Fix error 400 when exporting backup

### DIFF
--- a/backend/serdes/urls.py
+++ b/backend/serdes/urls.py
@@ -3,7 +3,7 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path("dump-db/", views.dump_db_view, name="dump-db"),
+    path("dump-db/", views.ExportBackupView.as_view(), name="dump-db"),
     path(
         "load-backup/",
         views.LoadBackupView.as_view(),

--- a/backend/serdes/views.py
+++ b/backend/serdes/views.py
@@ -21,9 +21,9 @@ class ExportBackupView(APIView):
             return Response(status=status.HTTP_403_FORBIDDEN)
         response = HttpResponse(content_type="application/json")
         timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-        response[
-            "Content-Disposition"
-        ] = f'attachment; filename="ciso-assistant-db-{timestamp}.json"'
+        response["Content-Disposition"] = (
+            f'attachment; filename="ciso-assistant-db-{timestamp}.json"'
+        )
 
         response.write(f'[{{"meta": [{{"media_version": "{VERSION}"}}]}},\n')
         # Here we dump th data to stdout

--- a/backend/serdes/views.py
+++ b/backend/serdes/views.py
@@ -1,47 +1,42 @@
+import io
 import json
-from django.http import HttpResponse
-from django.core import management
-from django.core.management.commands import loaddata, dumpdata
-from django.contrib.auth.decorators import user_passes_test
+import sys
 from datetime import datetime
+
+from ciso_assistant.settings import VERSION
+from django.core import management
+from django.core.management.commands import dumpdata, loaddata
+from django.http import HttpResponse
 from rest_framework import status
 from rest_framework.parsers import JSONParser
 from rest_framework.response import Response
-
 from rest_framework.views import APIView
-
-from ciso_assistant.settings import VERSION
-
-import sys
-import io
 
 from serdes.serializers import LoadBackupSerializer
 
 
-def is_admin_check(user):
-    return user.has_backup_permission
+class ExportBackupView(APIView):
+    def get(self, request, *args, **kwargs):
+        if not request.user.has_backup_permission:
+            return Response(status=status.HTTP_403_FORBIDDEN)
+        response = HttpResponse(content_type="application/json")
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        response[
+            "Content-Disposition"
+        ] = f'attachment; filename="ciso-assistant-db-{timestamp}.json"'
 
-
-@user_passes_test(is_admin_check)
-def dump_db_view(request):
-    response = HttpResponse(content_type="application/json")
-    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    response["Content-Disposition"] = (
-        f'attachment; filename="ciso-assistant-db-{timestamp}.json"'
-    )
-
-    response.write(f'[{{"meta": [{{"media_version": "{VERSION}"}}]}},\n')
-    # Here we dump th data to stdout
-    # NOTE: We will not be able to dump selected folders with this method.
-    management.call_command(
-        dumpdata.Command(),
-        exclude=["contenttypes", "auth.permission", "sessions.session"],
-        indent=4,
-        stdout=response,
-        natural_foreign=True,
-    )
-    response.write("]")
-    return response
+        response.write(f'[{{"meta": [{{"media_version": "{VERSION}"}}]}},\n')
+        # Here we dump th data to stdout
+        # NOTE: We will not be able to dump selected folders with this method.
+        management.call_command(
+            dumpdata.Command(),
+            exclude=["contenttypes", "auth.permission", "sessions.session"],
+            indent=4,
+            stdout=response,
+            natural_foreign=True,
+        )
+        response.write("]")
+        return response
 
 
 class LoadBackupView(APIView):
@@ -49,7 +44,7 @@ class LoadBackupView(APIView):
     serializer_class = LoadBackupSerializer
 
     def post(self, request, *args, **kwargs):
-        if not is_admin_check(request.user):
+        if not request.user.has_backup_permission:
             return Response(status=status.HTTP_403_FORBIDDEN)
         if request.data:
             sys.stdin = io.StringIO(json.dumps(request.data[1]))


### PR DESCRIPTION
This fixes the error 400 when attempting to export a backup.

The issue was due to dump_db_view being a function-based view, and thus not inheriting `settings.DEFAULT_AUTHENTICATION_CLASSES`, therefore assuming the authentication is session-based while it is in fact token-based.