### PR TITLE
fix: risk acceptance actions

### DIFF
--- a/frontend/src/routes/(app)/[model=urlmodel]/[id=uuid]/+layout.server.ts
+++ b/frontend/src/routes/(app)/[model=urlmodel]/[id=uuid]/+layout.server.ts
@@ -31,6 +31,8 @@ export const load: LayoutServerLoad = async ({ fetch, params }) => {
 		[K in urlModel]: RelatedModel;
 	};
 
+	const form = await superValidate(zod(z.object({ id: z.string().uuid() })));
+
 	const model = getModelInfo(params.model);
 	const relatedModels = {} as RelatedModels;
 
@@ -115,5 +117,5 @@ export const load: LayoutServerLoad = async ({ fetch, params }) => {
 			})
 		);
 	}
-	return { data, relatedModels, urlModel: params.model, model: URL_MODEL_MAP[params.model] };
+	return { data, form, relatedModels, urlModel: params.model, model: URL_MODEL_MAP[params.model] };
 };

--- a/frontend/src/routes/(app)/[model=urlmodel]/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/[model=urlmodel]/[id=uuid]/+page.svelte
@@ -81,7 +81,7 @@
 		const modalComponent: ModalComponent = {
 			ref: ConfirmModal,
 			props: {
-				_form: data.data.form,
+				_form: data.form,
 				id: id,
 				debug: false,
 				URLModel: getModelInfo('risk-acceptances').urlModel,

--- a/frontend/src/routes/(app)/risk-matrices/[id=uuid]/+layout.server.ts
+++ b/frontend/src/routes/(app)/risk-matrices/[id=uuid]/+layout.server.ts
@@ -1,5 +1,5 @@
-import { BASE_API_URL, ISO_8601_REGEX } from '$lib/utils/constants';
-import { getModelInfo, processObject } from '$lib/utils/crud';
+import { BASE_API_URL } from '$lib/utils/constants';
+import { getModelInfo } from '$lib/utils/crud';
 import { tableSourceMapper, type TableSource } from '@skeletonlabs/skeleton';
 
 import { modelSchema } from '$lib/utils/schemas';


### PR DESCRIPTION
Risk acceptance confirm modal needs a form to be triggered since superform V2. I added a simple "id" form juste to be able to trigger it, since we don't need any information about the form.