### PR TITLE
Update startup-tests.yml

### DIFF
--- a/.github/workflows/startup-tests.yml
+++ b/.github/workflows/startup-tests.yml
@@ -8,6 +8,7 @@ env:
   GITHUB_WORKFLOW: github_actions
   backend-directory: ./backend
   working-directory: ./frontend
+  POSTGRES_PASSWORD: postgres
 
 jobs:
   startup-functional-test:
@@ -18,7 +19,6 @@ jobs:
         image: postgres:14.1
         env:
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5

--- a/.github/workflows/startup-tests.yml
+++ b/.github/workflows/startup-tests.yml
@@ -18,7 +18,7 @@ jobs:
         image: postgres:14.1
         env:
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
+          POSTGRES_PASSWORD: $(uuidgen)
           POSTGRES_DB: postgres
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5

--- a/.github/workflows/startup-tests.yml
+++ b/.github/workflows/startup-tests.yml
@@ -19,6 +19,7 @@ jobs:
         image: postgres:14.1
         env:
           POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: ${{ env.POSTGRES_PASSWORD }}
           POSTGRES_DB: postgres
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5

--- a/.github/workflows/startup-tests.yml
+++ b/.github/workflows/startup-tests.yml
@@ -65,11 +65,11 @@ jobs:
           echo DJANGO_SUPERUSER_PASSWORD=1234 >> .env
           echo POSTGRES_NAME=postgres >> .env
           echo POSTGRES_USER=postgres >> .env
-          echo POSTGRES_PASSWORD=$POSTGRES_PASSWORD >> .env
+          echo POSTGRES_PASSWORD=${{ env.POSTGRES_PASSWORD }} >> .env
           echo DB_HOST=localhost >> .env
           echo CISO_ASSISTANT_SUPERUSER_EMAIL='' >> .env
           echo CISO_ASSISTANT_URL=http://localhost:4173 >> .env
-          echo "THIS IS A TEST, DO NOT KEEP IT. $POSTGRES_PASSWORD"
+          echo "THIS IS A TEST, DO NOT KEEP IT;" ${{ env.POSTGRES_PASSWORD }}
       - name: Run migrations
         working-directory: ${{ env.backend-directory }}
         run: |

--- a/.github/workflows/startup-tests.yml
+++ b/.github/workflows/startup-tests.yml
@@ -8,8 +8,7 @@ env:
   GITHUB_WORKFLOW: github_actions
   backend-directory: ./backend
   working-directory: ./frontend
-  POSTGRES_PASSWORD: $(uuidgen)
-
+  
 jobs:
   startup-functional-test:
     runs-on: ubuntu-20.04
@@ -19,7 +18,7 @@ jobs:
         image: postgres:14.1
         env:
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: ${{ env.POSTGRES_PASSWORD }}
+          POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
@@ -66,11 +65,10 @@ jobs:
           echo DJANGO_SUPERUSER_PASSWORD=1234 >> .env
           echo POSTGRES_NAME=postgres >> .env
           echo POSTGRES_USER=postgres >> .env
-          echo POSTGRES_PASSWORD=${{ env.POSTGRES_PASSWORD }} >> .env
+          echo POSTGRES_PASSWORD=postgres >> .env
           echo DB_HOST=localhost >> .env
           echo CISO_ASSISTANT_SUPERUSER_EMAIL='' >> .env
           echo CISO_ASSISTANT_URL=http://localhost:4173 >> .env
-          echo "THIS IS A TEST, DO NOT KEEP IT;" ${{ env.POSTGRES_PASSWORD }}
       - name: Run migrations
         working-directory: ${{ env.backend-directory }}
         run: |

--- a/.github/workflows/startup-tests.yml
+++ b/.github/workflows/startup-tests.yml
@@ -18,7 +18,7 @@ jobs:
         image: postgres:14.1
         env:
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5

--- a/.github/workflows/startup-tests.yml
+++ b/.github/workflows/startup-tests.yml
@@ -18,7 +18,7 @@ jobs:
         image: postgres:14.1
         env:
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: $(uuidgen)
+          POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5

--- a/.github/workflows/startup-tests.yml
+++ b/.github/workflows/startup-tests.yml
@@ -65,10 +65,11 @@ jobs:
           echo DJANGO_SUPERUSER_PASSWORD=1234 >> .env
           echo POSTGRES_NAME=postgres >> .env
           echo POSTGRES_USER=postgres >> .env
-          echo POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }} >> .env
+          echo POSTGRES_PASSWORD=$POSTGRES_PASSWORD >> .env
           echo DB_HOST=localhost >> .env
           echo CISO_ASSISTANT_SUPERUSER_EMAIL='' >> .env
           echo CISO_ASSISTANT_URL=http://localhost:4173 >> .env
+          echo "THIS IS A TEST, DO NOT KEEP IT. $POSTGRES_PASSWORD"
       - name: Run migrations
         working-directory: ${{ env.backend-directory }}
         run: |

--- a/.github/workflows/startup-tests.yml
+++ b/.github/workflows/startup-tests.yml
@@ -8,7 +8,7 @@ env:
   GITHUB_WORKFLOW: github_actions
   backend-directory: ./backend
   working-directory: ./frontend
-  POSTGRES_PASSWORD: postgres
+  POSTGRES_PASSWORD: $(uuidgen)
 
 jobs:
   startup-functional-test:


### PR DESCRIPTION
avoid using a secret for postres password:
- this has no security benefit, as the service is running on localhost for the test runner
- this makes external PRs fail, because they are not allowed to get the secret. To be reviewed carefully before merge.