### PR TITLE
use test credential for Postgres

### DIFF
--- a/.github/workflows/backend-api-tests.yml
+++ b/.github/workflows/backend-api-tests.yml
@@ -39,7 +39,6 @@ jobs:
               working-directory: ${{env.working-directory}}
               run: |
                 touch .env
-                echo DJANGO_SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }} >> .env
                 echo DJANGO_DEBUG='True' >> .env
                 echo DB_HOST=localhost >> .env
                 echo EMAIL_HOST=localhost >> .env

--- a/.github/workflows/backend-coverage.yaml
+++ b/.github/workflows/backend-coverage.yaml
@@ -20,7 +20,7 @@ jobs:
         image: postgres:14.1
         env:
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_PASSWORD: postgres # test credential
           POSTGRES_DB: postgres
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
@@ -46,11 +46,10 @@ jobs:
         working-directory: ${{env.working-directory}}
         run: |
           touch .env
-          echo DJANGO_SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }} >> .env
           echo DJANGO_DEBUG='True' >> .env
           echo POSTGRES_NAME=postgres >> .env
           echo POSTGRES_USER=postgres >> .env
-          echo POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }} >> .env
+          echo POSTGRES_PASSWORD=postgers >> .env
           echo DB_HOST=localhost >> .env
           echo EMAIL_HOST=localhost >> .env
           echo EMAIL_PORT=1025 >> .env

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -21,7 +21,7 @@ jobs:
         image: postgres:14.1
         env:
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_PASSWORD: postgres # test credential
           POSTGRES_DB: postgres
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
@@ -68,12 +68,11 @@ jobs:
         working-directory: ${{ env.backend-directory }}
         run: |
           touch .env
-          echo DJANGO_SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }} >> .env
           echo DJANGO_SUPERUSER_EMAIL=admin@tests.com >> .env
           echo DJANGO_SUPERUSER_PASSWORD=1234 >> .env
           echo POSTGRES_NAME=postgres >> .env
           echo POSTGRES_USER=postgres >> .env
-          echo POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }} >> .env
+          echo POSTGRES_PASSWORD=postgres >> .env
           echo DB_HOST=localhost >> .env
           echo CISO_ASSISTANT_SUPERUSER_EMAIL='' >> .env
           echo CISO_ASSISTANT_URL=http://localhost:4173 >> .env

--- a/.github/workflows/startup-tests.yml
+++ b/.github/workflows/startup-tests.yml
@@ -60,7 +60,6 @@ jobs:
         working-directory: ${{ env.backend-directory }}
         run: |
           touch .env
-          echo DJANGO_SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }} >> .env
           echo DJANGO_SUPERUSER_EMAIL=admin@tests.com >> .env
           echo DJANGO_SUPERUSER_PASSWORD=1234 >> .env
           echo POSTGRES_NAME=postgres >> .env
@@ -114,7 +113,6 @@ jobs:
         working-directory: ${{ env.backend-directory }}
         run: |
           touch .env
-          echo DJANGO_SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }} >> .env
           export $(grep -v '^#' .env | xargs)
       - name: Config the Docker app
         run: |


### PR DESCRIPTION
- PG is running on localhost => no risk of undue access (moreover, this is only a test database)
- This will allow external PR.
- Also remove DJANGO_QECRET_KEY, which is selected randomly if not specified in environment