### PR TITLE
avoid store conflict

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -149,6 +149,13 @@ class StoredLibrary(LibraryMixin):
         urn = library_data["urn"]
         locale = library_data.get("locale", "en")
         version = int(library_data["version"])
+
+        is_stored = StoredLibrary.objects.filter(
+            urn=urn, locale=locale, version=version
+        ).exists()
+        if is_stored:
+            return None  # We do not store the library if it is same content
+
         is_loaded = LoadedLibrary.objects.filter(
             urn=urn, locale=locale, version=version
         ).exists()

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -150,10 +150,9 @@ class StoredLibrary(LibraryMixin):
         locale = library_data.get("locale", "en")
         version = int(library_data["version"])
 
-        is_stored = StoredLibrary.objects.filter(
+        if StoredLibrary.objects.filter(
             urn=urn, locale=locale, version=version
-        ).exists()
-        if is_stored:
+        ).exists():
             return None  # We do not store the library if it is same content
 
         is_loaded = LoadedLibrary.objects.filter(


### PR DESCRIPTION
Avoid library store error if hash changed but the triplet (urn, locale, version) is unchanged.