### PR TITLE
Fix functional tests github action artifacts

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -99,8 +99,8 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: functional-tests-report
+          name: functional-tests-report-${{ matrix.playwright-browser }}
           path: |
-            ${{ env.working-directory }}/tests/${{ matrix.playwright-browser }}results/
-            ${{ env.working-directory }}/tests/${{ matrix.playwright-browser }}reports/
+            ${{ env.working-directory }}/tests/results/
+            ${{ env.working-directory }}/tests/reports/
           retention-days: 5


### PR DESCRIPTION
Artifacts were not uploaded anymore in the functional tests action since the split by browser of the tests