### PR TITLE
User can add evidences from applied controls

### DIFF
--- a/frontend/src/lib/components/ModelTable/LibraryActions.svelte
+++ b/frontend/src/lib/components/ModelTable/LibraryActions.svelte
@@ -28,6 +28,7 @@
 
 {#if actionsURLModel === 'stored-libraries' && Object.hasOwn(library, 'is_loaded') && !library.is_loaded}
 	{#if loading.form && loading.library === library.urn}
+		<!-- Put this in a snippet once we update to svelte 5 -->
 		<div class="flex items-center cursor-progress" role="status">
 			<svg
 				aria-hidden="true"

--- a/frontend/src/lib/components/ModelTable/ModelTable.svelte
+++ b/frontend/src/lib/components/ModelTable/ModelTable.svelte
@@ -11,7 +11,6 @@
 	import type { SuperValidated } from 'sveltekit-superforms';
 	import type { AnyZodObject } from 'zod';
 	import type { TableSource } from './types';
-	import * as m from '$paraglide/messages';
 	import { localItems, toCamelCase } from '$lib/utils/locales';
 	import { languageTag } from '$paraglide/runtime';
 	import { ISO_8601_REGEX } from '$lib/utils/constants';
@@ -61,6 +60,11 @@
 	export let regionFootCell: CssClasses = '';
 
 	export let displayActions = true;
+
+	export let addOption: boolean = false;
+	export let containerModel: object | undefined; // Find a better name for this prop ?
+	export let containerObject: object | undefined; // Find a better name for this prop ?
+	export let containerReferences: Set<string> = new Set();
 
 	function onRowClick(
 		event: SvelteEvent<MouseEvent | KeyboardEvent, HTMLTableRowElement>,
@@ -282,10 +286,14 @@
                 URLModel={actionsURLModel}
                 detailURL={`/${actionsURLModel}/${row.meta[identifierField]}${detailQueryParameter}`}
                 editURL={!(row.meta.builtin || row.meta.urn) ? `/${actionsURLModel}/${row.meta[identifierField]}/edit?next=${$page.url.pathname}` : undefined}
-                {row}
+                row={row.meta}
                 hasBody={$$slots.actionsBody}
                 {identifierField}
                 preventDelete={preventDelete(row)}
+								{containerModel}
+								{containerObject}
+								{containerReferences}
+								{addOption}
               >
                 <svelte:fragment slot="head">
                   {#if $$slots.actionsHead}

--- a/frontend/src/lib/components/TableRowActions/TableRowActions.svelte
+++ b/frontend/src/lib/components/TableRowActions/TableRowActions.svelte
@@ -7,7 +7,6 @@
 	import { getModalStore } from '@skeletonlabs/skeleton';
 	import type { SuperValidated } from 'sveltekit-superforms';
 	import type { AnyZodObject } from 'zod';
-
 	import * as m from '$paraglide/messages';
 
 	const modalStore: ModalStore = getModalStore();
@@ -21,6 +20,13 @@
 	export let URLModel: urlModel | string | undefined;
 	export let identifierField = 'id';
 	export let preventDelete = false;
+
+	export let addOption: boolean = false;
+	export let containerModel: object | undefined; // Find a better name for this prop N
+	export let containerObject: { id: string; [key: string]: any } | undefined; // Find a better name for this prop ?
+	export let containerReferences: Set<string>;
+	let addLoading = false;
+	let removeLoading = false;
 
 	export let hasBody = false;
 
@@ -56,6 +62,14 @@
 	$: displayEdit =
 		canEditObject && URLModel && !['frameworks', 'risk-matrices'].includes(URLModel) && editURL;
 	$: displayDelete = canDeleteObject && deleteForm !== undefined;
+
+	const displayAdd =
+		containerModel &&
+		containerModel.reverseForeignKeyFields &&
+		containerModel.reverseForeignKeyFields.filter(
+			(field) => field.urlModel === model.urlModel && addOption
+		).length > 0;
+	let isInsideObject = containerReferences.has(row.id);
 </script>
 
 <span
@@ -64,6 +78,97 @@
 	<slot name="head" />
 	<slot name="body" />
 	{#if !hasBody}
+		{#if displayAdd && containerObject}
+			{#if isInsideObject}
+				<button
+					class="cursor-pointer hover:text-primary-500"
+					on:click={(e) => {
+						const formData = new FormData();
+						formData.append('evidence', row.id);
+						addLoading = true;
+
+						fetch(`/applied_controls/${containerObject.id}?/remove_evidence`, {
+							method: 'POST',
+							body: formData
+						}).then((res) => {
+							if (res.ok) {
+								isInsideObject = false;
+							} else {
+								removeLoading = false;
+							}
+						});
+						e.stopPropagation();
+					}}
+				>
+					{#if removeLoading}
+						<div class="flex items-center cursor-progress" role="status">
+							<svg
+								aria-hidden="true"
+								class="w-5 h-5 text-gray-200 animate-spin dark:text-gray-600 fill-primary-500"
+								viewBox="0 0 100 101"
+								fill="none"
+								xmlns="http://www.w3.org/2000/svg"
+							>
+								<path
+									d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
+									fill="currentColor"
+								/>
+								<path
+									d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
+									fill="currentFill"
+								/>
+							</svg>
+						</div>
+					{:else}
+						<i class="fa-solid fa-square-minus" />
+					{/if}
+				</button>
+			{:else}
+				<button
+					class="cursor-pointer hover:text-primary-500"
+					on:click={(e) => {
+						const formData = new FormData();
+						formData.append('evidence', row.id);
+						addLoading = true;
+
+						fetch(`/applied_controls/${containerObject.id}?/add_evidence`, {
+							method: 'POST',
+							body: formData
+						}).then((res) => {
+							if (res.ok) {
+								isInsideObject = true;
+							} else {
+								addLoading = false;
+							}
+						});
+						e.stopPropagation();
+					}}
+				>
+					{#if addLoading}
+						<div class="flex items-center cursor-progress" role="status">
+							<svg
+								aria-hidden="true"
+								class="w-5 h-5 text-gray-200 animate-spin dark:text-gray-600 fill-primary-500"
+								viewBox="0 0 100 101"
+								fill="none"
+								xmlns="http://www.w3.org/2000/svg"
+							>
+								<path
+									d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
+									fill="currentColor"
+								/>
+								<path
+									d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
+									fill="currentFill"
+								/>
+							</svg>
+						</div>
+					{:else}
+						<i class="fa-solid fa-plus" />
+					{/if}
+				</button>
+			{/if}
+		{/if}
 		{#if displayDetail}
 			<a
 				href={detailURL}

--- a/frontend/src/lib/utils/crud.ts
+++ b/frontend/src/lib/utils/crud.ts
@@ -102,6 +102,8 @@ interface ForeignKeyField {
 	field: string;
 	urlModel: urlModel;
 	urlParams?: string;
+	displayAll?: boolean;
+	addOption?: boolean;
 }
 
 interface Field {
@@ -115,6 +117,7 @@ interface SelectField {
 }
 
 export interface ModelMapEntry {
+	urlModel: string;
 	name: string;
 	localName: string;
 	localNamePlural: string;
@@ -134,6 +137,7 @@ type ModelMap = {
 
 export const URL_MODEL_MAP: ModelMap = {
 	folders: {
+		urlModel: 'folders',
 		name: 'folder',
 		localName: 'domain',
 		localNamePlural: 'domains',
@@ -145,6 +149,7 @@ export const URL_MODEL_MAP: ModelMap = {
 		reverseForeignKeyFields: [{ field: 'folder', urlModel: 'projects' }]
 	},
 	projects: {
+		urlModel: 'projects',
 		name: 'project',
 		localName: 'project',
 		localNamePlural: 'projects',
@@ -159,6 +164,7 @@ export const URL_MODEL_MAP: ModelMap = {
 		filters: [{ field: 'lc_status' }, { field: 'folder' }]
 	},
 	'risk-matrices': {
+		urlModel: 'risk-matrices',
 		name: 'riskmatrix',
 		localName: 'riskMatrix',
 		localNamePlural: 'riskMatrices',
@@ -167,6 +173,7 @@ export const URL_MODEL_MAP: ModelMap = {
 		foreignKeyFields: [{ field: 'folder', urlModel: 'folders' }]
 	},
 	'risk-assessments': {
+		urlModel: 'risk-assessments',
 		name: 'riskassessment',
 		localName: 'riskAssessment',
 		localNamePlural: 'riskAssessments',
@@ -184,6 +191,7 @@ export const URL_MODEL_MAP: ModelMap = {
 		filters: [{ field: 'project' }, { field: 'auditor' }, { field: 'status' }]
 	},
 	threats: {
+		urlModel: 'threats',
 		name: 'threat',
 		localName: 'threat',
 		localNamePlural: 'threats',
@@ -192,6 +200,7 @@ export const URL_MODEL_MAP: ModelMap = {
 		foreignKeyFields: [{ field: 'folder', urlModel: 'folders' }]
 	},
 	'risk-scenarios': {
+		urlModel: 'risk-scenarios',
 		name: 'riskscenario',
 		localName: 'riskScenario',
 		localNamePlural: 'riskScenarios',
@@ -209,6 +218,7 @@ export const URL_MODEL_MAP: ModelMap = {
 		filters: [{ field: 'threats' }, { field: 'risk_assessment' }]
 	},
 	'applied-controls': {
+		urlModel: 'applied-controls',
 		name: 'appliedcontrol',
 		localName: 'appliedControl',
 		localNamePlural: 'appliedControls',
@@ -233,7 +243,9 @@ export const URL_MODEL_MAP: ModelMap = {
 			{ field: 'folder', urlModel: 'folders' },
 			{ field: 'evidences', urlModel: 'evidences' }
 		],
-		reverseForeignKeyFields: [{ field: 'applied_controls', urlModel: 'evidences' }],
+		reverseForeignKeyFields: [
+			{ displayAll: true, urlModel: 'evidences', field: 'applied_controls', addOption: true }
+		],
 		selectFields: [{ field: 'status' }, { field: 'category' }, { field: 'effort' }],
 		filters: [
 			{ field: 'reference_control' },
@@ -244,6 +256,7 @@ export const URL_MODEL_MAP: ModelMap = {
 		]
 	},
 	policies: {
+		urlModel: 'policies',
 		name: 'appliedcontrol',
 		localName: 'policy',
 		localNamePlural: 'policies',
@@ -263,6 +276,7 @@ export const URL_MODEL_MAP: ModelMap = {
 		]
 	},
 	'risk-acceptances': {
+		urlModel: 'risk-acceptances',
 		name: 'riskacceptance',
 		localName: 'riskAcceptance',
 		localNamePlural: 'riskAcceptances',
@@ -280,6 +294,7 @@ export const URL_MODEL_MAP: ModelMap = {
 		filters: [{ field: 'risk_scenarios' }, { field: 'folder' }, { field: 'approver' }]
 	},
 	'reference-controls': {
+		urlModel: 'reference-controls',
 		name: 'referencecontrol',
 		localName: 'referenceControl',
 		localNamePlural: 'referenceControls',
@@ -290,6 +305,7 @@ export const URL_MODEL_MAP: ModelMap = {
 		filters: [{ field: 'folder' }]
 	},
 	assets: {
+		urlModel: 'assets',
 		name: 'asset',
 		localName: 'asset',
 		localNamePlural: 'assets',
@@ -303,6 +319,7 @@ export const URL_MODEL_MAP: ModelMap = {
 		filters: [{ field: 'parent_assets' }, { field: 'folder' }, { field: 'type' }]
 	},
 	users: {
+		urlModel: 'users',
 		name: 'user',
 		localName: 'user',
 		localNamePlural: 'users',
@@ -312,6 +329,7 @@ export const URL_MODEL_MAP: ModelMap = {
 		filters: []
 	},
 	'user-groups': {
+		urlModel: 'user-groups',
 		name: 'usergroup',
 		localName: 'userGroup',
 		localNamePlural: 'userGroups',
@@ -322,6 +340,7 @@ export const URL_MODEL_MAP: ModelMap = {
 		filters: []
 	},
 	'role-assignments': {
+		urlModel: 'role-assignments',
 		name: 'roleassignment',
 		localName: 'roleAssignment',
 		localNamePlural: 'roleAssignments',
@@ -331,6 +350,7 @@ export const URL_MODEL_MAP: ModelMap = {
 		filters: []
 	},
 	frameworks: {
+		urlModel: 'frameworks',
 		name: 'framework',
 		localName: 'framework',
 		localNamePlural: 'frameworks',
@@ -344,6 +364,7 @@ export const URL_MODEL_MAP: ModelMap = {
 		]
 	},
 	evidences: {
+		urlModel: 'evidences',
 		name: 'evidence',
 		localName: 'evidence',
 		localNamePlural: 'evidences',
@@ -356,6 +377,7 @@ export const URL_MODEL_MAP: ModelMap = {
 		]
 	},
 	'compliance-assessments': {
+		urlModel: 'compliance-assessments',
 		name: 'complianceassessment',
 		localName: 'complianceAssessment',
 		localNamePlural: 'complianceAssessments',
@@ -371,6 +393,7 @@ export const URL_MODEL_MAP: ModelMap = {
 		filters: [{ field: 'status' }]
 	},
 	requirements: {
+		urlModel: 'requirements',
 		name: 'requirement',
 		localName: 'requirement',
 		localNamePlural: 'requirements',
@@ -378,6 +401,7 @@ export const URL_MODEL_MAP: ModelMap = {
 		verboseNamePlural: 'Requirements'
 	},
 	'requirement-assessments': {
+		urlModel: 'requirement-assessments',
 		name: 'requirementassessment',
 		localName: 'requirementAssessment',
 		localNamePlural: 'requirementAssessments',
@@ -391,6 +415,7 @@ export const URL_MODEL_MAP: ModelMap = {
 		]
 	},
 	'stored-libraries': {
+		urlModel: 'stored-libraries',
 		name: 'storedlibrary',
 		localName: 'stored library',
 		localNamePlural: 'stored libraries',
@@ -398,6 +423,7 @@ export const URL_MODEL_MAP: ModelMap = {
 		verboseNamePlural: 'stored Libraries'
 	},
 	'loaded-libraries': {
+		urlModel: 'loaded-libraries',
 		name: 'loadedlibrary',
 		localName: 'loaded library',
 		localNamePlural: 'loaded libraries',

--- a/frontend/src/routes/(app)/[model=urlmodel]/[id=uuid]/+layout.server.ts
+++ b/frontend/src/routes/(app)/[model=urlmodel]/[id=uuid]/+layout.server.ts
@@ -19,6 +19,7 @@ export const load: LayoutServerLoad = async ({ fetch, params }) => {
 
 	type RelatedModel = {
 		urlModel: urlModel;
+		addOption: boolean;
 		info: ModelMapEntry;
 		table: TableSource;
 		deleteForm: SuperValidated<AnyZodObject>;
@@ -43,7 +44,9 @@ export const load: LayoutServerLoad = async ({ fetch, params }) => {
 		const initialData = {};
 		await Promise.all(
 			model.reverseForeignKeyFields.map(async (e) => {
-				const relEndpoint = `${BASE_API_URL}/${e.urlModel}/?${e.field}=${params.id}`;
+				const relEndpoint = e.displayAll
+					? `${BASE_API_URL}/${e.urlModel}/`
+					: `${BASE_API_URL}/${e.urlModel}/?${e.field}=${params.id}`;
 				const res = await fetch(relEndpoint);
 				const revData = await res.json().then((res) => res.results);
 
@@ -62,6 +65,7 @@ export const load: LayoutServerLoad = async ({ fetch, params }) => {
 				};
 
 				const info = getModelInfo(e.urlModel);
+				const addOption = Boolean(e.addOption);
 				const urlModel = e.urlModel;
 
 				const deleteForm = await superValidate(zod(z.object({ id: z.string().uuid() })));
@@ -116,6 +120,7 @@ export const load: LayoutServerLoad = async ({ fetch, params }) => {
 				}
 				relatedModels[e.urlModel] = {
 					urlModel,
+					addOption,
 					info,
 					table,
 					deleteForm,

--- a/frontend/src/routes/(app)/[model=urlmodel]/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/[model=urlmodel]/[id=uuid]/+page.svelte
@@ -25,6 +25,7 @@
 	const toastStore: ToastStore = getToastStore();
 
 	export let data;
+
 	$: data.relatedModels = Object.fromEntries(Object.entries(data.relatedModels).sort());
 
 	if (data.model.detailViewFields) {
@@ -276,7 +277,23 @@
 							</h4>
 						</div>
 						{#if model.table}
-							<ModelTable source={model.table} deleteForm={model.deleteForm} URLModel={urlmodel}>
+							<!-- Using data.urlModel.replace("-","_") may not work with some url models (right now it just transforms "applied-controls" to "applied_controls" because we need to access model.foreignKeys.applied_controls) -->
+							{@const containerReferences = model.addOption
+								? new Set(
+										model.foreignKeys[data.urlModel.replace('-', '_')]
+											.filter((obj) => obj.id === data.data.id)[0]
+											[urlmodel].map((obj) => obj.id)
+								  )
+								: undefined}
+							<ModelTable
+								source={model.table}
+								deleteForm={model.deleteForm}
+								URLModel={urlmodel}
+								addOption={model.addOption}
+								containerObject={data.data}
+								containerModel={data.model}
+								{containerReferences}
+							>
 								<button
 									slot="addButton"
 									class="btn variant-filled-primary self-end my-auto"

--- a/frontend/src/routes/(app)/applied_controls/[id=uuid]/+page.server.ts
+++ b/frontend/src/routes/(app)/applied_controls/[id=uuid]/+page.server.ts
@@ -1,0 +1,51 @@
+import { BASE_API_URL, URN_REGEX } from '$lib/utils/constants';
+
+import { fail, type Actions } from '@sveltejs/kit';
+import { setFlash } from 'sveltekit-flash-message/server';
+
+export const actions: Actions = {
+	add_evidence: async (event) => {
+		const endpoint = `${BASE_API_URL}/applied-controls/${event.params.id}/add_evidence/`;
+		const formData = await event.request.formData();
+
+		const evidence = formData.get('evidence');
+		const res = await event.fetch(endpoint, {
+			method: 'POST',
+			body: JSON.stringify({ evidence }),
+			headers: {
+				'Content-Type': 'application/json'
+			}
+		});
+		if (!res.ok) {
+			setFlash({ type: 'error', message: 'Some Localized Error Message' }, event);
+			const errorText = await res.text();
+			fail(res.status, {
+				message: errorText
+			});
+		}
+
+		setFlash({ type: 'success', message: 'Some localized success message.' }, event);
+	},
+	remove_evidence: async (event) => {
+		const endpoint = `${BASE_API_URL}/applied-controls/${event.params.id}/remove_evidence/`;
+		const formData = await event.request.formData();
+
+		const evidence = formData.get('evidence');
+		const res = await event.fetch(endpoint, {
+			method: 'POST',
+			body: JSON.stringify({ evidence }),
+			headers: {
+				'Content-Type': 'application/json'
+			}
+		});
+		if (!res.ok) {
+			setFlash({ type: 'error', message: 'Some Localized Error Message' }, event);
+			const errorText = await res.text();
+			fail(res.status, {
+				message: errorText
+			});
+		}
+
+		setFlash({ type: 'success', message: 'Some localized success message.' }, event);
+	}
+};


### PR DESCRIPTION
This is an incomplete PR, the goal is to give user the ability to add evidences to its applied control directly from the detail view of its applied control.

Current problems :

- The toast isn't displayed in the frontend (this is surely due to not using SuperForm with my buttons, but we could maybe just directly trigger the toast in the frontend).
- The toast messages are not yet localized.
- If the user has a lot of evidences he will have a hard time listing the evidences currently linked to its applied control
  - Solution 1: Adding a <input type="checkbox" ...> to filter the ModelTable to it only displays the evidences currently linked to the applied control
  - Solution 2 (which is better): Displaying a second ModelTable in a second tabgroup (the first ModelTable of the tabgroup being one displaying the evidences linked to the applied control and the second ModelTable displaying all existing evidences and allowing the user to link these evidences to its applied control).
 
