### PR TITLE
feat: unescape html after cleaning

### DIFF
--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -11,7 +11,7 @@ from django.contrib.auth import get_user_model
 from django.db import models
 from core.serializer_fields import FieldsRelatedField
 
-import structlog, bleach
+import structlog, bleach, html
 
 logger = structlog.get_logger(__name__)
 
@@ -54,7 +54,7 @@ class BaseModelSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(e.args[0])
 
     def validate_name(self, value):
-        clean_value = bleach.clean(value, tags=[], attributes={})
+        clean_value = html.unescape(bleach.clean(value, strip=True))
         if clean_value != value:
             raise serializers.ValidationError(
                 "The name must not contain characters from HTML tags or attributes."

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -57,7 +57,7 @@ class BaseModelSerializer(serializers.ModelSerializer):
         clean_value = html.unescape(bleach.clean(value, strip=True))
         if clean_value != value:
             raise serializers.ValidationError(
-                "The name must not contain characters from HTML tags or attributes."
+                "The name is not valid due to HTML tags or attributes"
             )
         return value
 


### PR DESCRIPTION
To resolve #534

Now html tags and attributes are still cleaned but characters like `"&", ">", ...` are unescaped