### PR TITLE
Use a symbol for the special actions field of the field component map

### DIFF
--- a/frontend/src/lib/components/ModelTable/ModelTable.svelte
+++ b/frontend/src/lib/components/ModelTable/ModelTable.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import TableRowActions from '$lib/components/TableRowActions/TableRowActions.svelte';
-	import { FIELD_COLORED_TAG_MAP, FIELD_COMPONENT_MAP } from '$lib/utils/crud';
+	import {
+		FIELD_COLORED_TAG_MAP,
+		FIELD_COMPONENT_MAP,
+		CUSTOM_ACTIONS_COMPONENT
+	} from '$lib/utils/crud';
 	import { createEventDispatcher, onMount } from 'svelte';
 
 	import { tableA11y } from './actions';
@@ -278,7 +282,7 @@
 						>
             <slot name="actions" meta={row.meta}>
             {#if row.meta[identifierField]}
-              {@const actionsComponent = field_component_map['actions']}
+              {@const actionsComponent = field_component_map[CUSTOM_ACTIONS_COMPONENT]}
               {@const actionsURLModel = source.meta.urlmodel ?? URLModel}
               <TableRowActions
                 deleteForm={deleteForm}

--- a/frontend/src/lib/utils/crud.ts
+++ b/frontend/src/lib/utils/crud.ts
@@ -415,21 +415,23 @@ export const URL_MODEL_MAP: ModelMap = {
 	}
 };
 
+export const CUSTOM_ACTIONS_COMPONENT = Symbol('CustomActions');
+
 export const FIELD_COMPONENT_MAP = {
 	evidences: {
 		attachment: EvidenceFilePreview
 	},
 	libraries: {
 		locale: LanguageDisplay,
-		actions: LibraryActions
+		[CUSTOM_ACTIONS_COMPONENT]: LibraryActions
 	},
 	// "stored-libraries": {
 	// 	locale: LanguageDisplay,
-	// 	actions: LibraryActions
+	// 	[CUSTOM_ACTIONS_COMPONENT]: LibraryActions
 	// },
 	// "loaded-libraries": {
 	// 	locale: LanguageDisplay
-	// 	// actions: LibraryActions
+	// 	// [CUSTOM_ACTIONS_COMPONENT]: LibraryActions
 	// },
 	'user-groups': {
 		localization_dict: UserGroupNameDisplay


### PR DESCRIPTION
As "actions" was a special key with a different purpose than the other keys that can be declared in the field component map, and because we might one day have a field named "actions" in some object.

We can't let the "actions" key be enumerable and let it forbid us from naming an object field "actions" just because we couldn't use a custom component to display it in the model table.

Using a Symbol for a special key like this one is cleaner.
