### PR TITLE
Fix mismatch between data model and flash mode

### DIFF
--- a/frontend/src/routes/(app)/compliance-assessments/[id=uuid]/flash-mode/+page.server.ts
+++ b/frontend/src/routes/(app)/compliance-assessments/[id=uuid]/flash-mode/+page.server.ts
@@ -25,6 +25,7 @@ export const load = (async ({ fetch, params }) => {
 export const actions: Actions = {
 	updateRequirementAssessment: async (event) => {
 		const data = await event.request.json();
+		console.debug(data);
 		const value: { id: string; result: string } = data;
 		const URLModel = 'requirement-assessments';
 		const endpoint = `${BASE_API_URL}/${URLModel}/${value.id}/`;
@@ -34,6 +35,7 @@ export const actions: Actions = {
 			body: JSON.stringify(value)
 		};
 
-		await event.fetch(endpoint, requestInitOptions);
+		const res = await event.fetch(endpoint, requestInitOptions);
+		console.debug(await res.json());
 	}
 };

--- a/frontend/src/routes/(app)/compliance-assessments/[id=uuid]/flash-mode/+page.server.ts
+++ b/frontend/src/routes/(app)/compliance-assessments/[id=uuid]/flash-mode/+page.server.ts
@@ -25,7 +25,6 @@ export const load = (async ({ fetch, params }) => {
 export const actions: Actions = {
 	updateRequirementAssessment: async (event) => {
 		const data = await event.request.json();
-		console.debug(data);
 		const value: { id: string; result: string } = data;
 		const URLModel = 'requirement-assessments';
 		const endpoint = `${BASE_API_URL}/${URLModel}/${value.id}/`;
@@ -36,6 +35,6 @@ export const actions: Actions = {
 		};
 
 		const res = await event.fetch(endpoint, requestInitOptions);
-		console.debug(await res.json());
+		return { status: res.status, body: await res.json() };
 	}
 };

--- a/frontend/src/routes/(app)/compliance-assessments/[id=uuid]/flash-mode/+page.svelte
+++ b/frontend/src/routes/(app)/compliance-assessments/[id=uuid]/flash-mode/+page.svelte
@@ -10,7 +10,7 @@
 	breadcrumbObject.set(data.compliance_assessment);
 
 	const possible_options = [
-		{ id: '', label: m.notAssessed() },
+		{ id: 'not_assessed', label: m.notAssessed() },
 		{ id: 'non_compliant', label: m.nonCompliant() },
 		{ id: 'partially_compliant', label: m.partiallyCompliant() },
 		{ id: 'compliant', label: m.compliant() },


### PR DESCRIPTION
In flash mode, the `not_assessed` result was assigned an empty string, while in the data model, it is represented by the string `'not_assessed'`