### PR TITLE
fix: handle no first/last name during sso login

### DIFF
--- a/backend/iam/sso/saml/views.py
+++ b/backend/iam/sso/saml/views.py
@@ -135,14 +135,14 @@ class FinishACSView(SAMLViewMixin, View):
             email = auth._nameid
             user = User.objects.get(email=email)
             idp_first_name = auth._attributes.get(
-                "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname"
+                "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname", [""]
             )[0]
             idp_last_name = auth._attributes.get(
-                "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname"
+                "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname", [""]
             )[0]
-            if user.first_name != idp_first_name:
+            if idp_first_name and user.first_name != idp_first_name:
                 user.first_name = idp_first_name
-            if user.last_name != idp_last_name:
+            if idp_last_name and user.last_name != idp_last_name:
                 user.last_name = idp_last_name
             user.is_sso = True
             user.save()


### PR DESCRIPTION
During the SSO login, if the user has not configured his first name or last name on the IdP, an error will be triggered.
This PR prevents that.