### PR TITLE
hotfix: firefox pipeline deactivation

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -33,7 +33,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: ["3.11"]
-        playwright-browser: ["chromium", "firefox"]
+        playwright-browser: ["chromium"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Functional tests on firefox browser are uncertain due to dependency problems with playwright on GitHub Actions.
This PR deactivate it to to prevent checks from failing randomly.