### PR TITLE
Avoid initialisation error in case of welcome mail sending failure

### DIFF
--- a/backend/iam/models.py
+++ b/backend/iam/models.py
@@ -275,12 +275,10 @@ class UserManager(BaseUserManager):
         """create a normal user following Django convention"""
         logger.info("creating user", email=email)
         extra_fields.setdefault("is_superuser", False)
-        if not (EMAIL_HOST or EMAIL_HOST_RESCUE):
-            extra_fields.setdefault("mailing", False)
         return self._create_user(
             email=email,
             password=password,
-            mailing=True,
+            mailing=(EMAIL_HOST or EMAIL_HOST_RESCUE),
             initial_group=None,
             **extra_fields,
         )
@@ -291,13 +289,10 @@ class UserManager(BaseUserManager):
         extra_fields.setdefault("is_superuser", True)
         if extra_fields.get("is_superuser") is not True:
             raise ValueError("Superuser must have is_superuser=True.")
-        extra_fields.setdefault(
-            "mailing", not (password) and (EMAIL_HOST or EMAIL_HOST_RESCUE)
-        )
         superuser = self._create_user(
             email=email,
             password=password,
-            mailing=True,
+            mailing=not (password) and (EMAIL_HOST or EMAIL_HOST_RESCUE),
             intial_group=UserGroup.objects.get(name="BI-UG-ADM"),
             **extra_fields,
         )

--- a/backend/iam/models.py
+++ b/backend/iam/models.py
@@ -227,9 +227,20 @@ class UserGroup(NameDescriptionMixin, FolderMixin):
 class UserManager(BaseUserManager):
     use_in_migrations = True
 
-    def _create_user(self, email, password, mailing=True, **extra_fields):
+    def _create_user(
+        self,
+        email: str,
+        password: str,
+        mailing: bool,
+        initial_group: UserGroup,
+        **extra_fields,
+    ):
         """
         Create and save a user with the given email, and password.
+        If mailing is set, send a welcome mail
+        If initial_group is given, put the new user in this group
+        On mail error, raise a corresponding exception, but the user is properly created
+        TODO: find a better way to manage mailing error
         """
 
         validate_email(email)
@@ -245,7 +256,8 @@ class UserManager(BaseUserManager):
         user.user_groups.set(extra_fields.get("user_groups", []))
         user.password = make_password(password if password else str(uuid.uuid4()))
         user.save(using=self._db)
-
+        if initial_group:
+            initial_group.user_set.add(user)
         logger.info("user created sucessfully", user=user)
 
         if mailing:
@@ -259,14 +271,22 @@ class UserManager(BaseUserManager):
                 raise exception
         return user
 
-    def create_user(self, email, password=None, **extra_fields):
+    def create_user(self, email: str, password: str = None, **extra_fields):
+        """create a normal user following Django convention"""
         logger.info("creating user", email=email)
         extra_fields.setdefault("is_superuser", False)
         if not (EMAIL_HOST or EMAIL_HOST_RESCUE):
             extra_fields.setdefault("mailing", False)
-        return self._create_user(email, password, **extra_fields)
+        return self._create_user(
+            email=email,
+            password=password,
+            mailing=True,
+            initial_group=None,
+            **extra_fields,
+        )
 
-    def create_superuser(self, email, password=None, **extra_fields):
+    def create_superuser(self, email: str, password: str = None, **extra_fields):
+        """create a superuser following Django convention"""
         logger.info("creating superuser", email=email)
         extra_fields.setdefault("is_superuser", True)
         if extra_fields.get("is_superuser") is not True:
@@ -274,8 +294,13 @@ class UserManager(BaseUserManager):
         extra_fields.setdefault(
             "mailing", not (password) and (EMAIL_HOST or EMAIL_HOST_RESCUE)
         )
-        superuser = self._create_user(email, password, **extra_fields)
-        UserGroup.objects.get(name="BI-UG-ADM").user_set.add(superuser)
+        superuser = self._create_user(
+            email=email,
+            password=password,
+            mailing=True,
+            intial_group=UserGroup.objects.get(name="BI-UG-ADM"),
+            **extra_fields,
+        )
         return superuser
 
 

--- a/backend/iam/models.py
+++ b/backend/iam/models.py
@@ -293,7 +293,7 @@ class UserManager(BaseUserManager):
             email=email,
             password=password,
             mailing=not (password) and (EMAIL_HOST or EMAIL_HOST_RESCUE),
-            intial_group=UserGroup.objects.get(name="BI-UG-ADM"),
+            initial_group=UserGroup.objects.get(name="BI-UG-ADM"),
             **extra_fields,
         )
         return superuser


### PR DESCRIPTION
Make all tasks before sending mail, especially putting a superuser in the global admin group. Otherwise, the superuser can be created without any right, which makes the instance unusable.