### PR TITLE
feat: allow sso configuration without metadata url

### DIFF
--- a/frontend/src/lib/components/Forms/ModelForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm.svelte
@@ -827,17 +827,22 @@
 							cacheLock={cacheLocks['idp_entity_id']}
 							bind:cachedValue={formDataCache['idp_entity_id']}
 						/>
+						<p class="text-gray-600 text-sm">Option 1: Fill the metadata url</p>
 						<TextField
 							{form}
 							field="metadata_url"
 							label={m.metadataURL()}
-							required={data.provider === 'saml'}
 							disabled={!data.is_enabled}
 							cacheLock={cacheLocks['metadata_url']}
 							bind:cachedValue={formDataCache['metadata_url']}
 						/>
+						<div class="flex items-center justify-center w-full space-x-2">
+							<hr class="w-1/2 items-center bg-gray-200 border-0" />
+							<span class="flex items-center text-gray-600 text-sm">{m.or()}</span>
+							<hr class="w-1/2 items-center bg-gray-200 border-0" />
+						</div>
+						<p class="text-gray-600 text-sm">Option 2: Fill the SSO URL, SLO URL and x509cert</p>
 						<TextField
-							hidden
 							{form}
 							field="sso_url"
 							label={m.SSOURL()}
@@ -846,7 +851,6 @@
 							bind:cachedValue={formDataCache['sso_url']}
 						/>
 						<TextField
-							hidden
 							{form}
 							field="slo_url"
 							label={m.SLOURL()}
@@ -855,7 +859,6 @@
 							bind:cachedValue={formDataCache['slo_url']}
 						/>
 						<TextArea
-							hidden
 							{form}
 							field="x509cert"
 							label={m.x509Cert()}

--- a/frontend/src/lib/utils/schemas.ts
+++ b/frontend/src/lib/utils/schemas.ts
@@ -242,7 +242,7 @@ export const SSOSettingsSchema = z.object({
 		.preprocess(toArrayPreprocessor, z.array(z.string().optional()))
 		.optional(),
 	idp_entity_id: z.string().optional(),
-	metadata_url: z.string().url().optional(),
+	metadata_url: z.string().optional(),
 	sso_url: z.string().optional().nullable(),
 	slo_url: z.string().optional().nullable(),
 	x509cert: z.string().optional(),


### PR DESCRIPTION
Allow to configure SSO with Identity providers which don't provide a metadata URL