### PR TITLE
Fix backup imports

### DIFF
--- a/backend/core/startup.py
+++ b/backend/core/startup.py
@@ -1,11 +1,11 @@
-from django.apps import AppConfig
-from django.db.models.signals import post_migrate
 import os
 
-from ciso_assistant.settings import CISO_ASSISTANT_SUPERUSER_EMAIL
+from django.apps import AppConfig
 from django.core.management import call_command
-
+from django.db.models.signals import post_migrate
 from structlog import get_logger
+
+from ciso_assistant.settings import CISO_ASSISTANT_SUPERUSER_EMAIL
 
 logger = get_logger(__name__)
 
@@ -271,9 +271,8 @@ def startup(sender: AppConfig, **kwargs):
     Create superuser if CISO_ASSISTANT_SUPERUSER_EMAIL defined
     """
     from django.contrib.auth.models import Permission
-    from allauth.socialaccount.providers.saml.provider import SAMLProvider
+
     from iam.models import Folder, Role, RoleAssignment, User, UserGroup
-    from global_settings.models import GlobalSettings
 
     print("startup handler: initialize database")
 
@@ -372,53 +371,6 @@ def startup(sender: AppConfig, **kwargs):
             )
         except Exception as e:
             print(e)  # NOTE: Add this exception in the logger
-
-    default_attribute_mapping = SAMLProvider.default_attribute_mapping
-
-    settings = {
-        "attribute_mapping": {
-            "uid": default_attribute_mapping["uid"],
-            "email_verified": default_attribute_mapping["email_verified"],
-            "email": default_attribute_mapping["email"],
-        },
-        "idp": {
-            "entity_id": "",
-            "metadata_url": "",
-            "sso_url": "",
-            "slo_url": "",
-            "x509cert": "",
-        },
-        "sp": {
-            "entity_id": "ciso-assistant",
-        },
-        "advanced": {
-            "allow_repeat_attribute_name": True,
-            "allow_single_label_domains": False,
-            "authn_request_signed": False,
-            "digest_algorithm": "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
-            "logout_request_signed": False,
-            "logout_response_signed": False,
-            "metadata_signed": False,
-            "name_id_encrypted": False,
-            "reject_deprecated_algorithm": True,
-            "reject_idp_initiated_sso": True,
-            "signature_algorithm": "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
-            "want_assertion_encrypted": False,
-            "want_assertion_signed": False,
-            "want_attribute_statement": True,
-            "want_message_signed": False,
-            "want_name_id": False,
-            "want_name_id_encrypted": False,
-        },
-    }
-
-    if not GlobalSettings.objects.filter(name=GlobalSettings.Names.SSO).exists():
-        logger.info("SSO settings not found, creating default settings")
-        sso_settings = GlobalSettings.objects.create(
-            name=GlobalSettings.Names.SSO,
-            value={"client_id": "0", "settings": settings},
-        )
-        logger.info("SSO settings created", settings=sso_settings.value)
 
     call_command("storelibraries")
 

--- a/backend/iam/sso/saml/defaults.py
+++ b/backend/iam/sso/saml/defaults.py
@@ -1,0 +1,41 @@
+from allauth.socialaccount.providers.saml.provider import SAMLProvider
+
+
+DEFAULT_SAML_ATTRIBUTE_MAPPING = SAMLProvider.default_attribute_mapping
+
+DEFAULT_SAML_SETTINGS = {
+    "attribute_mapping": {
+        "uid": DEFAULT_SAML_ATTRIBUTE_MAPPING["uid"],
+        "email_verified": DEFAULT_SAML_ATTRIBUTE_MAPPING["email_verified"],
+        "email": DEFAULT_SAML_ATTRIBUTE_MAPPING["email"],
+    },
+    "idp": {
+        "entity_id": "",
+        "metadata_url": "",
+        "sso_url": "",
+        "slo_url": "",
+        "x509cert": "",
+    },
+    "sp": {
+        "entity_id": "ciso-assistant",
+    },
+    "advanced": {
+        "allow_repeat_attribute_name": True,
+        "allow_single_label_domains": False,
+        "authn_request_signed": False,
+        "digest_algorithm": "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
+        "logout_request_signed": False,
+        "logout_response_signed": False,
+        "metadata_signed": False,
+        "name_id_encrypted": False,
+        "reject_deprecated_algorithm": True,
+        "reject_idp_initiated_sso": True,
+        "signature_algorithm": "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
+        "want_assertion_encrypted": False,
+        "want_assertion_signed": False,
+        "want_attribute_statement": True,
+        "want_message_signed": False,
+        "want_name_id": False,
+        "want_name_id_encrypted": False,
+    },
+}

--- a/backend/serdes/views.py
+++ b/backend/serdes/views.py
@@ -21,9 +21,9 @@ class ExportBackupView(APIView):
             return Response(status=status.HTTP_403_FORBIDDEN)
         response = HttpResponse(content_type="application/json")
         timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-        response[
-            "Content-Disposition"
-        ] = f'attachment; filename="ciso-assistant-db-{timestamp}.json"'
+        response["Content-Disposition"] = (
+            f'attachment; filename="ciso-assistant-db-{timestamp}.json"'
+        )
 
         response.write(f'[{{"meta": [{{"media_version": "{VERSION}"}}]}},\n')
         # Here we dump th data to stdout

--- a/backend/serdes/views.py
+++ b/backend/serdes/views.py
@@ -3,7 +3,6 @@ import json
 import sys
 from datetime import datetime
 
-from ciso_assistant.settings import VERSION
 from django.core import management
 from django.core.management.commands import dumpdata, loaddata
 from django.http import HttpResponse
@@ -12,6 +11,7 @@ from rest_framework.parsers import JSONParser
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from ciso_assistant.settings import VERSION
 from serdes.serializers import LoadBackupSerializer
 
 
@@ -21,9 +21,9 @@ class ExportBackupView(APIView):
             return Response(status=status.HTTP_403_FORBIDDEN)
         response = HttpResponse(content_type="application/json")
         timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-        response["Content-Disposition"] = (
-            f'attachment; filename="ciso-assistant-db-{timestamp}.json"'
-        )
+        response[
+            "Content-Disposition"
+        ] = f'attachment; filename="ciso-assistant-db-{timestamp}.json"'
 
         response.write(f'[{{"meta": [{{"media_version": "{VERSION}"}}]}},\n')
         # Here we dump th data to stdout
@@ -66,6 +66,7 @@ class LoadBackupView(APIView):
                     "contenttypes",
                     "auth.permission",
                     "sessions.session",
+                    "iam.ssosettings",
                     "knox.authtoken",
                 ],
             )


### PR DESCRIPTION
There was an issue when importing a database backup, due to `SSOSettingsQuerySet` failing to get the GlobalSettings object after a restore.
This was fixed by moving the `SSOSettings` object's creation to its queryset's first evaluation instead of post-migrate.