### PR TITLE
Fix potential information disclosure

### DIFF
--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -86,7 +86,7 @@ class BaseModelSerializer(serializers.ModelSerializer):
             return object_created
         except Exception as e:
             logger.error(e)
-            raise serializers.ValidationError(e.args[0])
+            raise serializers.ValidationError()
 
     class Meta:
         model: models.Model


### PR DESCRIPTION
serializers.ValidationError is passed to the ViewSet and returned to the client. Displaying the message of the exception WILL cause unwanted information disclosure.