### PR TITLE
added a text when no preview available on evidence

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -739,5 +739,6 @@
 	"nameDuplicate": "Name already exists",
 	"noAnswer": "No answer",
 	"successfullyUpdatedClientSettings": "Client settings successfully updated, please refresh the page.",
-	"xRaysEmptyMessage": "You have to create at least one project to use X-rays."
+	"xRaysEmptyMessage": "You have to create at least one project to use X-rays.",
+	"NoPreviewMessage": "No preview available."
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -672,5 +672,6 @@
 	"owner": "Propriétaire",
 	"waitingRiskAcceptances": "Bonjour ! Vous avez actuellement {number} risque{s} en attente d'acceptation. Vous pouvez les retrouver dans l'onglet risque.",
 	"successfullyUpdatedClientSettings": "Paramètres du client mis à jour avec succès. Vous pouvez rafrachir la page.",
-	"xRaysEmptyMessage": "Vous devez créer au moins un projet pour utiliser X-rays."
+	"xRaysEmptyMessage": "Vous devez créer au moins un projet pour utiliser X-rays.",
+	"NoPreviewMessage": "Aucun aperçu disponible."
 }

--- a/frontend/src/lib/components/ModelTable/EvidenceFilePreview.svelte
+++ b/frontend/src/lib/components/ModelTable/EvidenceFilePreview.svelte
@@ -41,6 +41,8 @@
 			<img src={attachment.url} alt="attachment" class="h-24" />
 		{:else if attachment.type === 'application/pdf'}
 			<embed src={attachment.url} type="application/pdf" class="h-24" />
+		{:else}
+			<p>{m.NoPreviewMessage()}</p>
 		{/if}
 	{:else}
 		<span data-testid="loading-field">

--- a/frontend/src/routes/(app)/(third-party)/evidences/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/evidences/[id=uuid]/+page.svelte
@@ -182,6 +182,10 @@
 					<img src={attachment.url} alt="attachment" />
 				{:else if attachment.type === 'application/pdf'}
 					<embed src={attachment.url} type="application/pdf" width="100%" height="600px" />
+				{:else}
+					<div class="flex items-center justify-center space-x-4">
+						<p class="font-bold text-sm">{m.NoPreviewMessage()}</p>
+					</div>
 				{/if}
 			{:else}
 				<span data-testid="loading-field">


### PR DESCRIPTION
Added a text "No preview available" when the file of the evidence can not be previewed by the browser.