### PR TITLE
chore: Add nested evidence list in policies (like in applied controls)

### DIFF
--- a/frontend/src/lib/utils/crud.ts
+++ b/frontend/src/lib/utils/crud.ts
@@ -289,6 +289,7 @@ export const URL_MODEL_MAP: ModelMap = {
 			{ field: 'evidences', urlModel: 'evidences' },
 			{ field: 'owner', urlModel: 'users' }
 		],
+		reverseForeignKeyFields: [{ field: 'applied_controls', urlModel: 'evidences' }],
 		selectFields: [{ field: 'csf_function' }, { field: 'status' }, { field: 'effort' }],
 		filters: [
 			{ field: 'reference_control' },


### PR DESCRIPTION
If you go inside an applied control, you’ll see below its details, a table with its evidence and the possibility to manage them from the page.

We should see the list of evidence linked to a policy and be able to add them from the detail view like in an applied control.