### PR TITLE
chore: Fix thirdParty translations

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -5,6 +5,7 @@ tests/results/
 tests/reports/
 yarn.lock
 vite.config.js.timestamp-*
+vite.config.ts.timestamp-*
 /packages/create-svelte/template/CHANGELOG.md
 /packages/package/test/**/package
 /documentation/types.js

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -690,6 +690,7 @@
 	"mission": "Mission",
 	"ownedFolders": "Owned domains",
 	"thirdParty": "Third parties",
+	"thirdPartyCategory": "Third parties",
 	"entityAssessment": "Entity assessment",
 	"entityAssessments": "Entity assessments",
 	"addEntityAssessment": "Add entity assessment",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -689,7 +689,7 @@
 	"referenceLink": "Reference link",
 	"mission": "Mission",
 	"ownedFolders": "Owned domains",
-	"thirdParty": "Third parties",
+	"thirdParty": "Third party",
 	"thirdPartyCategory": "Third parties",
 	"entityAssessment": "Entity assessment",
 	"entityAssessments": "Entity assessments",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -687,7 +687,7 @@
 	"backupLoadingError": "Une erreur s'est produite lors du chargement de la sauvegarde.",
 	"backupGreaterVersionError": "Impossible de charger la sauvegarde, la version de la sauvegarde est supérieure à la version actuelle de votre application.",
 	"backupLowerVersionError": "Une erreur s'est produite, la version de sauvegarde est peut-être trop ancienne, si c'est le cas, elle doit être mise à jour avant de réessayer.",
-	"thirdParty": "Gestion des tiers",
+	"thirdPartyCategory": "Gestion des tiers",
 	"catalog": "Catalogue",
 	"actions": "Actions"
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -687,6 +687,7 @@
 	"backupLoadingError": "Une erreur s'est produite lors du chargement de la sauvegarde.",
 	"backupGreaterVersionError": "Impossible de charger la sauvegarde, la version de la sauvegarde est supérieure à la version actuelle de votre application.",
 	"backupLowerVersionError": "Une erreur s'est produite, la version de sauvegarde est peut-être trop ancienne, si c'est le cas, elle doit être mise à jour avant de réessayer.",
+	"thirdParty": "Tiers",
 	"thirdPartyCategory": "Gestion des tiers",
 	"catalog": "Catalogue",
 	"actions": "Actions"

--- a/frontend/src/lib/components/SideBar/SideBarCategory.svelte
+++ b/frontend/src/lib/components/SideBar/SideBarCategory.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
 	export let item: any; // Specify the type of 'item' as a key of 'Sidebar'
 	import { safeTranslate } from '$lib/utils/i18n';
-	import { localItems } from '$lib/utils/locales';
-	import { languageTag } from '$paraglide/runtime';
 </script>
 
 <span class="whitespace-nowrap text-primary-800 font-semibold uppercase tracking-tighter text-xs">

--- a/frontend/src/lib/components/SideBar/SideBarCategory.svelte
+++ b/frontend/src/lib/components/SideBar/SideBarCategory.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	export let item: any; // Specify the type of 'item' as a key of 'Sidebar'
+	import { safeTranslate } from '$lib/utils/i18n';
 	import { localItems } from '$lib/utils/locales';
 	import { languageTag } from '$paraglide/runtime';
 </script>
 
 <span class="whitespace-nowrap text-primary-800 font-semibold uppercase tracking-tighter text-xs">
-	{localItems()[item.name]}
+	{safeTranslate(item.name)}
 </span>

--- a/frontend/src/lib/components/SideBar/navData.ts
+++ b/frontend/src/lib/components/SideBar/navData.ts
@@ -177,7 +177,7 @@ export const navData = {
 		},
 
 		{
-			name: 'thirdParty',
+			name: 'thirdPartyCategory',
 			items: [
 				{
 					name: 'entities',


### PR DESCRIPTION
Translating “third party” to “gestion des tiers” results in wrong badge for TP users.

The ‘third party’ label in the sidebar should have its own identifier.