### PR TITLE
Added a next link when editing audit in analytics 

### DIFF
--- a/frontend/src/routes/(app)/(internal)/analytics/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/analytics/+page.svelte
@@ -532,7 +532,7 @@
 									<div class="absolute top-2 right-4 mt-2 space-x-1">
 										<div class="flex flex-col space-y-1">
 											<a
-												href="/compliance-assessments/{compliance_assessment.id}/edit"
+												href="/compliance-assessments/{compliance_assessment.id}/edit?next=/analytics?tab=3"
 												class="btn variant-filled-primary"
 												><i class="fa-solid fa-edit mr-2" /> {m.edit()}
 											</a>


### PR DESCRIPTION
Added a next link when editing audit in analytics to go back to analytics ( the cancel and update button were just updating the data but were not returning to a page). 