### PR TITLE
chore: improve question layout for Firefox

### DIFF
--- a/frontend/src/lib/components/Forms/Question.svelte
+++ b/frontend/src/lib/components/Forms/Question.svelte
@@ -42,6 +42,7 @@
 					<RadioGroup active="variant-filled-primary" hover="hover:variant-soft-primary">
 						{#each question.options as option}
 							<RadioItem
+								class="whitespace-nowrap"
 								bind:group={question.answer}
 								name="question"
 								value={option}


### PR DESCRIPTION
When the question is too long in requirement assessments edit page, the answers are not aligned correctly.