### PR TITLE
Display folder field in evidence when creating from it from an applied control

### DIFF
--- a/frontend/src/lib/components/Forms/ModelForm/EvidenceForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/EvidenceForm.svelte
@@ -27,7 +27,7 @@
 	field="attachment"
 	label={m.attachment()}
 />
-{#if !(initialData.applied_controls || initialData.requirement_assessments)}
+{#if !initialData.requirement_assessments}
 	<AutocompleteSelect
 		{form}
 		options={getOptions({ objects: model.foreignKeys['folder'] })}
@@ -35,7 +35,6 @@
 		cacheLock={cacheLocks['folder']}
 		bind:cachedValue={formDataCache['folder']}
 		label={m.domain()}
-		hidden={initialData.applied_controls || initialData.requirement_assessments}
 	/>
 {:else}
 	<HiddenInput {form} field="folder" />


### PR DESCRIPTION
As an applied control may be global, inheriting its domain may cause errors if the user attempting to create an evidence inside it may not have the permission to create an evidence in the global domain.