### PR TITLE
Fix TableRowActions button sizes

### DIFF
--- a/frontend/src/lib/components/TableRowActions/TableRowActions.svelte
+++ b/frontend/src/lib/components/TableRowActions/TableRowActions.svelte
@@ -69,7 +69,9 @@
 	$: displayDelete = canDeleteObject && deleteForm !== undefined;
 </script>
 
-<span class="space-x-2 whitespace-nowrap flex flex-row items-center text-xl text-surface-700 justify-end">
+<span
+	class="space-x-2 whitespace-nowrap flex flex-row items-center text-xl text-surface-700 justify-end"
+>
 	<slot name="head" />
 	<slot name="body" />
 	{#if !hasBody}

--- a/frontend/src/lib/components/TableRowActions/TableRowActions.svelte
+++ b/frontend/src/lib/components/TableRowActions/TableRowActions.svelte
@@ -69,7 +69,7 @@
 	$: displayDelete = canDeleteObject && deleteForm !== undefined;
 </script>
 
-<span class="space-x-2 whitespace-nowrap flex flex-row items-center text-surface-700 justify-end">
+<span class="space-x-2 whitespace-nowrap flex flex-row items-center text-xl text-surface-700 justify-end">
 	<slot name="head" />
 	<slot name="body" />
 	{#if !hasBody}


### PR DESCRIPTION
Quick fix to make the TableRowActions buttons as they were before with their right size, the current TableRowActions are too small.