### PR TITLE
Use taskfile instead of a makefile in the enterprise dev 

### DIFF
--- a/enterprise/frontend/Taskfile.yml
+++ b/enterprise/frontend/Taskfile.yml
@@ -1,0 +1,76 @@
+version: "3"
+
+vars:
+  PM: pnpm
+  BUILD_DIR: .build
+  COMMUNITY_DIR: ../../frontend
+  ENTERPRISE_DIR: ../../enterprise/frontend
+  FRONTEND_DIR: "{{.BUILD_DIR}}/frontend"
+  ARTIFACTS: ["{{.BUILD_DIR}}", "node_modules", "package.json", "build"]
+  .DEFAULT_GOAL: build-enterprise
+
+tasks:
+  ensure-pnpm:
+    cmds:
+      - command -v pnpm || npm install -g pnpm
+
+  pre-build:
+    deps: [ensure-pnpm]
+    cmds:
+      - mkdir -p "{{.BUILD_DIR}}"
+      - rsync -av --exclude="{{.COMMUNITY_DIR}}/build/" --exclude="node_modules/" {{.COMMUNITY_DIR}} {{.BUILD_DIR}}
+      - rsync -avI --exclude=Taskfile.yml --exclude=Makefile --exclude=Dockerfile --exclude=README.md {{.ENTERPRISE_DIR}} {{.BUILD_DIR}}
+      - "{{.PM}} install --frozen-lockfile -C {{.FRONTEND_DIR}}"
+
+  build-enterprise:
+    deps: [pre-build]
+    cmds:
+      - "{{.PM}} run -C {{.FRONTEND_DIR}} build"
+      - rsync -av "{{.FRONTEND_DIR}}/build" "{{.ENTERPRISE_DIR}}/build"
+      - rsync -av "{{.FRONTEND_DIR}}/node_modules" "{{.ENTERPRISE_DIR}}/node_modules"
+      - rsync -av "{{.FRONTEND_DIR}}/package.json" "{{.ENTERPRISE_DIR}}/package.json"
+
+  watch:
+    silent: true
+    cmds:
+      - |
+        fswatch --batch-marker='EOF' -xn ./src ../../frontend | while read file event; do
+          if [ "$$file" = "EOF" ]; then
+            task copy_files CHANGED_FILES="$$list"
+            list=()
+          else
+            basename_file="$$(basename "$$file")"
+            if [[ "$$file" != *~ ]] && [[ ! "$$basename_file" =~ ^[0-9]+$$ ]] && [[ ! "$$basename_file" =~ ^\. ]] && ! git check-ignore -q "$$file"; then
+              echo "Tracking: $$file $$event"
+              list+=("$$file")
+            fi
+          fi
+        done
+
+  copy_files:
+    silent: true
+    vars:
+      CHANGED_FILES: []
+    cmds:
+      - |
+        for file in {{range .CHANGED_FILES}}{{.}} {{end}}; do
+          if [ -n "$$file" ]; then
+            relative_path="$${file#*/frontend/}"
+            target_dir="{{.FRONTEND_DIR}}/$$(dirname "$$relative_path")"
+            mkdir -p "$$target_dir"
+            rsync -av "$${file}" "$$target_dir"
+            echo "Copied $$file to $$target_dir"
+          fi
+        done
+
+  dev:
+    preconditions:
+      - sh: "[ -d .build/frontend ] || task pre-build"
+    cmds:
+      - "{{.PM}} -C {{.FRONTEND_DIR}} run dev &"
+      - "task watch &"
+      - "wait"
+
+  clean:
+    cmds:
+      - rm -rf {{range .ARTIFACTS}}{{.}} {{end}}


### PR DESCRIPTION
built a taskfile that takes the same methods as the makefile. 

The watch method used for dev method is still not working with copy_files method. 