### PR TITLE
Fix regression on paste on FileInput

### DIFF
--- a/frontend/src/lib/components/Forms/FileInput.svelte
+++ b/frontend/src/lib/components/Forms/FileInput.svelte
@@ -30,7 +30,11 @@
 		const [mainType, preciseType] = mimeType.toLocaleLowerCase().split('/');
 		const shortPreciseType = getShortenPreciseType(preciseType);
 
-		if (mainType === 'image' && allowedExtensions.has(shortPreciseType)) return shortPreciseType;
+		if (
+			mainType === 'image' &&
+			(allowedExtensions === '*' || allowedExtensions.includes(shortPreciseType))
+		)
+			return shortPreciseType;
 		return null;
 	}
 


### PR DESCRIPTION
The regression occurred because we removed the default value for the allowedExtensions prop and added the '*' value to explicitly state that we accept any file extension.