### PR TITLE
fix: update risk matrix to use ref_id instead of rid

### DIFF
--- a/backend/core/helpers.py
+++ b/backend/core/helpers.py
@@ -1049,9 +1049,9 @@ def build_scenario_clusters(risk_assessment: RiskAssessment):
         "created_at"
     ):
         if ri.current_level >= 0:
-            risk_matrix_current[ri.current_proba][ri.current_impact].add(ri.rid)
+            risk_matrix_current[ri.current_proba][ri.current_impact].add(ri.ref_id)
         if ri.residual_level >= 0:
-            risk_matrix_residual[ri.residual_proba][ri.residual_impact].add(ri.rid)
+            risk_matrix_residual[ri.residual_proba][ri.residual_impact].add(ri.ref_id)
 
     return {"current": risk_matrix_current, "residual": risk_matrix_residual}
 


### PR DESCRIPTION
This pull request fixes an issue that occurred when exporting a risk assessment as a PDF, the change involves updating the identifiers used in the risk matrices.

* [`backend/core/helpers.py`](diffhunk://#diff-5f32ac9fae57289f4732cb8f6a637fb8819e1afcd35eb329c1281ce510d77a6fL1052-R1054): Modified the `build_scenario_clusters` function to use `ri.ref_id` instead of `ri.rid` for adding elements to the `risk_matrix_current` and `risk_matrix_residual`.