### PR TITLE
fix: make email comparison for SAML case insensitive

### DIFF
--- a/backend/iam/adapter.py
+++ b/backend/iam/adapter.py
@@ -54,7 +54,7 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
     def pre_social_login(self, request, sociallogin):
         email_address = next(iter(sociallogin.account.extra_data.values()))[0]
         try:
-            user = User.objects.get(email=email_address)
+            user = User.objects.get(email=email_address.lower())
             sociallogin.user = user
             sociallogin.connect(request, user)
         except User.DoesNotExist:

--- a/backend/iam/models.py
+++ b/backend/iam/models.py
@@ -391,6 +391,9 @@ class User(AbstractBaseUser, AbstractBaseModel, FolderMixin):
         logger.info("user deleted", user=self)
 
     def save(self, *args, **kwargs):
+        # Make sure to always convert username to lowercase for easier comparison with SSO
+        if self.email:
+            self.email = self.email.lower()
         super().save(*args, **kwargs)
         logger.info("user saved", user=self)
 

--- a/backend/iam/sso/saml/views.py
+++ b/backend/iam/sso/saml/views.py
@@ -135,7 +135,7 @@ class FinishACSView(SAMLViewMixin, View):
             login.state["next"] = next_url
         try:
             email = auth._nameid
-            user = User.objects.get(email=email)
+            user = User.objects.get(email=email.lower())
             idp_first_name = auth._attributes.get(
                 "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname", [""]
             )[0]


### PR DESCRIPTION
Email comparison when doing SSO with SAML is currently case sensitive.
However, email addresses should be treated as case insensitive.

This PR makes sure that:
1) Email address of each user is saved as lowercase in the database
2) Email address received from IDP when doing SSO is converted to lowercase prior to comparison