### PR TITLE
clarify ebios-rm spec

### DIFF
--- a/documentation/architecture/data-model.md
+++ b/documentation/architecture/data-model.md
@@ -1292,7 +1292,7 @@ erDiagram
     EBIOS_RM_STUDY        |o--o{ RISK_ASSESSMENT      : generates
     ATTACK_PATH           }o--|| RO_TO                : derives
     RO_TO                 }o--o{ FEARED_EVENT         : corresponds_to
-    OPERATIONAL_SCENARIO  }o--|{ ATTACK_PATH          : derives
+    OPERATIONAL_SCENARIO  |o--|| ATTACK_PATH          : derives
     OPERATIONAL_SCENARIO  }o--o{ THREAT               : leverages
     ATTACK_PATH           }o--o{ STAKEHOLDER          : leverages
     STAKEHOLDER           }o--o{ APPLIED_CONTROL      : reinforces
@@ -1346,13 +1346,15 @@ erDiagram
     }
 
     ATTACK_PATH {
+        string ref_id
+        string name
         string description
         bool   selected
         string justification
     }
 
     OPERATIONAL_SCENARIO {
-        string description
+        string operating_modes_description
         int    likelihood
         bool   selected
         string justification


### PR DESCRIPTION
add ref_id/name to attack path
operational scenario corresponds to a single attack path