### PR TITLE
fix: Library uuid replaced by name in matrix view

### DIFF
--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -119,6 +119,7 @@ class AssessmentReadSerializer(BaseModelSerializer):
 class RiskMatrixReadSerializer(ReferentialSerializer):
     folder = FieldsRelatedField()
     json_definition = serializers.JSONField(source="get_json_translated")
+    library = FieldsRelatedField(["name", "id"])
 
     class Meta:
         model = RiskMatrix

--- a/frontend/src/lib/utils/crud.ts
+++ b/frontend/src/lib/utils/crud.ts
@@ -177,7 +177,8 @@ export const URL_MODEL_MAP: ModelMap = {
 		verboseName: 'Risk matrix',
 		verboseNamePlural: 'Risk matrices',
 		foreignKeyFields: [
-			{ field: 'folder', urlModel: 'folders', urlParams: 'content_type=DO&content_type=GL' }
+			{ field: 'folder', urlModel: 'folders', urlParams: 'content_type=DO&content_type=GL' },
+			{ field: 'library', urlModel: 'libraries' }
 		]
 	},
 	'risk-assessments': {

--- a/frontend/src/routes/(app)/(internal)/risk-matrices/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/risk-matrices/[id=uuid]/+page.svelte
@@ -38,12 +38,17 @@
 									{/each}
 								</ul>
 							{:else if value.id}
-								{@const itemHref = `/${
-									URL_MODEL_MAP['risk-matrices']['foreignKeyFields']?.find(
-										(item) => item.field === key
-									)?.urlModel
-								}/${value.id}`}
-								<a href={itemHref} class="anchor">{value.str}</a>
+								{#if key === 'library'}
+									{@const itemHref = `/libraries/${value.id}?loaded`}
+									<a href={itemHref} class="anchor">{value.name}</a>
+								{:else}
+									{@const itemHref = `/${
+										URL_MODEL_MAP['risk-matrices']['foreignKeyFields']?.find(
+											(item) => item.field === key
+										)?.urlModel
+									}/${value.id}`}
+									<a href={itemHref} class="anchor">{value.str}</a>
+								{/if}
 							{:else}
 								{value.str ?? value}
 							{/if}


### PR DESCRIPTION
When displaying a risk matrix in the catalog, we can see the field library with a UUID. 
This should be replaced by the name of the library.