### PR TITLE
Add more flexibility in Helm chart

### DIFF
--- a/charts/ciso-assistant/templates/ingress.yaml
+++ b/charts/ciso-assistant/templates/ingress.yaml
@@ -1,16 +1,19 @@
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  {{- with .Values.ingress.annotations }}
   annotations:
-    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
-    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
   name: ciso-assistant-{{ .Values.clientName }}
   labels:
     client: {{ .Values.clientName }}
     {{- include "common.labels" . | nindent 4 }}
 spec:
-  ingressClassName: nginx
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
   rules:
   - host: {{ .Values.clientName }}.{{ .Values.clusterDomain }}
     http:
@@ -19,6 +22,20 @@ spec:
           service:
             name: ciso-assistant-{{ .Values.clientName }}
             port:
-              number: 443
+              number: 3000
         path: /
         pathType: Prefix
+      - backend:
+          service:
+            name: ciso-assistant-{{ .Values.clientName }}
+            port:
+              number: 8000
+        path: /api/
+        pathType: Prefix
+  {{- if .Values.ingress.tls }}
+  tls:
+    - hosts:
+      - {{ .Values.clientName }}.{{ .Values.clusterDomain }}
+      secretName: ciso-assistant-{{ .Values.clientName }}-tls
+  {{- end }}
+{{- end }}

--- a/charts/ciso-assistant/templates/service.yaml
+++ b/charts/ciso-assistant/templates/service.yaml
@@ -7,14 +7,14 @@ metadata:
     {{- include "common.labels" . | nindent 4 }}
 spec:
   ports:
-  - name: http
-    port: 80
+  - name: backend
+    port: 8000
     protocol: TCP
-    targetPort: 80
-  - name: https
-    port: 443
+    targetPort: 8000
+  - name: frontend
+    port: 3000
     protocol: TCP
-    targetPort: 443
+    targetPort: 3000
   selector:
     app: ciso-assistant
     client: {{ .Values.clientName }}

--- a/charts/ciso-assistant/templates/statefulset.yaml
+++ b/charts/ciso-assistant/templates/statefulset.yaml
@@ -1,3 +1,4 @@
+{{ $scheme := ternary "https" "http" .Values.ingress.tls -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -26,7 +27,7 @@ spec:
         - name: CISO_ASSISTANT_SUPERUSER_EMAIL
           value: {{ .Values.emailAdmin }}
         - name: CISO_ASSISTANT_URL
-          value: https://{{ .Values.clientName }}.{{ .Values.clusterDomain }}
+          value: {{ $scheme }}://{{ .Values.clientName }}.{{ .Values.clusterDomain }}
         - name: ALLOWED_HOSTS
           value: localhost,127.0.0.1,{{ .Values.clientName }}.{{ .Values.clusterDomain }}
         - name: EMAIL_HOST_PASSWORD
@@ -53,9 +54,13 @@ spec:
       - name: ciso-assistant-frontend
         env:
         - name: ORIGIN
-          value: "{{ .Values.frontendOrigin | default (printf "https://%s.%s" .Values.clientName .Values.clusterDomain) }}"
+          value: "{{ .Values.frontendOrigin | default (printf "%s://%s.%s" $scheme .Values.clientName .Values.clusterDomain) }}"
+        - name: PROTOCOL_HEADER
+          value: x-forwarded-proto
+        - name: HOST_HEADER
+          value: x-forwarded-host
         - name: PUBLIC_BACKEND_API_EXPOSED_URL
-          value: https://{{ .Values.clientName }}.{{ .Values.clusterDomain }}/api
+          value: {{ $scheme }}://{{ .Values.clientName }}.{{ .Values.clusterDomain }}/api
         envFrom:
         - configMapRef:
             name: ciso-assistant-config
@@ -64,32 +69,6 @@ spec:
         ports:
         - containerPort: 3000
           protocol: TCP
-      - name: caddy
-        command:
-        - sh
-        - '-c'
-        - |
-          echo {{ .Values.clientName }}.{{ .Values.clusterDomain }} "{" > Caddyfile
-          echo "reverse_proxy /api/iam/sso/redirect/ localhost:8000" >> Caddyfile
-          echo "reverse_proxy /api/accounts/saml/0/acs/ localhost:8000" >> Caddyfile
-          echo "reverse_proxy /api/accounts/saml/0/acs/finish/ localhost:8000" >> Caddyfile
-          echo "reverse_proxy /* localhost:3000" >> Caddyfile
-          echo "}" >> Caddyfile
-          exec caddy run
-        env:
-        - name: CISO_ASSISTANT_URL
-          value: https://{{ .Values.clientName }}.{{ .Values.clusterDomain }}
-        image: "{{ .Values.image.caddy.repository }}:{{ .Values.image.caddy.tag }}"
-        imagePullPolicy: {{ .Values.image.caddy.pullPolicy }}
-        ports:
-        - containerPort: 80
-          protocol: TCP
-        - containerPort: 443
-          protocol: TCP
-        volumeMounts:
-        - mountPath: /data
-          name: db-data
-          subPath: caddy
       enableServiceLinks: false
       imagePullSecrets:
       - name: registry-secret

--- a/charts/ciso-assistant/values.yaml
+++ b/charts/ciso-assistant/values.yaml
@@ -34,11 +34,16 @@ image:
     repository: ghcr.io/intuitem/ciso-assistant-community/frontend
     tag: "{{ default .Chart.AppVersion .Values.global.appVersion }}"
     pullPolicy: Always
-  caddy:
-    repository: caddy
-    tag: "2.7.6"
-    pullPolicy: IfNotPresent
 
 persistence:
   size: 5Gi
   accessMode: ReadWriteOnce
+
+ingress:
+  enabled: true
+  annotations: {}
+    # nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    # cert-manager.io/cluster-issuer: letsencrypt
+  ingressClassName: nginx
+
+  tls: false


### PR DESCRIPTION
To make CISO Assistant more flexible for Kubernetes users, I made some (breaking) changes on the Helm Chart : 

- Add Ingress config in values (annotations and ingressClassName)
- Enable tls on Ingress
- Caddy removal (useless if ingress.tls used)

I don't think it will be a big pain to migrate chart with these changes.

It will requires using Cert-Manager for automatic letsencrypt/ACME/PKI certificate generation, or just create secret manually alongside the chart deploy.

I will be happy to add custom TLS secret creation from values file if it can help some users to avoid doing manual things.

That PR can probably fix these issues : #1123 #1135