### PR TITLE
Leverage RBAC for global settings

### DIFF
--- a/backend/core/startup.py
+++ b/backend/core/startup.py
@@ -315,6 +315,8 @@ ADMINISTRATOR_PERMISSIONS_LIST = [
     "restore",
     "view_globalsettings",
     "change_globalsettings",
+    "view_ssosettings",
+    "change_ssosettings",
     "view_requirementmappingset",
     "add_requirementmappingset",
     "delete_requirementmappingset",

--- a/backend/global_settings/views.py
+++ b/backend/global_settings/views.py
@@ -40,19 +40,21 @@ class GeneralSettingsViewSet(viewsets.ModelViewSet):
     queryset = GlobalSettings.objects.filter(name="general")
 
     def retrieve(self, request, *args, **kwargs):
-        instance = self.model.objects.get(name="general")[0]
+        instance = self.get_object()
         serializer = self.get_serializer(instance)
         return Response(serializer.data)
 
     def update(self, request, *args, **kwargs):
-        instance = self.model.objects.get(name="general")
+        instance = self.get_object()
         serializer = self.get_serializer(instance, data=request.data)
         serializer.is_valid(raise_exception=True)
         serializer.save()
         return Response(serializer.data)
 
     def get_object(self):
-        return self.model.objects.get(name="general")
+        obj = self.model.objects.get(name="general")
+        self.check_object_permissions(self.request, obj)
+        return obj
 
     @action(detail=True, name="Get write data")
     def object(self, request, pk=None):

--- a/backend/iam/sso/views.py
+++ b/backend/iam/sso/views.py
@@ -47,12 +47,12 @@ class SSOSettingsViewSet(BaseModelViewSet):
     model = SSOSettings
 
     def retrieve(self, request, *args, **kwargs):
-        instance = self.model.objects.get()
+        instance = self.get_object()
         serializer = self.get_serializer(instance)
         return Response(serializer.data)
 
     def update(self, request, *args, **kwargs):
-        instance = self.model.objects.get()
+        instance = self.get_object()
         serializer = self.get_serializer(instance, data=request.data)
         serializer.is_valid(raise_exception=True)
         serializer.save()
@@ -64,7 +64,9 @@ class SSOSettingsViewSet(BaseModelViewSet):
         return Response({p[0]: p[1] for p in _providers})
 
     def get_object(self):
-        return SSOSettings.objects.get()
+        obj = self.model.objects.get()
+        self.check_object_permissions(self.request, obj)
+        return obj
 
     @action(detail=True, name="Get write data")
     def object(self, request, pk=None):


### PR DESCRIPTION
When writing a custom `get_object` method in a viewset, we must perform call `self.check_object_permissions(request, obj)`. Otherwise, `RBACPermissions.has_object_permission` will **not** be called.