### PR TITLE
Rename uploaded artifacts in GitHub actions

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 env:
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   GITHUB_WORKFLOW: github_actions
   backend-directory: ./backend
   frontend-directory: ./frontend
@@ -110,10 +111,12 @@ jobs:
         run: pnpm exec playwright test --project=${{ matrix.playwright-browser }}
         env:
           CI: true
+      - name: Set current date as env variable
+        run: echo "NOW=$(date +'%Y-%m-%dT%H-%M-%S')" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: functional-tests-report-${{ matrix.playwright-browser }}
+          name: ${{ env.BRANCH_NAME }}-${{ env.NOW }}-${{ github.jobs[github.job].name }}-report-${{ matrix.playwright-browser }}
           path: |
             ${{ env.backend-directory }}/*.log
             ${{ env.frontend-directory }}/tests/results/
@@ -212,10 +215,12 @@ jobs:
         run: pnpm exec playwright test --project=${{ matrix.playwright-browser }}
         env:
           CI: true
+      - name: Set current date as env variable
+        run: echo "NOW=$(date +'%Y-%m-%dT%H-%M-%S')" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: enterprise-functional-tests-report-${{ matrix.playwright-browser }}
+          name: ${{ env.BRANCH_NAME }}-${{ env.NOW }}-${{ github.jobs[github.job].name }}-report-${{ matrix.playwright-browser }}
           path: |
             ${{ env.backend-directory }}/*.log
             ${{ env.enterprise-frontend-build-directory }}/tests/results/

--- a/.github/workflows/startup-tests.yml
+++ b/.github/workflows/startup-tests.yml
@@ -95,10 +95,12 @@ jobs:
       - name: Run tests
         working-directory: ${{ env.frontend-directory }}
         run: pnpm exec playwright test tests/functional/startup.test.ts
+      - name: Set current date as env variable
+        run: echo "NOW=$(date +'%Y-%m-%dT%H-%M-%S')" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: startup-functional-test-report
+          name: ${{ env.BRANCH_NAME }}-${{ env.NOW }}-${{ github.jobs[github.job].name }}-report-${{ matrix.playwright-browser }}
           path: |
             ${{ env.backend-directory }}/*.log
             ${{ env.frontend-directory }}/tests/reports/
@@ -228,10 +230,12 @@ jobs:
       - name: Run tests
         working-directory: ${{ env.enterprise-frontend-build-directory }}
         run: pnpm exec playwright test tests/functional/startup.test.ts
+      - name: Set current date as env variable
+        run: echo "NOW=$(date +'%Y-%m-%dT%H-%M-%S')" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: enterprise-startup-functional-test-report
+          name: ${{ env.BRANCH_NAME }}-${{ env.NOW }}-${{ github.jobs[github.job].name }}-report-${{ matrix.playwright-browser }}
           path: |
             ${{ env.backend-directory }}/*.log
             ${{ env.enterprise-frontend-build-directory }}/tests/reports/


### PR DESCRIPTION
New format is `<branch>-<timestamp>-<artifact name>`. E.g. [CA-661-git-hub-actions-find-better-names-for-uploaded-artifacts-2024-12-24T16-03-16-functional-tests-report-chromium](https://github.com/intuitem/ciso-assistant-community/actions/runs/12483668941/artifacts/2359699597)
