### PR TITLE
Require stakeholder category field

### DIFF
--- a/frontend/src/lib/utils/schemas.ts
+++ b/frontend/src/lib/utils/schemas.ts
@@ -432,7 +432,7 @@ export const roToSchema = z.object({
 export const StakeholderSchema = z.object({
 	ebios_rm_study: z.string(),
 	applied_controls: z.string().uuid().optional().array().optional(),
-	category: z.string().optional(),
+	category: z.string(),
 	entity: z.string().optional(),
 	current_dependency: z.number().min(0).max(4).default(0).optional(),
 	current_penetration: z.number().min(0).max(4).default(0).optional(),


### PR DESCRIPTION
The field is not optional at the data model level, making it optional in
the frontend is senseless.
