### PR TITLE
Include search params in edit next URL when coming from list

### DIFF
--- a/frontend/src/lib/components/Breadcrumbs/Breadcrumbs.svelte
+++ b/frontend/src/lib/components/Breadcrumbs/Breadcrumbs.svelte
@@ -10,8 +10,9 @@
 		breadcrumbs: Breadcrumb[],
 		currentPath: string
 	): Promise<Breadcrumb[]> {
-		const idx = breadcrumbs.findIndex((c) => c.href === currentPath);
-		if (idx >= 0 && idx < breadcrumbs.length - 1) {
+		const idx = breadcrumbs.findIndex((c) => c.href?.startsWith(currentPath));
+		// First breadcrumb is home, its href is always '/'
+		if (idx > 0 && idx < breadcrumbs.length - 1) {
 			breadcrumbs = breadcrumbs.slice(0, idx + 1);
 		}
 		return breadcrumbs;

--- a/frontend/src/lib/components/ModelTable/ModelTable.svelte
+++ b/frontend/src/lib/components/ModelTable/ModelTable.svelte
@@ -406,7 +406,7 @@
 										URLModel={actionsURLModel}
 										detailURL={`/${actionsURLModel}/${row.meta[identifierField]}${detailQueryParameter}`}
 										editURL={!(row.meta.builtin || row.meta.urn)
-											? `/${actionsURLModel}/${row.meta[identifierField]}/edit?next=${$page.url.pathname}`
+											? `/${actionsURLModel}/${row.meta[identifierField]}/edit?next=${encodeURIComponent($page.url.pathname + $page.url.search)}`
 											: undefined}
 										{row}
 										hasBody={$$slots.actionsBody}


### PR DESCRIPTION
I purposefully did not include next urls coming from detail views as it requires additional testing.
Including url search params in next urls coming from list views is safe however, as search params are only used for filtering in list views.