### PR TITLE
The value 4 should not be allowed in the security_objectives_display …

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -1640,7 +1640,7 @@ class Asset(
                 key=lambda x: self.DEFAULT_SECURITY_OBJECTIVES.index(x[0]),
             )
             if content.get("is_enabled", False)
-            and content.get("value", -1) in range(0, 5)
+            and content.get("value", -1) in range(0, 4)
         ]
 
     def get_disaster_recovery_objectives_display(self) -> list[dict[str, str]]:


### PR DESCRIPTION
…array

This does not fix input validation, it does however prevent the application from breaking if a invalid value of 4 is entered. Similarly to how 5 and above works today.