### PR TITLE
fix: deactivate score after scoring for not applicable requirement assessments

### DIFF
--- a/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/TreeViewItemLead.svelte
+++ b/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/TreeViewItemLead.svelte
@@ -28,7 +28,7 @@
 		<span class="badge {classesText} h-fit" style="background-color: {resultColor ?? '#d1d5db'};">
 			{leadResult}
 		</span>
-		{#if statusI18n !== 'notApplicable' && isScored}
+		{#if resultI18n !== 'notApplicable' && isScored}
 			<ProgressRadial
 				stroke={100}
 				meter={displayScoreColor(score, max_score)}


### PR DESCRIPTION
status is for to_do, done etc... result is for not_applicable, applicable etc... someone just swapped the two notions without checking 