### PR TITLE
fix: form consistency for stakeholder as a mandatory field

### DIFF
--- a/frontend/src/lib/components/Forms/ModelForm/StakeholderForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/StakeholderForm.svelte
@@ -106,6 +106,8 @@
 					label={m.entity()}
 					hidden={initialData.entity}
 					helpText={m.stakeholderEntityHelpText()}
+					required
+					mandatory
 				/>
 			</span>
 

--- a/frontend/src/lib/components/Forms/ModelForm/StakeholderForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/StakeholderForm.svelte
@@ -106,8 +106,6 @@
 					label={m.entity()}
 					hidden={initialData.entity}
 					helpText={m.stakeholderEntityHelpText()}
-					required
-					mandatory
 				/>
 			</span>
 

--- a/frontend/src/lib/utils/schemas.ts
+++ b/frontend/src/lib/utils/schemas.ts
@@ -448,7 +448,7 @@ export const StakeholderSchema = z.object({
 	ebios_rm_study: z.string(),
 	applied_controls: z.string().uuid().optional().array().optional(),
 	category: z.string(),
-	entity: z.string().optional(),
+	entity: z.string(),
 	current_dependency: z.number().min(0).max(4).default(0).optional(),
 	current_penetration: z.number().min(0).max(4).default(0).optional(),
 	current_maturity: z.number().min(1).max(4).default(1).optional(),


### PR DESCRIPTION
Modified “Add stakeholder” entity to have it mendatory with red star and good help text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Validation Updates**
	- Made the `entity` field required in the Stakeholder schema
	- Enforced stricter validation rules for stakeholder objects
<!-- end of auto-generated comment: release notes by coderabbit.ai -->