### PR TITLE
Increase limit_request_line param for gunicorn for SSO.

### DIFF
--- a/backend/startup.sh
+++ b/backend/startup.sh
@@ -32,6 +32,6 @@ exec gunicorn --chdir ciso_assistant \
   --timeout $GUNICORN_TIMEOUT \
   --keep-alive $GUNICORN_KEEPALIVE \
   --workers=$GUNICORN_WORKERS \
-  --limit-request-line=$GUNICORN_LIMIT_REQUEST_LINE
+  --limit-request-line=$GUNICORN_LIMIT_REQUEST_LINE \
   --env RUN_MAIN=true \
   ciso_assistant.wsgi:application

--- a/backend/startup.sh
+++ b/backend/startup.sh
@@ -25,11 +25,13 @@ fi
 GUNICORN_WORKERS=${GUNICORN_WORKERS:-3}
 GUNICORN_TIMEOUT=${GUNICORN_TIMEOUT:-100}
 GUNICORN_KEEPALIVE=${GUNICORN_KEEPALIVE:-30}
+GUNICORN_LIMIT_REQUEST_LINE=${GUNICORN_LIMIT_REQUEST_LINE:-5120}
 
 exec gunicorn --chdir ciso_assistant \
   --bind :8000 \
   --timeout $GUNICORN_TIMEOUT \
   --keep-alive $GUNICORN_KEEPALIVE \
   --workers=$GUNICORN_WORKERS \
+  --limit-request-line=$GUNICORN_LIMIT_REQUEST_LINE
   --env RUN_MAIN=true \
   ciso_assistant.wsgi:application


### PR DESCRIPTION
This PR increases limit_request_line param for gunicorn, this allows some IDP (such as GoAuthentik) provider to work as the request line often goes beyond the default value of 4094 when using the SSO feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration**
	- Added new environment variable `GUNICORN_LIMIT_REQUEST_LINE` to control HTTP request line size in server startup configuration.
	- Enhanced server configuration flexibility by allowing customizable request line size limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->