### PR TITLE
fix: better consistency for ref_id as optional field

### DIFF
--- a/.github/workflows/frontend-coverage.yaml
+++ b/.github/workflows/frontend-coverage.yaml
@@ -5,6 +5,7 @@ on:
     branches: ["main"]
     paths:
       - "frontend/**"
+  workflow_dispatch:
 
 env:
   GITHUB_WORKFLOW: github_actions
@@ -37,6 +38,9 @@ jobs:
       - name: Install dependencies
         working-directory: ${{env.working-directory}}
         run: pnpm i --frozen-lockfile
+      - name: Prepare sveltekit
+        working-directory: ${{env.working-directory}}
+        run: pnpm run prepare
       - name: Run coverage
         working-directory: ${{env.working-directory}}
         run: pnpm run coverage

--- a/.github/workflows/frontend-unit-tests.yml
+++ b/.github/workflows/frontend-unit-tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - "frontend/**"
+  workflow_dispatch:
 
 env:
   GITHUB_WORKFLOW: github_actions
@@ -36,6 +37,9 @@ jobs:
       - name: Install dependencies
         working-directory: ${{env.working-directory}}
         run: pnpm i --frozen-lockfile
+      - name: Prepare sveltekit
+        working-directory: ${{env.working-directory}}
+        run: pnpm run prepare
       - name: Run tests
         working-directory: ${{env.working-directory}}
         run: pnpm run test:ci

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
 	"version": "0.0.1",
 	"private": true,
 	"scripts": {
+		"prepare": "svelte-kit sync",
 		"dev": "vite dev",
 		"build": "paraglide-js compile --project ./project.inlang && vite build",
 		"preview": "vite preview",

--- a/frontend/src/lib/utils/schemas.ts
+++ b/frontend/src/lib/utils/schemas.ts
@@ -63,7 +63,7 @@ const NameDescriptionMixin = {
 
 export const FolderSchema = z.object({
 	...NameDescriptionMixin,
-	ref_id: z.string().optional().nullable(),
+	ref_id: z.string().optional(),
 	parent_folder: z.string().optional()
 });
 
@@ -78,7 +78,7 @@ export const FolderImportSchema = z.object({
 export const ProjectSchema = z.object({
 	...NameDescriptionMixin,
 	folder: z.string(),
-	ref_id: z.string().optional().nullable(),
+	ref_id: z.string().optional(),
 	lc_status: z.string().optional().default('in_design')
 });
 
@@ -98,7 +98,7 @@ export const RiskAssessmentSchema = z.object({
 	version: z.string().optional().default('0.1'),
 	project: z.string(),
 	status: z.string().optional().nullable(),
-	ref_id: z.string().optional().nullable(),
+	ref_id: z.string().optional(),
 	risk_matrix: z.string(),
 	eta: z.union([z.literal('').transform(() => null), z.string().date()]).nullish(),
 	due_date: z.union([z.literal('').transform(() => null), z.string().date()]).nullish(),
@@ -112,7 +112,7 @@ export const ThreatSchema = z.object({
 	...NameDescriptionMixin,
 	folder: z.string(),
 	provider: z.string().optional().nullable(),
-	ref_id: z.string().optional().nullable(),
+	ref_id: z.string().optional(),
 	annotation: z.string().optional().nullable()
 });
 
@@ -139,7 +139,7 @@ export const RiskScenarioSchema = z.object({
 
 export const AppliedControlSchema = z.object({
 	...NameDescriptionMixin,
-	ref_id: z.string().optional().nullable(),
+	ref_id: z.string().optional(),
 	category: z.string().optional().nullable(),
 	csf_function: z.string().optional().nullable(),
 	priority: z.number().optional().nullable(),
@@ -179,7 +179,7 @@ export const ReferenceControlSchema = z.object({
 	category: z.string().optional().nullable(),
 	csf_function: z.string().optional().nullable(),
 	folder: z.string(),
-	ref_id: z.string().optional().nullable(),
+	ref_id: z.string().optional(),
 	annotation: z.string().optional().nullable()
 });
 
@@ -268,7 +268,7 @@ export const SetPasswordSchema = z.object({
 export const ComplianceAssessmentSchema = z.object({
 	...NameDescriptionMixin,
 	version: z.string().optional().default('0.1'),
-	ref_id: z.string().optional().nullable(),
+	ref_id: z.string().optional(),
 	project: z.string(),
 	status: z.string().optional().nullable(),
 	selected_implementation_groups: z.array(z.string().optional()).optional(),

--- a/frontend/src/lib/utils/schemas.ts
+++ b/frontend/src/lib/utils/schemas.ts
@@ -134,7 +134,7 @@ export const RiskScenarioSchema = z.object({
 	assets: z.string().uuid().optional().array().optional(),
 	vulnerabilities: z.string().uuid().optional().array().optional(),
 	owner: z.string().uuid().optional().array().optional(),
-	ref_id: z.string().max(8).optional().nullable()
+	ref_id: z.string().max(8).optional()
 });
 
 export const AppliedControlSchema = z.object({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the `ref_id` field across multiple schemas to ensure it only accepts valid string values or remains empty, enhancing data validation consistency.

- **New Features**
  - Introduced a new preparation step for SvelteKit in GitHub Actions workflows for frontend code coverage and unit tests.
  - Added a new script entry to the package.json for synchronizing the SvelteKit project.
  - Enabled manual triggering of GitHub Actions workflows for frontend coverage and unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->