### PR TITLE
feat: allow helm chart secretes to be provided via external secret

### DIFF
--- a/charts/ciso-assistant-next/templates/backend/deployment.yaml
+++ b/charts/ciso-assistant-next/templates/backend/deployment.yaml
@@ -103,11 +103,11 @@ spec:
           - name: EMAIL_HOST_USER
             value: {{ .Values.backend.config.smtp.primary.username | quote }}
           {{- end }}
-          {{- if .Values.backend.config.smtp.primary.existingSecret }}
+          {{- if .Values.backend.config.smtp.existingSecret }}
           - name: EMAIL_HOST_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.backend.config.smtp.primary.existingSecret }}
+                name: {{ .Values.backend.config.smtp.existingSecret }}
                 key: email-primary-password
           {{- else if .Values.backend.config.smtp.primary.password }}
           - name: EMAIL_HOST_PASSWORD
@@ -116,6 +116,7 @@ spec:
                 name: {{ include "ciso-assistant.fullname" . }}-backend
                 key: email-primary-password
           {{- end }}
+          {{- if .Values.backend.config.smtp.rescue.enabled }}          -
           - name: EMAIL_HOST_RESCUE
             value: {{ .Values.backend.config.smtp.rescue.host | quote }}
           - name: EMAIL_PORT_RESCUE
@@ -126,11 +127,11 @@ spec:
           - name: EMAIL_HOST_USER_RESCUE
             value: {{ .Values.backend.config.smtp.rescue.username | quote }}
           {{- end }}
-          {{- if .Values.backend.config.smtp.rescue.existingSecret }}
-          - name: EMAIL_HOST_PASSWORD
+          {{- if .Values.backend.config.smtp.existingSecret }}
+          - name: EMAIL_HOST_PASSWORD_RESCUE
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.backend.config.smtp.rescue.existingSecret }}
+                name: {{ .Values.backend.config.smtp.existingSecret }}
                 key: email-rescue-password
           {{- else if .Values.backend.config.smtp.rescue.password }}
           - name: EMAIL_HOST_PASSWORD_RESCUE
@@ -138,6 +139,7 @@ spec:
               secretKeyRef:
                 name: {{ include "ciso-assistant.fullname" . }}-backend
                 key: email-rescue-password
+          {{- end }}
           {{- end }}
         volumeMounts:
         - name: tmp-data

--- a/charts/ciso-assistant-next/templates/backend/deployment.yaml
+++ b/charts/ciso-assistant-next/templates/backend/deployment.yaml
@@ -79,7 +79,11 @@ spec:
           - name: DJANGO_SECRET_KEY
             valueFrom:
               secretKeyRef:
+                {{- if .Values.backend.config.djangoExistingSecretKey }}
+                name: {{ .Values.backend.config.djangoExistingSecretKey }}
+                {{- else }}
                 name: {{ include "ciso-assistant.fullname" . }}-backend
+                {{- end }}
                 key: django-secret-key
           - name: CISO_ASSISTANT_SUPERUSER_EMAIL
             value: {{ .Values.backend.config.emailAdmin }}
@@ -99,7 +103,13 @@ spec:
           - name: EMAIL_HOST_USER
             value: {{ .Values.backend.config.smtp.primary.username | quote }}
           {{- end }}
-          {{- if .Values.backend.config.smtp.primary.password }}
+          {{- if .Values.backend.config.smtp.primary.existingSecret }}
+          - name: EMAIL_HOST_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.backend.config.smtp.primary.existingSecret }}
+                key: email-primary-password
+          {{- else if .Values.backend.config.smtp.primary.password }}
           - name: EMAIL_HOST_PASSWORD
             valueFrom:
               secretKeyRef:
@@ -116,7 +126,13 @@ spec:
           - name: EMAIL_HOST_USER_RESCUE
             value: {{ .Values.backend.config.smtp.rescue.username | quote }}
           {{- end }}
-          {{- if .Values.backend.config.smtp.rescue.password }}
+          {{- if .Values.backend.config.smtp.rescue.existingSecret }}
+          - name: EMAIL_HOST_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.backend.config.smtp.rescue.existingSecret }}
+                key: email-rescue-password
+          {{- else if .Values.backend.config.smtp.rescue.password }}
           - name: EMAIL_HOST_PASSWORD_RESCUE
             valueFrom:
               secretKeyRef:
@@ -125,7 +141,7 @@ spec:
           {{- end }}
         volumeMounts:
         - name: tmp-data
-          mountPath: /tmp 
+          mountPath: /tmp
         {{- if and (eq .Values.backend.config.databaseType "sqlite") .Values.backend.persistence.sqlite.enabled }}
         - name: sqlite-data
           mountPath: /ciso/db

--- a/charts/ciso-assistant-next/templates/backend/secret.yaml
+++ b/charts/ciso-assistant-next/templates/backend/secret.yaml
@@ -1,4 +1,4 @@
-{{- if or (and (not .Values.backend.config.smtp.primary.existingSecret) .Values.backend.config.smtp.primary.password) (and (not .Values.backend.config.smtp.rescue.existingSecret) .Values.backend.config.smtp.rescue.password) (and (not .Values.backend.config.djangoExistingSecretKey) .Values.backend.config.djangoSecretKey) }}
+{{- if or (and (not .Values.backend.config.smtp.existingSecret) (or .Values.backend.config.smtp.primary.password (and .Values.backend.config.smtp.rescue.enabled .Values.backend.config.smtp.rescue.password))) (and (not .Values.backend.config.djangoExistingSecretKey) .Values.backend.config.djangoSecretKey) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,10 +11,10 @@ data:
   {{- if and (not .Values.backend.config.djangoExistingSecretKey) .Values.backend.config.djangoSecretKey }}
   django-secret-key: {{ .Values.backend.config.djangoSecretKey | b64enc | quote}}
   {{- end }}
-  {{- if and (not .Values.backend.config.smtp.primary.existingSecret) .Values.backend.config.smtp.primary.password }}
+  {{- if and (not .Values.backend.config.smtp.existingSecret) .Values.backend.config.smtp.primary.password }}
   email-primary-password: {{ .Values.backend.config.smtp.primary.password | b64enc | quote}}
   {{- end }}
-  {{- if and (not .Values.backend.config.smtp.rescue.existingSecret) .Values.backend.config.smtp.rescue.password }}
+  {{- if and (not .Values.backend.config.smtp.existingSecret) .Values.backend.config.smtp.rescue.enabled .Values.backend.config.smtp.rescue.password }}
   email-rescue-password: {{ .Values.backend.config.smtp.rescue.password | b64enc | quote}}
   {{- end }}
 {{- end }}

--- a/charts/ciso-assistant-next/templates/backend/secret.yaml
+++ b/charts/ciso-assistant-next/templates/backend/secret.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.backend.config.smtp.primary.password .Values.backend.config.smtp.rescue.password }}
+{{- if or (and (not .Values.backend.config.smtp.primary.existingSecret) .Values.backend.config.smtp.primary.password) (and (not .Values.backend.config.smtp.rescue.existingSecret) .Values.backend.config.smtp.rescue.password) (and (not .Values.backend.config.djangoExistingSecretKey) .Values.backend.config.djangoSecretKey) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,11 +8,13 @@ metadata:
     {{- include "ciso-assistant.labels" (dict "context" . "name" .Values.backend.name "component" .Values.backend.name) | nindent 4 }}
 type: Opaque
 data:
+  {{- if and (not .Values.backend.config.djangoExistingSecretKey) .Values.backend.config.djangoSecretKey }}
   django-secret-key: {{ .Values.backend.config.djangoSecretKey | b64enc | quote}}
-  {{- if .Values.backend.config.smtp.primary.password }}
+  {{- end }}
+  {{- if and (not .Values.backend.config.smtp.primary.existingSecret) .Values.backend.config.smtp.primary.password }}
   email-primary-password: {{ .Values.backend.config.smtp.primary.password | b64enc | quote}}
   {{- end }}
-  {{- if .Values.backend.config.smtp.rescue.password }}
+  {{- if and (not .Values.backend.config.smtp.rescue.existingSecret) .Values.backend.config.smtp.rescue.password }}
   email-rescue-password: {{ .Values.backend.config.smtp.rescue.password | b64enc | quote}}
   {{- end }}
 {{- end }}

--- a/charts/ciso-assistant-next/values.yaml
+++ b/charts/ciso-assistant-next/values.yaml
@@ -64,6 +64,9 @@ backend:
     smtp:
       # -- Default from email address
       defaultFrom: no-reply@ciso-assistant.net
+      # -- Name of an existing secret resource containing the primary SMTP password in a 'email-primary-password' key
+      # -- and the rescue SMTP username in a 'email-rescue-username' key
+      existingSecret: ""
       primary:
         # -- Primary SMTP hostname
         host: primary.cool-mailer.net
@@ -74,10 +77,10 @@ backend:
         # -- Primary SMTP username
         username: apikey
         # -- Primary SMTP password
-        password: ""
-        # -- Name of an existing secret resource containing the SMTP password in a 'email-primary-password' key
-        existingSecret: ""
+        password: "primary_password_here"
       rescue:
+        # -- Rescue SMTP hostname
+        enabled: true
         # -- Rescue SMTP hostname
         host: smtp.secondary.mailer.cloud
         # -- Rescue SMTP hostname
@@ -87,9 +90,7 @@ backend:
         # -- Rescue SMTP hostname
         username: username
         # -- Rescue SMTP hostname
-        password: ""
-        # -- Name of an existing secret resource containing the SMTP password in a 'email-rescue-password' key
-        existingSecret: ""
+        password: "rescue_password_here"
 
     # -- Set the database type (sqlite, pgsql or externalPgsql)
     ## Note : PostgreSQL database configuration at `postgresql` or `externalPgsql` section

--- a/charts/ciso-assistant-next/values.yaml
+++ b/charts/ciso-assistant-next/values.yaml
@@ -1,5 +1,5 @@
 ## CISO Assistant configuration
-## Ref: https://github.com/intuitem/ciso-assistant-community  
+## Ref: https://github.com/intuitem/ciso-assistant-community
 ##
 
 # -- Provide a name in place of `ciso-assistant`
@@ -34,7 +34,7 @@ global:
   clusterDomain: cluster.local
 
   # -- Toggle and define pod-level security context
-  # @default -- `{}` 
+  # @default -- `{}`
   securityContext: {}
   #  fsGroupChangePolicy: Always
   #  sysctls: []
@@ -59,7 +59,7 @@ backend:
   config:
     # -- Admin email for initial configuration
     emailAdmin: admin@example.net
-  
+
     ## SMTP configuration
     smtp:
       # -- Default from email address
@@ -74,7 +74,9 @@ backend:
         # -- Primary SMTP username
         username: apikey
         # -- Primary SMTP password
-        password: "primary_password_here"
+        password: ""
+        # -- Name of an existing secret resource containing the SMTP password in a 'email-primary-password' key
+        existingSecret: ""
       rescue:
         # -- Rescue SMTP hostname
         host: smtp.secondary.mailer.cloud
@@ -85,7 +87,9 @@ backend:
         # -- Rescue SMTP hostname
         username: username
         # -- Rescue SMTP hostname
-        password: "rescue_password_here"
+        password: ""
+        # -- Name of an existing secret resource containing the SMTP password in a 'email-rescue-password' key
+        existingSecret: ""
 
     # -- Set the database type (sqlite, pgsql or externalPgsql)
     ## Note : PostgreSQL database configuration at `postgresql` or `externalPgsql` section
@@ -93,6 +97,8 @@ backend:
 
     # -- Set Django secret key
     djangoSecretKey: "changeme"
+    # -- Name of an existing secret resource containing the django secret in a 'django-secret-key' key
+    djangoExistingSecretKey: ""
 
     # -- Enable Django debug mode
     djangoDebug: false
@@ -150,7 +156,7 @@ backend:
   env: []
 
   # -- Toggle and define container-level security context
-  # @default -- `{}` 
+  # @default -- `{}`
   containerSecurityContext: {}
   #  seLinuxOptions: {}
   #  runAsUser: 1001
@@ -188,7 +194,7 @@ frontend:
   config:
     # -- Configure body size limit for uploads in bytes (unit suffix like K/M/G can be used)
     bodySizeLimit: "50M"
-  
+
   ## Frontend image
   image:
     # -- Registry to use for the frontend
@@ -220,7 +226,7 @@ frontend:
   env: []
 
   # -- Toggle and define container-level security context
-  # @default -- `{}` 
+  # @default -- `{}`
   containerSecurityContext: {}
   #  seLinuxOptions: {}
   #  runAsUser: 1001


### PR DESCRIPTION
New Features
-  values for django secret and smtp password can be provided via an external secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Enhanced secure configuration management by conditionally using pre-existing credentials.
	- Reduced reliance on hardcoded sensitive data for backend services and email configurations.
	- Improved configuration clarity to reinforce overall security and flexibility.
	- Added new fields in the configuration for existing secrets related to SMTP and Django.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->