### PR TITLE
fix: filters for Safari

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ pnpm run dev
 4. Reach the frontend on <http://localhost:5173>
 
 > [!NOTE]
-> Safari will not properly work in this setup, as it requires https for secure cookies. The simplest solution is to use Chrome or Firefox. An alternative is to use a caddy proxy. This is the solution used in docker-compose, so you can use it as an example.
+> Safari will not properly work in this setup, as it requires https for secure cookies. The simplest solution is to use Chrome or Firefox. An alternative is to use a caddy proxy. Please see the [readme file](frontend/README.md) in frontend directory for more information on this.
 
 5. Environment variables
 

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -1,0 +1,5 @@
+https://localhost {
+	reverse_proxy localhost:5173 {
+		header_up Origin http://localhost
+	}
+}

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -37,3 +37,10 @@ pnpm run build
 You can preview the production build with `pnpm run preview`.
 
 > To deploy your app, you may need to install an [adapter](https://kit.svelte.dev/docs/adapters) for your target environment.
+
+## Testing with Safari
+
+Safari requires https. To test it, the simplest solution is to use a local instance of caddy. To have it work properly, it is necessary to trick vite by sending it the Origin variable, as vite does not handle environment variables. The Caddyfile provided here is working properly, and can be launched by simply typing "caddy run".
+
+In this setup, it is necessary to launch the backend with an adjusted CISO_ASSISTANT_URL=https://localhost.
+

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -43,4 +43,3 @@ You can preview the production build with `pnpm run preview`.
 Safari requires https. To test it, the simplest solution is to use a local instance of caddy. To have it work properly, it is necessary to trick vite by sending it the Origin variable, as vite does not handle environment variables. The Caddyfile provided here is working properly, and can be launched by simply typing "caddy run".
 
 In this setup, it is necessary to launch the backend with an adjusted CISO_ASSISTANT_URL=https://localhost.
-

--- a/frontend/src/lib/components/ModelTable/ModelTable.svelte
+++ b/frontend/src/lib/components/ModelTable/ModelTable.svelte
@@ -224,10 +224,9 @@
 	import Anchor from '$lib/components/Anchor/Anchor.svelte';
 
 	const popupFilter: PopupSettings = {
-		event: 'focus-click',
+		event: 'click',
 		target: 'popupFilter',
 		placement: 'bottom-start',
-		closeQuery: 'li'
 	};
 
 	$: classesHexBackgroundText = (backgroundHexColor: string) => {

--- a/frontend/src/lib/components/ModelTable/ModelTable.svelte
+++ b/frontend/src/lib/components/ModelTable/ModelTable.svelte
@@ -226,7 +226,7 @@
 	const popupFilter: PopupSettings = {
 		event: 'click',
 		target: 'popupFilter',
-		placement: 'bottom-start',
+		placement: 'bottom-start'
 	};
 
 	$: classesHexBackgroundText = (backgroundHexColor: string) => {


### PR DESCRIPTION
This was a regression in 2.0.4, that occurs only for Safari. 
Add documentation to explain how to test with Safari in development using a caddy proxy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Revised compatibility notes to include a reference for additional Safari testing details.
	- Introduced a new section outlining the requirements and setup for testing the application in Safari using secure protocols.
- **New Features**
	- Added a local routing configuration to enable secure redirection for development requests.
	- Updated the popup interaction behavior to trigger on click, streamlining the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->