### PR TITLE
fix: use same ref_id translation for all createmodal

### DIFF
--- a/frontend/src/lib/components/Forms/ModelForm/FrameworkForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/FrameworkForm.svelte
@@ -13,7 +13,7 @@
 <TextField
 	{form}
 	field="ref_id"
-	label={m.ref()}
+	label={m.refId()}
 	cacheLock={cacheLocks['ref_id']}
 	bind:cachedValue={formDataCache['ref_id']}
 />

--- a/frontend/src/lib/components/Forms/ModelForm/ReferenceControlForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/ReferenceControlForm.svelte
@@ -17,7 +17,7 @@
 <TextField
 	{form}
 	field="ref_id"
-	label={m.ref()}
+	label={m.refId()}
 	cacheLock={cacheLocks['ref_id']}
 	bind:cachedValue={formDataCache['ref_id']}
 />

--- a/frontend/src/lib/components/Forms/ModelForm/SolutionForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/SolutionForm.svelte
@@ -24,7 +24,7 @@
 <TextField
 	{form}
 	field="ref_id"
-	label={m.ref()}
+	label={m.refId()}
 	cacheLock={cacheLocks['ref_id']}
 	bind:cachedValue={formDataCache['ref_id']}
 />

--- a/frontend/src/lib/components/Forms/ModelForm/ThreatForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/ThreatForm.svelte
@@ -25,7 +25,7 @@
 <TextField
 	{form}
 	field="ref_id"
-	label={m.ref()}
+	label={m.refId()}
 	cacheLock={cacheLocks['ref_id']}
 	bind:cachedValue={formDataCache['ref_id']}
 />


### PR DESCRIPTION
m.ref -> m.refId

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated display labels in forms to improve consistency and clarity for reference fields across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->