### PR TITLE
chore(i18n): reflect the renaming of project to perimeter

### DIFF
--- a/documentation/architecture/data-model.md
+++ b/documentation/architecture/data-model.md
@@ -465,7 +465,7 @@ The perimeter has the following fields:
 
 An assessment can only be attached to a perimeter that is in the same domain as the assessment.
 
-Note: perimeters where previously named "projects", but this was misleading.
+Note: perimeters were previously named "projects", but this was misleading.
 
 ### Project objects
 

--- a/frontend/messages/ar.json
+++ b/frontend/messages/ar.json
@@ -753,7 +753,7 @@
 	"mailFailedToSend": "فشل في إرسال البريد",
 	"questionOrQuestions": "أسئلة)",
 	"successfullyUpdatedClientSettings": "تم تحديث إعدادات العميل بنجاح، يرجى تحديث الصفحة.",
-	"xRaysEmptyMessage": "يتعين عليك إنشاء مشروع واحد على الأقل لاستخدام الأشعة السينية.",
+	"xRaysEmptyMessage": "يتعين عليك إنشاء محيط واحد على الأقل لاستخدام الأشعة السينية.",
 	"suggestControls": "اقتراح الضوابط",
 	"createAppliedControlsFromSuggestionsHelpText": "إنشاء عناصر تحكم تطبيقية من عناصر التحكم المرجعية المقترحة لمتطلبات الإطار",
 	"createAppliedControlsFromSuggestionsSuccess": "تم تطبيق عناصر التحكم بنجاح من عناصر التحكم المرجعية المقترحة",

--- a/frontend/messages/cs.json
+++ b/frontend/messages/cs.json
@@ -750,7 +750,7 @@
 	"mailFailedToSend": "E-mail se nepodařilo odeslat",
 	"questionOrQuestions": "Otázka(y)",
 	"successfullyUpdatedClientSettings": "Nastavení klienta úspěšně aktualizováno, prosím obnovte stránku.",
-	"xRaysEmptyMessage": "Musíte vytvořit alespoň jeden projekt, abyste mohli používat X-ray.",
+	"xRaysEmptyMessage": "Musíte vytvořit alespoň jeden obvod, abyste mohli používat X-ray.",
 	"suggestControls": "Navrhnout kontroly",
 	"createAppliedControlsFromSuggestionsHelpText": "Vytvořte aplikované kontroly z navrhovaných referenčních kontrol požadavků rámce",
 	"createAppliedControlsFromSuggestionsSuccess": "Aplikované kontroly byly úspěšně vytvořeny z navrhovaných referenčních kontrol",

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -752,7 +752,7 @@
 	"mailFailedToSend": "Die E-Mail konnte nicht gesendet werden",
 	"questionOrQuestions": "Frage(n)",
 	"successfullyUpdatedClientSettings": "Clienteinstellungen erfolgreich aktualisiert, bitte aktualisieren Sie die Seite.",
-	"xRaysEmptyMessage": "Um Röntgenstrahlen verwenden zu können, müssen Sie mindestens ein Projekt erstellen.",
+	"xRaysEmptyMessage": "Um Röntgenstrahlen verwenden zu können, müssen Sie mindestens ein Bereich erstellen.",
 	"suggestControls": "Steuerelemente vorschlagen",
 	"createAppliedControlsFromSuggestionsHelpText": "Erstellen Sie angewandte Kontrollen aus den vorgeschlagenen Referenzkontrollen der Framework-Anforderungen",
 	"createAppliedControlsFromSuggestionsSuccess": "Angewandte Kontrollen erfolgreich aus den vorgeschlagenen Referenzkontrollen erstellt",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -752,7 +752,7 @@
 	"mailFailedToSend": "El correo no se pudo enviar",
 	"questionOrQuestions": "Preguntas)",
 	"successfullyUpdatedClientSettings": "La configuración del cliente se actualizó correctamente, actualice la página.",
-	"xRaysEmptyMessage": "Debes crear al menos un proyecto para poder utilizar rayos X.",
+	"xRaysEmptyMessage": "Debes crear al menos un alcance para poder utilizar rayos X.",
 	"suggestControls": "Sugerir controles",
 	"createAppliedControlsFromSuggestionsHelpText": "Crear controles aplicados a partir de los controles de referencia sugeridos por los requisitos del marco",
 	"createAppliedControlsFromSuggestionsSuccess": "Controles aplicados creados exitosamente a partir de los controles de referencia sugeridos",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -767,7 +767,7 @@
 	"mailFailedToSend": "Le courrier n'a pas pu être envoyé",
 	"questionOrQuestions": "Question(s)",
 	"successfullyUpdatedClientSettings": "Paramètres du client mis à jour avec succès. Vous pouvez rafraîchir la page.",
-	"xRaysEmptyMessage": "Vous devez créer au moins un projet pour utiliser X-rays.",
+	"xRaysEmptyMessage": "Vous devez créer au moins un périmètre pour utiliser X-rays.",
 	"suggestControls": "Mesures recommandées",
 	"createAppliedControlsFromSuggestionsHelpText": "Créer des mesures appliquées à partir des mesures de référence suggérées",
 	"createAppliedControlsFromSuggestionsSuccess": "Mesures appliquées créées avec succès à partir des suggestions",

--- a/frontend/messages/hi.json
+++ b/frontend/messages/hi.json
@@ -752,7 +752,7 @@
 	"mailFailedToSend": "मेल भेजा जाना विफल रहा",
 	"questionOrQuestions": "प्रश्न",
 	"successfullyUpdatedClientSettings": "क्लाइंट सेटिंग्स सफलतापूर्वक अपडेट हो गई हैं, कृपया पेज को रीफ्रेश करें।",
-	"xRaysEmptyMessage": "एक्स-रे का उपयोग करने के लिए आपको कम से कम एक प्रोजेक्ट बनाना होगा।",
+	"xRaysEmptyMessage": "एक्स-रे का उपयोग करने के लिए आपको कम से कम एक परिधि बनाना होगा।",
 	"suggestControls": "नियंत्रण सुझाएँ",
 	"createAppliedControlsFromSuggestionsHelpText": "फ़्रेमवर्क की आवश्यकताओं के सुझाए गए संदर्भ नियंत्रणों से लागू नियंत्रण बनाएँ",
 	"createAppliedControlsFromSuggestionsSuccess": "सुझाए गए संदर्भ नियंत्रणों से सफलतापूर्वक लागू किए गए नियंत्रण बनाए गए",

--- a/frontend/messages/id.json
+++ b/frontend/messages/id.json
@@ -759,7 +759,7 @@
 	"mailFailedToSend": "Email gagal dikirim",
 	"questionOrQuestions": "Pertanyaan",
 	"successfullyUpdatedClientSettings": "Pengaturan klien berhasil diperbarui, silakan muat ulang halaman.",
-	"xRaysEmptyMessage": "Anda harus membuat setidaknya satu proyek untuk menggunakan X-rays.",
+	"xRaysEmptyMessage": "Anda harus membuat setidaknya satu lingkup untuk menggunakan sinar-X.",
 	"suggestControls": "Sarankan kontrol",
 	"createAppliedControlsFromSuggestionsHelpText": "Buat kontrol yang diterapkan dari kontrol referensi yang disarankan untuk persyaratan kerangka kerja",
 	"createAppliedControlsFromSuggestionsSuccess": "Kontrol yang diterapkan berhasil dibuat dari kontrol referensi yang disarankan",

--- a/frontend/messages/it.json
+++ b/frontend/messages/it.json
@@ -752,7 +752,7 @@
 	"mailFailedToSend": "Non è stato possibile inviare l'email",
 	"questionOrQuestions": "Domanda/e",
 	"successfullyUpdatedClientSettings": "Impostazioni client aggiornate correttamente. Ricaricare la pagina.",
-	"xRaysEmptyMessage": "Per utilizzare la funzione X-Ray è necessario creare almeno un progetto.",
+	"xRaysEmptyMessage": "Per utilizzare la funzione X-Ray è necessario creare almeno un ambito.",
 	"suggestControls": "Suggerisci controlli",
 	"createAppliedControlsFromSuggestionsHelpText": "Creare controlli partendo dai controlli di riferimento suggeriti e dai requisiti del framework",
 	"createAppliedControlsFromSuggestionsSuccess": "Controlli creati correttamente dai controlli di riferimento suggeriti",

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -752,7 +752,7 @@
 	"mailFailedToSend": "Nie udało się wysłać maila",
 	"questionOrQuestions": "Pytanie(a)",
 	"successfullyUpdatedClientSettings": "Ustawienia klienta zostały pomyślnie zaktualizowane. Odśwież stronę.",
-	"xRaysEmptyMessage": "Aby użyć promieni rentgenowskich, musisz utworzyć co najmniej jeden projekt.",
+	"xRaysEmptyMessage": "Aby użyć promieni rentgenowskich, musisz utworzyć co najmniej jeden zakres.",
 	"suggestControls": "Zaproponuj kontrole",
 	"createAppliedControlsFromSuggestionsHelpText": "Utwórz kontrolki stosowane na podstawie sugerowanych kontrolek referencyjnych wymagań struktury",
 	"createAppliedControlsFromSuggestionsSuccess": "Zastosowano pomyślnie elementy sterujące utworzone na podstawie sugerowanych elementów referencyjnych",

--- a/frontend/messages/pt.json
+++ b/frontend/messages/pt.json
@@ -752,7 +752,7 @@
 	"mailFailedToSend": "O e-mail não foi enviado",
 	"questionOrQuestions": "Questões)",
 	"successfullyUpdatedClientSettings": "As configurações do cliente foram atualizadas com sucesso. Atualize a página.",
-	"xRaysEmptyMessage": "Você precisa criar pelo menos um projeto para usar raios X.",
+	"xRaysEmptyMessage": "Você precisa criar pelo menos um âmbito para usar raios X.",
 	"suggestControls": "Sugerir controles",
 	"createAppliedControlsFromSuggestionsHelpText": "Crie controles aplicados a partir dos controles de referência sugeridos pelos requisitos da estrutura",
 	"createAppliedControlsFromSuggestionsSuccess": "Controles aplicados criados com sucesso a partir dos controles de referência sugeridos",

--- a/frontend/messages/ro.json
+++ b/frontend/messages/ro.json
@@ -752,7 +752,7 @@
 	"mailFailedToSend": "E-mailul nu a putut fi trimis",
 	"questionOrQuestions": "Întrebare(e)",
 	"successfullyUpdatedClientSettings": "Setările clientului au fost actualizate cu succes, vă rugăm să reîmprospătați pagina.",
-	"xRaysEmptyMessage": "Trebuie să creați cel puțin un proiect pentru a utiliza raze X.",
+	"xRaysEmptyMessage": "Trebuie să creați cel puțin o întindere pentru a utiliza raze X.",
 	"suggestControls": "Sugerați controale",
 	"createAppliedControlsFromSuggestionsHelpText": "Creați controale aplicate din controalele de referință sugerate de cerințele cadrului",
 	"createAppliedControlsFromSuggestionsSuccess": "Controalele aplicate create cu succes din controalele de referință sugerate",

--- a/frontend/messages/sv.json
+++ b/frontend/messages/sv.json
@@ -753,7 +753,7 @@
 	"mailFailedToSend": "E-postmeddelandet kunde inte skickas",
 	"questionOrQuestions": "Fråga(or)",
 	"successfullyUpdatedClientSettings": "Klientinställningar uppdaterades framgångsrikt, vänligen uppdatera sidan.",
-	"xRaysEmptyMessage": "Du måste skapa minst ett projekt för att använda röntgen.",
+	"xRaysEmptyMessage": "Du måste skapa minst ett perimeter för att använda röntgen.",
 	"suggestControls": "Föreslå kontroller",
 	"createAppliedControlsFromSuggestionsHelpText": "Skapa tillämpade kontroller från kravens föreslagna referenskontroller i ramverket",
 	"createAppliedControlsFromSuggestionsSuccess": "Tillämpade kontroller skapades framgångsrikt från de föreslagna referenskontrollerna",

--- a/frontend/messages/ur.json
+++ b/frontend/messages/ur.json
@@ -752,7 +752,7 @@
 	"mailFailedToSend": "میل بھیجنے میں ناکام رہا۔",
 	"questionOrQuestions": "سوال (سوال)",
 	"successfullyUpdatedClientSettings": "کلائنٹ کی ترتیبات کو کامیابی کے ساتھ اپ ڈیٹ کیا گیا، براہ کرم صفحہ کو ریفریش کریں۔",
-	"xRaysEmptyMessage": "ایکس رے استعمال کرنے کے لیے آپ کو کم از کم ایک پروجیکٹ بنانا ہوگا۔",
+	"xRaysEmptyMessage": "ایکسرے استعمال کرنے کے لیے آپ کو کم از کم ایک پیریمیٹرز بنانا ہوگا۔",
 	"suggestControls": "کنٹرولز تجویز کریں۔",
 	"createAppliedControlsFromSuggestionsHelpText": "فریم ورک کی ضروریات کے تجویز کردہ حوالہ کنٹرول سے لاگو کنٹرولز بنائیں",
 	"createAppliedControlsFromSuggestionsSuccess": "تجویز کردہ حوالہ کنٹرولز سے کامیابی کے ساتھ بنائے گئے لاگو کنٹرولز",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Revised the empty state messaging for the X-rays feature across multiple languages. The text now instructs users to create a “perimeter” (or equivalent) instead of a “project,” reflecting updated terminology in the user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->