### PR TITLE
fix: strip ref_id in Excel file containing framework description

### DIFF
--- a/tools/convert_library.py
+++ b/tools/convert_library.py
@@ -706,7 +706,7 @@ for tab in dataframe:
                 assert "name" in header
                 assert "description" in header
             elif any([c.value for c in row]):
-                ref_id = row[header["ref_id"]].value
+                ref_id = str(row[header["ref_id"]].value).strip()
                 name = row[header["name"]].value
                 description = row[header["description"]].value
                 translations = get_translations(header, row)


### PR DESCRIPTION
strip ref_id in implementation groups to be more tolerant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced data processing by ensuring identifier values are consistently formatted, reducing potential issues with extra whitespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->