### PR TITLE
fix: add safeguard to matrix data migration in case json_definition is already a dict

### DIFF
--- a/backend/core/migrations/0056_data_store_matrix_json_as_dict_not_str.py
+++ b/backend/core/migrations/0056_data_store_matrix_json_as_dict_not_str.py
@@ -7,8 +7,13 @@ def make_matrix_json_definition_dict(apps, schema_editor):
     RiskMatrix = apps.get_model("core", "RiskMatrix")
 
     for matrix in RiskMatrix.objects.all():
-        matrix.json_definition = json.loads(matrix.json_definition)
-        matrix.save()
+        try:
+            matrix.json_definition = json.loads(matrix.json_definition)
+            matrix.save()
+        except Exception as e:
+            if type(matrix.json_definition) is dict:
+                continue
+            print(f"Error converting matrix {matrix.id} to dict: {e}")
 
 
 class Migration(migrations.Migration):

--- a/backend/library/utils.py
+++ b/backend/library/utils.py
@@ -538,7 +538,7 @@ class LibraryImporter:
                 ", ".join(missing_fields)
             )"""
 
-        library_objects = json.loads(self._library.content)
+        library_objects = self._library.content
 
         if not any(
             object_field in library_objects for object_field in self.OBJECT_FIELDS

--- a/backend/library/views.py
+++ b/backend/library/views.py
@@ -140,7 +140,7 @@ class StoredLibraryViewSet(BaseModelViewSet):
         except:
             return Response(data="Library not found.", status=HTTP_404_NOT_FOUND)
 
-        library_objects = json.loads(lib.content)  # We may need caching for this
+        library_objects = lib.content  # We may need caching for this
         if not (framework := library_objects.get("framework")):
             return Response(
                 data="This library does not include a framework.",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling during the data migration to boost overall system stability by ensuring that individual conversion errors do not interrupt the migration process.
  
- **Changes**
  - Updated library content processing to handle raw content instead of parsed JSON, potentially affecting downstream usage of library data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->