### PR TITLE
feat: add children assets in assets detail view

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -1653,6 +1653,12 @@ class Asset(
             sub_children.update(child.get_descendants())
         return sub_children
 
+    @property
+    def children_assets(self):
+        descendants = self.get_descendants()
+        descendant_ids = [d.id for d in descendants]
+        return Asset.objects.filter(id__in=descendant_ids).exclude(id=self.id)
+
     def get_security_objectives(self) -> dict[str, dict[str, dict[str, int | bool]]]:
         """
         Gets the security objectives of a given asset.

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -8,6 +8,7 @@ from django.db import models
 from ciso_assistant.settings import EMAIL_HOST, EMAIL_HOST_RESCUE
 from core.models import *
 from core.serializer_fields import FieldsRelatedField, HashSlugRelatedField
+from core.utils import time_state
 from ebios_rm.models import EbiosRMStudy
 from iam.models import *
 
@@ -546,9 +547,15 @@ class AppliedControlReadSerializer(AppliedControlWriteSerializer):
     ranking_score = serializers.IntegerField(source="get_ranking_score")
     owner = FieldsRelatedField(many=True)
     security_exceptions = FieldsRelatedField(many=True)
-    # These properties shouldn't be displayed in the frontend detail view as they are simple derivations from fields already displayed in the detail view.
-    # has_evidences = serializers.BooleanField()
-    # eta_missed = serializers.BooleanField()
+    state = serializers.SerializerMethodField()
+    requirements_count = serializers.IntegerField(
+        source="requirement_assessments.count"
+    )
+
+    def get_state(self, obj):
+        if not obj.eta:
+            return None
+        return time_state(obj.eta.isoformat())
 
 
 class AppliedControlDuplicateSerializer(BaseModelSerializer):

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -8,7 +8,6 @@ from django.db import models
 from ciso_assistant.settings import EMAIL_HOST, EMAIL_HOST_RESCUE
 from core.models import *
 from core.serializer_fields import FieldsRelatedField, HashSlugRelatedField
-from core.utils import time_state
 from ebios_rm.models import EbiosRMStudy
 from iam.models import *
 
@@ -322,6 +321,7 @@ class AssetWriteSerializer(BaseModelSerializer):
 class AssetReadSerializer(AssetWriteSerializer):
     folder = FieldsRelatedField()
     parent_assets = FieldsRelatedField(many=True)
+    children_assets = FieldsRelatedField(["id"], many=True)
     owner = FieldsRelatedField(many=True)
     security_objectives = serializers.JSONField(
         source="get_security_objectives_display"
@@ -546,15 +546,9 @@ class AppliedControlReadSerializer(AppliedControlWriteSerializer):
     ranking_score = serializers.IntegerField(source="get_ranking_score")
     owner = FieldsRelatedField(many=True)
     security_exceptions = FieldsRelatedField(many=True)
-    state = serializers.SerializerMethodField()
-    requirements_count = serializers.IntegerField(
-        source="requirement_assessments.count"
-    )
-
-    def get_state(self, obj):
-        if not obj.eta:
-            return None
-        return time_state(obj.eta.isoformat())
+    # These properties shouldn't be displayed in the frontend detail view as they are simple derivations from fields already displayed in the detail view.
+    # has_evidences = serializers.BooleanField()
+    # eta_missed = serializers.BooleanField()
 
 
 class AppliedControlDuplicateSerializer(BaseModelSerializer):

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -159,6 +159,7 @@
 	"typicalEvidence": "Typical evidence",
 	"parentAsset": "Parent asset",
 	"parentAssets": "Parent assets",
+	"childrenAssets": "Children assets",
 	"approver": "Approver",
 	"state": "State",
 	"justification": "Justification",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -159,6 +159,7 @@
 	"typicalEvidence": "Preuve typique",
 	"parentAsset": "Actif parent",
 	"parentAssets": "Actifs parents",
+	"childrenAssets": "Actifs enfants",
 	"approver": "Approbateur",
 	"state": "État",
 	"justification": "Justification",

--- a/frontend/src/lib/components/DetailView/DetailView.svelte
+++ b/frontend/src/lib/components/DetailView/DetailView.svelte
@@ -269,6 +269,33 @@
 													: (safeTranslate(['low', 'medium', 'high', 'critical'][value]) ??
 														m.undefined())}
 											{stringifiedSeverity}
+										{:else if key === 'children_assets'}
+											{#if Object.keys(value).length > 0}
+														<ul class="inline-flex flex-wrap space-x-4">
+
+													{#each value as val}
+														<li data-testid={key.replace('_', '-') + '-field-value'}>
+															{#if val.str && val.id}
+																{@const itemHref = `/${
+																	URL_MODEL_MAP[data.urlModel]['foreignKeyFields']?.find(
+																		(item) => item.field === key
+																	)?.urlModel
+																}/${val.id}`}
+																<Anchor breadcrumbAction="push" href={itemHref} class="anchor"
+																
+																	>{val.str}</Anchor
+																>
+															{:else if val.str}
+																{safeTranslate(val.str)}
+															{:else}
+																{value}
+															{/if}
+														</li>
+													{/each}
+												</ul>
+											{:else}
+												--
+											{/if}
 										{:else if Array.isArray(value)}
 											{#if Object.keys(value).length > 0}
 												<ul>

--- a/frontend/src/lib/components/DetailView/DetailView.svelte
+++ b/frontend/src/lib/components/DetailView/DetailView.svelte
@@ -185,6 +185,10 @@
 	if (data.urlModel === 'folders') {
 		orderRelatedModels = ['perimeters', 'entities'];
 	}
+
+	function truncateString(str: string, maxLength: number = 50): string {
+		return str.length > maxLength ? str.slice(0, maxLength) + '...' : str;
+	}
 </script>
 
 <div class="flex flex-col space-y-2">
@@ -280,8 +284,8 @@
 																		(item) => item.field === key
 																	)?.urlModel
 																}/${val.id}`}
-																<Anchor breadcrumbAction="push" href={itemHref} class="anchor"
-																	>{val.str}</Anchor
+																<Anchor breadcrumbAction="push" href={itemHref} class="anchor">
+																	{truncateString(val.str)}</Anchor
 																>
 															{:else if val.str}
 																{safeTranslate(val.str)}

--- a/frontend/src/lib/components/DetailView/DetailView.svelte
+++ b/frontend/src/lib/components/DetailView/DetailView.svelte
@@ -271,8 +271,7 @@
 											{stringifiedSeverity}
 										{:else if key === 'children_assets'}
 											{#if Object.keys(value).length > 0}
-														<ul class="inline-flex flex-wrap space-x-4">
-
+												<ul class="inline-flex flex-wrap space-x-4">
 													{#each value as val}
 														<li data-testid={key.replace('_', '-') + '-field-value'}>
 															{#if val.str && val.id}
@@ -282,7 +281,6 @@
 																	)?.urlModel
 																}/${val.id}`}
 																<Anchor breadcrumbAction="push" href={itemHref} class="anchor"
-																
 																	>{val.str}</Anchor
 																>
 															{:else if val.str}

--- a/frontend/src/lib/utils/crud.ts
+++ b/frontend/src/lib/utils/crud.ts
@@ -385,6 +385,7 @@ export const URL_MODEL_MAP: ModelMap = {
 		verboseNamePlural: 'Assets',
 		foreignKeyFields: [
 			{ field: 'parent_assets', urlModel: 'assets' },
+			{ field: 'children_assets', urlModel: 'assets' },
 			{ field: 'owner', urlModel: 'users' },
 			{ field: 'folder', urlModel: 'folders', urlParams: 'content_type=DO&content_type=GL' },
 			{ field: 'filtering_labels', urlModel: 'filtering-labels' },


### PR DESCRIPTION
Adding a children assets in assets detail view can be useful to see al the descendance and so the importance of an asset .
If 1 is the parent of 2 and 2 is the parent of 3, 1 will have 2 and 3 as children assets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Assets now display associated child assets for improved hierarchical navigation.
  - Updated multilingual support with new labels for child assets in English and French.
  - Enhanced asset relationship mapping across the platform.

- **Enhancements**
  - Added a property to directly access child assets in the Asset class.
  - Included child asset identifiers in the AssetReadSerializer for better data representation.
  - Enhanced the DetailView component to render child assets when available.
  - Introduced a utility function for string truncation in the DetailView component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->