### PR TITLE
fix: unique constraint violation for mapping_urn

### DIFF
--- a/tools/prepare_mapping.py
+++ b/tools/prepare_mapping.py
@@ -51,7 +51,7 @@ ws.append(["library_provider", packager])
 ws.append(["library_packager", packager])
 ws.append(["library_dependencies", f"{source_library_urn}, {target_library_urn}"])
 ws.append(
-    ["mapping_urn", f"urn:{packager.lower()}:risk:req_mapping_set:{source_ref_id}"]
+    ["mapping_urn", f"urn:{packager.lower()}:risk:req_mapping_set:{ref_id}"]
 )
 ws.append(["mapping_ref_id", ref_id])
 ws.append(["mapping_name", name])


### PR DESCRIPTION
fix #1590
Uses the `ref_id` variable, which combines both the source and target framework, to get the urn.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the Excel export so that mapping reference identifiers now combine key details for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->