### PR TITLE
fix: increase the healthcheck to accomodate slow hw

### DIFF
--- a/config/templates/docker-compose-postgresql-caddy.yml.j2
+++ b/config/templates/docker-compose-postgresql-caddy.yml.j2
@@ -52,8 +52,8 @@ services:
       test: ["CMD-SHELL", "curl -f http://backend:8000/api/build || exit 1"]
       interval: 10s
       timeout: 5s
-      retries: 10
-      start_period: 60s
+      retries: 20
+      start_period: 100s
 
   huey:
     container_name: huey

--- a/config/templates/docker-compose-postgresql-traefik.yml.j2
+++ b/config/templates/docker-compose-postgresql-traefik.yml.j2
@@ -52,8 +52,8 @@ services:
       test: ["CMD-SHELL", "curl -f http://backend:8000/api/build || exit 1"]
       interval: 10s
       timeout: 5s
-      retries: 10
-      start_period: 60s
+      retries: 20
+      start_period: 100s
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.backend.rule=Host(`{{ fqdn }}`) && PathPrefix(`/api`)"

--- a/config/templates/docker-compose-sqlite-caddy.yml.j2
+++ b/config/templates/docker-compose-sqlite-caddy.yml.j2
@@ -23,8 +23,8 @@ services:
       test: ["CMD-SHELL", "curl -f http://backend:8000/api/build || exit 1"]
       interval: 10s
       timeout: 5s
-      retries: 10
-      start_period: 60s
+      retries: 20
+      start_period: 100s
 
   huey:
     container_name: huey

--- a/config/templates/docker-compose-sqlite-traefik.yml.j2
+++ b/config/templates/docker-compose-sqlite-traefik.yml.j2
@@ -23,8 +23,8 @@ services:
       test: ["CMD-SHELL", "curl -f http://backend:8000/api/build || exit 1"]
       interval: 10s
       timeout: 5s
-      retries: 10
-      start_period: 60s
+      retries: 20
+      start_period: 100s
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.backend.rule=Host(`{{ fqdn }}`) && PathPrefix(`/api`)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,8 @@ services:
       test: ["CMD-SHELL", "curl -f http://backend:8000/api/build || exit 1"]
       interval: 10s
       timeout: 5s
-      retries: 10
-      start_period: 60s
+      retries: 20
+      start_period: 100s
 
   huey:
     container_name: huey


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced backend service health check settings by increasing retry attempts and extending the initial delay before checks begin. These adjustments improve resilience during service startup and contribute to a more stable overall system performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->