### PR TITLE
fix: findings assessments cateory choices in french

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -3637,10 +3637,10 @@ class RequirementAssessment(AbstractBaseModel, FolderMixin, ETADueDateMixin):
 
 class FindingsAssessment(Assessment):
     class Category(models.TextChoices):
-        UNDEFINED = "--", _("Undefined")
-        PENTEST = "pentest", _("Pentest")
-        AUDIT = "audit", _("Audit")
-        SELF_IDENTIFIED = "self_identified", _("Self-identified")
+        UNDEFINED = "--", "Undefined"
+        PENTEST = "pentest", "Pentest"
+        AUDIT = "audit", "Audit"
+        SELF_IDENTIFIED = "self_identified", "Self-identified"
 
     owner = models.ManyToManyField(
         User,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated assessment category labels to use plain English text instead of multilingual translations. Users may now see these labels displayed only in English.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->