### PR TITLE
fix(chart): only create ingress tls configuration when certificateSecret is provided

### DIFF
--- a/charts/ciso-assistant-next/templates/ingress/ingress.yaml
+++ b/charts/ciso-assistant-next/templates/ingress/ingress.yaml
@@ -31,7 +31,7 @@ spec:
               number: {{ .Values.backend.service.port }}
         path: /api/
         pathType: Prefix
-  {{- if .Values.global.tls }}
+  {{- if and .Values.global.tls .Values.ingress.certificateSecret }}
   tls:
     - hosts:
       - {{ .Values.global.domain }}

--- a/charts/ciso-assistant-next/templates/ingress/tls-secret.yaml
+++ b/charts/ciso-assistant-next/templates/ingress/tls-secret.yaml
@@ -1,5 +1,4 @@
-{{- if and .Values.ingress.enabled .Values.global.tls }}
-{{- if .Values.ingress.certificateSecret }}
+{{- if and .Values.ingress.enabled .Values.ingress.certificateSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,5 +9,4 @@ type: kubernetes.io/tls
 data:
   tls.crt: {{ .Values.ingress.certificateSecret.certificate | b64enc }}
   tls.key: {{ .Values.ingress.certificateSecret.key | b64enc }}
-{{- end }}
 {{- end }}


### PR DESCRIPTION
Thanks for your amazing work on CISO-Assistant!

The current helm chart does not handle deployment type where the application is deployed behind a load balancer that performs the TLS termination (AWS ALB for instance).

In this configuration, pods should still be configured with environment variables containing https URL (controlled by the global TLS chart parameter) but the tls attribute on the ingress object should not be created, as the ingress should only listen on port 80.

This change proposes to modify the condition for tls attribute of the ingress section and only create the attribute when the certificate secret is provided in the chart values. The secret creation condition is also modified accordingly.

Best regards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

These updates refine the TLS configuration to ensure secure connections are only established when a valid certificate is provided, resulting in a more robust and secure user experience.

- **Bug Fixes**
  - Enhanced TLS setup so that secure connections activate only with proper certificate specifications.
  - Adjusted configuration conditions to prevent inadvertent TLS enablement, thereby improving overall security and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->