### PR TITLE
helm : Add Huey, remove secondary SMTP and some helm fixes

### DIFF
--- a/charts/ciso-assistant-next/README.md
+++ b/charts/ciso-assistant-next/README.md
@@ -45,18 +45,12 @@ helm install ciso-assistant-release oci://ghcr.io/intuitem/helm-charts/ce/ciso-a
 | backend.config.djangoSecretKey | string | `"changeme"` | Set Django secret key |
 | backend.config.emailAdmin | string | `"admin@example.net"` | Admin email for initial configuration |
 | backend.config.smtp.defaultFrom | string | `"no-reply@ciso-assistant.net"` | Default from email address |
-| backend.config.smtp.existingSecret | string | `""` | and the rescue SMTP username in a 'email-rescue-username' key |
+| backend.config.smtp.existingSecret | string | `""` | Name of an existing secret resource containing the primary SMTP password in a 'email-primary-password' key |
 | backend.config.smtp.primary.host | string | `"primary.cool-mailer.net"` | Primary SMTP hostname |
 | backend.config.smtp.primary.password | string | `"primary_password_here"` | Primary SMTP password |
 | backend.config.smtp.primary.port | int | `587` | Primary SMTP post |
 | backend.config.smtp.primary.useTls | bool | `true` | Enable TLS for primary SMTP |
 | backend.config.smtp.primary.username | string | `"apikey"` | Primary SMTP username |
-| backend.config.smtp.rescue.enabled | bool | `true` | Rescue SMTP hostname |
-| backend.config.smtp.rescue.host | string | `"smtp.secondary.mailer.cloud"` | Rescue SMTP hostname |
-| backend.config.smtp.rescue.password | string | `"rescue_password_here"` | Rescue SMTP hostname |
-| backend.config.smtp.rescue.port | int | `587` | Rescue SMTP hostname |
-| backend.config.smtp.rescue.useTls | bool | `true` | Enable TLS for rescue SMTP |
-| backend.config.smtp.rescue.username | string | `"username"` | Rescue SMTP hostname |
 | backend.containerSecurityContext | object | `{}` | Toggle and define container-level security context |
 | backend.env | list | `[]` | Environment variables to pass to backend |
 | backend.image.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Image pull policy for the backend |
@@ -70,7 +64,7 @@ helm install ciso-assistant-release oci://ghcr.io/intuitem/helm-charts/ce/ciso-a
 | backend.persistence.localStorage.size | string | `"5Gi"` | Local Storage persistant volume size |
 | backend.persistence.localStorage.storageClass | string | `""` | Local Storage persistant volume storageClass |
 | backend.persistence.sqlite.accessMode | string | `"ReadWriteOnce"` | SQLite persistant volume accessMode |
-| backend.persistence.sqlite.enabled | bool | `true` | Enable SQLite persistence Note: only when `backend.config.databaseType` use `sqlite` value |
+| backend.persistence.sqlite.enabled | bool | `true` | Enable SQLite persistence # Note: only when `backend.config.databaseType` use `sqlite` value |
 | backend.persistence.sqlite.size | string | `"5Gi"` | SQLite persistant volume size |
 | backend.persistence.sqlite.storageClass | string | `""` | SQLite persistant volume storageClass |
 | backend.replicas | int | `1` | The number of backend pods to run |
@@ -112,6 +106,24 @@ helm install ciso-assistant-release oci://ghcr.io/intuitem/helm-charts/ce/ciso-a
 | global.securityContext | object | `{}` | Toggle and define pod-level security context |
 | global.tls | bool | `false` | Globally enable TLS (Ingress, URLs, etc.) |
 | global.tolerations | list | `[]` | Default tolerations for all components |
+| huey.containerSecurityContext | object | `{}` | Toggle and define container-level security context |
+| huey.env | list | `[]` | Environment variables to pass to Huey |
+| huey.image.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Image pull policy for the Huey |
+| huey.image.registry | string | `""` (defaults to global.image.registry) | Registry to use for the Huey |
+| huey.image.repository | string | `"intuitem/ciso-assistant-community/backend"` | Repository to use for the Huey |
+| huey.image.tag | string | `""` (defaults to global.image.tag) | Tag to use for the Huey |
+| huey.imagePullSecrets | list | `[]` (defaults to global.imagePullSecrets) | Secrets with credentials to pull images from a private registry |
+| huey.name | string | `"huey"` | Huey name |
+| huey.persistence.sqlite.accessMode | string | `"ReadWriteOnce"` | SQLite persistant volume accessMode |
+| huey.persistence.sqlite.enabled | bool | `true` | Enable SQLite persistence (for Huey) |
+| huey.persistence.sqlite.size | string | `"1Gi"` | SQLite persistant volume size |
+| huey.persistence.sqlite.storageClass | string | `""` | SQLite persistant volume storageClass |
+| huey.replicas | int | `1` | The number of frontend pods to run |
+| huey.resources | object | `{}` | Resources for the Huey |
+| huey.service.annotations | object | `{}` | Huey service annotations |
+| huey.service.labels | object | `{}` | Huey service labels |
+| huey.service.port | int | `80` | Huey service http port |
+| huey.service.portName | string | `"http"` | Huey service port name |
 | ingress.annotations | object | `{}` | Additional ingress annotations |
 | ingress.certificateSecret | object | `{}` | Custom TLS certificate as secret # Note: 'key' and 'certificate' are expected in PEM format |
 | ingress.enabled | bool | `true` | Enable an ingress resource for the CISO Assistant |

--- a/charts/ciso-assistant-next/README.md
+++ b/charts/ciso-assistant-next/README.md
@@ -98,6 +98,7 @@ helm install ciso-assistant-release oci://ghcr.io/intuitem/helm-charts/ce/ciso-a
 | global.clusterDomain | string | `"cluster.local"` | Kubernetes cluster domain name |
 | global.commonLabels | object | `{}` | Labels to add to all deployed objects |
 | global.domain | string | `"octopus.foo.bar"` | Default domain used by all components # Used for ingresses, certificates, environnement vars, etc. |
+| global.extraAllowedHosts | string | `""` | Extra allowed hosts (comma separated, without spaces) |
 | global.image.imagePullPolicy | string | `"IfNotPresent"` | If defined, a imagePullPolicy applied to all CISO Assistant deployments |
 | global.image.registry | string | `"ghcr.io"` | If defined, a registry applied to all CISO Assistant deployments |
 | global.image.tag | string | `""` | Overrides the global CISO Assistant image tag whose default is the chart appVersion |

--- a/charts/ciso-assistant-next/README.md
+++ b/charts/ciso-assistant-next/README.md
@@ -119,7 +119,7 @@ helm install ciso-assistant-release oci://ghcr.io/intuitem/helm-charts/ce/ciso-a
 | huey.persistence.sqlite.enabled | bool | `true` | Enable SQLite persistence (for Huey) |
 | huey.persistence.sqlite.size | string | `"1Gi"` | SQLite persistant volume size |
 | huey.persistence.sqlite.storageClass | string | `""` | SQLite persistant volume storageClass |
-| huey.replicas | int | `1` | The number of frontend pods to run |
+| huey.replicas | int | `1` | The number of Huey pods to run |
 | huey.resources | object | `{}` | Resources for the Huey |
 | huey.service.annotations | object | `{}` | Huey service annotations |
 | huey.service.labels | object | `{}` | Huey service labels |

--- a/charts/ciso-assistant-next/templates/_helpers.tpl
+++ b/charts/ciso-assistant-next/templates/_helpers.tpl
@@ -47,7 +47,7 @@ Common labels
 */}}
 {{- define "ciso-assistant.labels" -}}
 helm.sh/chart: {{ include "ciso-assistant.chart" .context }}
-{{ include "ciso-assistant.selectorLabels" (dict "context" .context "component" .component "name" .name) }}
+{{ include "ciso-assistant.selectorLabels" (dict "context" .context "component" .component) }}
 app.kubernetes.io/managed-by: {{ .context.Release.Service }}
 app.kubernetes.io/version: {{ include "ciso-assistant.versionLabelValue" .context }}
 {{- with .context.Values.global.commonLabels }}

--- a/charts/ciso-assistant-next/templates/backend/deployment.yaml
+++ b/charts/ciso-assistant-next/templates/backend/deployment.yaml
@@ -95,7 +95,7 @@ spec:
           - name: CISO_ASSISTANT_URL
             value: {{ template "ciso-assistant.url" . }}
           - name: ALLOWED_HOSTS
-            value: localhost,127.0.0.1,{{ include "ciso-assistant.fullname" . }}-backend,{{ template "ciso-assistant.url" . }},{{ .Values.global.domain }}
+            value: localhost,127.0.0.1,{{ include "ciso-assistant.fullname" . }}-backend,{{ .Values.global.domain }}{{ if .Values.global.extraAllowedHosts }},{{ .Values.global.extraAllowedHosts }}{{ end }}
           - name: DEFAULT_FROM_EMAIL
             value: {{ .Values.backend.config.smtp.defaultFrom | quote }}
           - name: EMAIL_HOST

--- a/charts/ciso-assistant-next/templates/backend/deployment.yaml
+++ b/charts/ciso-assistant-next/templates/backend/deployment.yaml
@@ -4,18 +4,18 @@ metadata:
   name: {{ template "ciso-assistant.fullname" . }}-backend
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "ciso-assistant.labels" (dict "context" . "name" .Values.backend.name "component" .Values.backend.name) | nindent 4 }}
+    {{- include "ciso-assistant.labels" (dict "context" . "component" "backend") | nindent 4 }}
 spec:
   replicas: {{ .Values.backend.replicas }}
   selector:
     matchLabels:
-      {{- include "ciso-assistant.selectorLabels" (dict "context" . "component" .Values.backend.name) | nindent 6 }}
+      {{- include "ciso-assistant.selectorLabels" (dict "context" . "component" "backend") | nindent 6 }}
   template:
     metadata:
       annotations:
         checksum/secret-backend: {{ include (print $.Template.BasePath "/backend/secret.yaml") . | sha256sum }}
       labels:
-        {{- include "ciso-assistant.labels" (dict "context" . "name" .Values.backend.name "component" .Values.backend.name) | nindent 8 }}
+        {{- include "ciso-assistant.labels" (dict "context" . "component" "backend") | nindent 8 }}
     spec:
       {{- with .Values.backend.imagePullSecrets | default .Values.global.imagePullSecrets }}
       imagePullSecrets:
@@ -36,8 +36,6 @@ spec:
           {{- if and (eq .Values.backend.config.databaseType "sqlite") .Values.backend.persistence.sqlite.enabled }}
           - name: SQLITE_FILE
             value: /ciso/db/ciso-assistant.sqlite3
-          - name: HUEY_FILE_PATH
-            value: /ciso/db/huey.db
           {{- else if eq .Values.backend.config.databaseType "pgsql" }}
           - name: DB_HOST
             value: {{ template "ciso-assistant.fullname" . }}-postgresql
@@ -71,7 +69,12 @@ spec:
           - name: POSTGRES_PASSWORD
             value: {{ .Values.externalPgsql.password | quote }}
           {{- end }}
+          {{- else }}
+          - name: SQLITE_FILE
+            value: /tmp/ciso-assistant.sqlite3
           {{- end }}
+          - name: HUEY_FILE_PATH
+            value: /tmp/huey.db
           {{- if .Values.backend.persistence.localStorage.enabled }}
           - name: LOCAL_STORAGE_DIRECTORY
             value: /ciso/localStorage
@@ -117,31 +120,6 @@ spec:
               secretKeyRef:
                 name: {{ include "ciso-assistant.fullname" . }}-backend
                 key: email-primary-password
-          {{- end }}
-          {{- if .Values.backend.config.smtp.rescue.enabled }}
-          - name: EMAIL_HOST_RESCUE
-            value: {{ .Values.backend.config.smtp.rescue.host | quote }}
-          - name: EMAIL_PORT_RESCUE
-            value: {{ .Values.backend.config.smtp.rescue.port | quote }}
-          - name: EMAIL_USE_TLS_RESCUE
-            value: {{ .Values.backend.config.smtp.rescue.useTls | quote }}
-          {{- if .Values.backend.config.smtp.rescue.username }}
-          - name: EMAIL_HOST_USER_RESCUE
-            value: {{ .Values.backend.config.smtp.rescue.username | quote }}
-          {{- end }}
-          {{- if .Values.backend.config.smtp.existingSecret }}
-          - name: EMAIL_HOST_PASSWORD_RESCUE
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.backend.config.smtp.existingSecret }}
-                key: email-rescue-password
-          {{- else if .Values.backend.config.smtp.rescue.password }}
-          - name: EMAIL_HOST_PASSWORD_RESCUE
-            valueFrom:
-              secretKeyRef:
-                name: {{ include "ciso-assistant.fullname" . }}-backend
-                key: email-rescue-password
-          {{- end }}
           {{- end }}
         volumeMounts:
         - name: tmp-data

--- a/charts/ciso-assistant-next/templates/backend/persistentvolumeclaim.yaml
+++ b/charts/ciso-assistant-next/templates/backend/persistentvolumeclaim.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "ciso-assistant.fullname" . }}-sqlite
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "ciso-assistant.labels" (dict "context" . "name" .Values.backend.name "component" .Values.backend.name) | nindent 4 }}
+    {{- include "ciso-assistant.labels" (dict "context" . "component" "backend") | nindent 4 }}
 spec:
   accessModes: 
     - {{ .Values.backend.persistence.sqlite.accessMode }}
@@ -24,7 +24,7 @@ metadata:
   name: {{ include "ciso-assistant.fullname" . }}-localstorage
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "ciso-assistant.labels" (dict "context" . "name" .Values.backend.name "component" .Values.backend.name) | nindent 4 }}
+    {{- include "ciso-assistant.labels" (dict "context" . "component" "backend") | nindent 4 }}
 spec:
   accessModes: 
     - {{ .Values.backend.persistence.localStorage.accessMode }}

--- a/charts/ciso-assistant-next/templates/backend/secret.yaml
+++ b/charts/ciso-assistant-next/templates/backend/secret.yaml
@@ -1,11 +1,11 @@
-{{- if or (and (not .Values.backend.config.smtp.existingSecret) (or .Values.backend.config.smtp.primary.password (and .Values.backend.config.smtp.rescue.enabled .Values.backend.config.smtp.rescue.password))) (and (not .Values.backend.config.djangoExistingSecretKey) .Values.backend.config.djangoSecretKey) }}
+{{- if or (and (not .Values.backend.config.smtp.existingSecret) .Values.backend.config.smtp.primary.password) (and (not .Values.backend.config.djangoExistingSecretKey) .Values.backend.config.djangoSecretKey) }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "ciso-assistant.fullname" . }}-backend
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "ciso-assistant.labels" (dict "context" . "name" .Values.backend.name "component" .Values.backend.name) | nindent 4 }}
+    {{- include "ciso-assistant.labels" (dict "context" . "component" "backend") | nindent 4 }}
 type: Opaque
 data:
   {{- if and (not .Values.backend.config.djangoExistingSecretKey) .Values.backend.config.djangoSecretKey }}
@@ -13,8 +13,5 @@ data:
   {{- end }}
   {{- if and (not .Values.backend.config.smtp.existingSecret) .Values.backend.config.smtp.primary.password }}
   email-primary-password: {{ .Values.backend.config.smtp.primary.password | b64enc | quote}}
-  {{- end }}
-  {{- if and (not .Values.backend.config.smtp.existingSecret) .Values.backend.config.smtp.rescue.enabled .Values.backend.config.smtp.rescue.password }}
-  email-rescue-password: {{ .Values.backend.config.smtp.rescue.password | b64enc | quote}}
   {{- end }}
 {{- end }}

--- a/charts/ciso-assistant-next/templates/backend/service.yaml
+++ b/charts/ciso-assistant-next/templates/backend/service.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "ciso-assistant.labels" (dict "context" . "name" .Values.backend.name "component" .Values.backend.name) | nindent 4 }}
+    {{- include "ciso-assistant.labels" (dict "context" . "component" "backend") | nindent 4 }}
 spec:
   ports:
   - name: {{ .Values.backend.service.portName }}
@@ -16,4 +16,4 @@ spec:
     port: {{ .Values.backend.service.port }}
     targetPort: http
   selector:
-    {{- include "ciso-assistant.selectorLabels" (dict "context" . "component" .Values.backend.name) | nindent 4 }}
+    {{- include "ciso-assistant.selectorLabels" (dict "context" . "component" "backend") | nindent 4 }}

--- a/charts/ciso-assistant-next/templates/frontend/deployment.yaml
+++ b/charts/ciso-assistant-next/templates/frontend/deployment.yaml
@@ -4,16 +4,16 @@ metadata:
   name: {{ template "ciso-assistant.fullname" . }}-frontend
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "ciso-assistant.labels" (dict "context" . "name" .Values.frontend.name "component" .Values.frontend.name) | nindent 4 }}
+    {{- include "ciso-assistant.labels" (dict "context" . "component" "frontend") | nindent 4 }}
 spec:
   replicas: {{ .Values.frontend.replicas }}
   selector:
     matchLabels:
-      {{- include "ciso-assistant.selectorLabels" (dict "context" . "component" .Values.frontend.name) | nindent 6 }}
+      {{- include "ciso-assistant.selectorLabels" (dict "context" . "component" "frontend") | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "ciso-assistant.labels" (dict "context" . "name" .Values.frontend.name "component" .Values.frontend.name) | nindent 8 }}
+        {{- include "ciso-assistant.labels" (dict "context" . "component" "frontend") | nindent 8 }}
     spec:
       {{- with .Values.frontend.imagePullSecrets | default .Values.global.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/ciso-assistant-next/templates/frontend/service.yaml
+++ b/charts/ciso-assistant-next/templates/frontend/service.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "ciso-assistant.labels" (dict "context" . "name" .Values.frontend.name "component" .Values.frontend.name) | nindent 4 }}
+    {{- include "ciso-assistant.labels" (dict "context" . "component" "frontend") | nindent 4 }}
 spec:
   ports:
   - name: {{ .Values.frontend.service.portName }}
@@ -16,4 +16,4 @@ spec:
     port: {{ .Values.frontend.service.port }}
     targetPort: http
   selector:
-    {{- include "ciso-assistant.selectorLabels" (dict "context" . "component" .Values.frontend.name) | nindent 4 }}
+    {{- include "ciso-assistant.selectorLabels" (dict "context" . "component" "frontend") | nindent 4 }}

--- a/charts/ciso-assistant-next/templates/huey/deployment.yaml
+++ b/charts/ciso-assistant-next/templates/huey/deployment.yaml
@@ -56,7 +56,7 @@ spec:
           - name: CISO_ASSISTANT_URL
             value: {{ template "ciso-assistant.url" . }}
           - name: ALLOWED_HOSTS
-            value: localhost,127.0.0.1,{{ include "ciso-assistant.fullname" . }}-backend,{{ template "ciso-assistant.url" . }},{{ .Values.global.domain }}
+            value: localhost,127.0.0.1,{{ include "ciso-assistant.fullname" . }}-backend,{{ .Values.global.domain }}{{ if .Values.global.extraAllowedHosts }},{{ .Values.global.extraAllowedHosts }}{{ end }}
           - name: DEFAULT_FROM_EMAIL
             value: {{ .Values.backend.config.smtp.defaultFrom | quote }}
           - name: EMAIL_HOST

--- a/charts/ciso-assistant-next/templates/huey/deployment.yaml
+++ b/charts/ciso-assistant-next/templates/huey/deployment.yaml
@@ -1,0 +1,120 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "ciso-assistant.fullname" . }}-huey
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ciso-assistant.labels" (dict "context" . "component" "huey") | nindent 4 }}
+spec:
+  replicas: {{ .Values.huey.replicas }}
+  selector:
+    matchLabels:
+      {{- include "ciso-assistant.selectorLabels" (dict "context" . "component" "huey") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "ciso-assistant.labels" (dict "context" . "component" "huey") | nindent 8 }}
+    spec:
+      {{- with .Values.huey.imagePullSecrets | default .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.global.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: {{ .Values.huey.name }}
+        image: {{ default .Values.global.image.registry .Values.huey.image.registry }}/{{ .Values.huey.image.repository }}:{{ default (include "ciso-assistant.defaultTag" .) .Values.huey.image.tag }}
+        imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.huey.image.imagePullPolicy }}
+        command: ["/bin/sh"]
+        args: ["-c", "poetry run python manage.py run_huey -w 2 --scheduler-interval 60"]
+        env:
+          {{- with .Values.huey.env }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- if .Values.huey.persistence.sqlite.enabled }}
+          - name: HUEY_FILE_PATH
+            value: /data/huey/huey.db
+          {{- else }}
+          - name: HUEY_FILE_PATH
+            value: /tmp/huey.db
+          {{- end }}
+          - name: DJANGO_DEBUG
+            value: {{ ternary "True" "False" .Values.backend.config.djangoDebug | quote }}
+          - name: DJANGO_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                {{- if .Values.backend.config.djangoExistingSecretKey }}
+                name: {{ .Values.backend.config.djangoExistingSecretKey }}
+                {{- else }}
+                name: {{ include "ciso-assistant.fullname" . }}-backend
+                {{- end }}
+                key: django-secret-key
+          - name: CISO_ASSISTANT_SUPERUSER_EMAIL
+            value: {{ .Values.backend.config.emailAdmin }}
+          - name: CISO_ASSISTANT_URL
+            value: {{ template "ciso-assistant.url" . }}
+          - name: ALLOWED_HOSTS
+            value: localhost,127.0.0.1,{{ include "ciso-assistant.fullname" . }}-backend,{{ template "ciso-assistant.url" . }},{{ .Values.global.domain }}
+          - name: DEFAULT_FROM_EMAIL
+            value: {{ .Values.backend.config.smtp.defaultFrom | quote }}
+          - name: EMAIL_HOST
+            value: {{ .Values.backend.config.smtp.primary.host | quote }}
+          - name: EMAIL_PORT
+            value: {{ .Values.backend.config.smtp.primary.port | quote }}
+          - name: EMAIL_USE_TLS
+            value: {{ .Values.backend.config.smtp.primary.useTls | quote }}
+          {{- if .Values.backend.config.smtp.primary.username }}
+          - name: EMAIL_HOST_USER
+            value: {{ .Values.backend.config.smtp.primary.username | quote }}
+          {{- end }}
+          {{- if .Values.backend.config.smtp.existingSecret }}
+          - name: EMAIL_HOST_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.backend.config.smtp.existingSecret }}
+                key: email-primary-password
+          {{- else if .Values.backend.config.smtp.primary.password }}
+          - name: EMAIL_HOST_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "ciso-assistant.fullname" . }}-backend
+                key: email-primary-password
+          {{- end }}
+        volumeMounts:
+        - name: tmp-data
+          mountPath: /tmp
+        {{- if .Values.huey.persistence.sqlite.enabled }}
+        - name: huey-data
+          mountPath: /data/huey
+        {{- end }}
+        ports:
+        - name: http
+          containerPort: 8000
+          protocol: TCP
+        {{- if .Values.huey.resources }}
+        resources:
+          {{ toYaml .Values.huey.resources | indent 10 }}
+        {{- end }}
+        {{- with .Values.huey.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with .Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.global.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: tmp-data
+        emptyDir:
+          sizeLimit: 256Mi
+      {{- if .Values.huey.persistence.sqlite.enabled }}
+      - name: huey-data
+        persistentVolumeClaim:
+          claimName: {{ include "ciso-assistant.fullname" . }}-sqlite
+      {{- end }}

--- a/charts/ciso-assistant-next/templates/huey/persistentvolumeclaim.yaml
+++ b/charts/ciso-assistant-next/templates/huey/persistentvolumeclaim.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.huey.persistence.sqlite.enabled }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "ciso-assistant.fullname" . }}-huey-sqlite
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ciso-assistant.labels" (dict "context" . "component" "huey") | nindent 4 }}
+spec:
+  accessModes: 
+    - {{ .Values.huey.persistence.sqlite.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.huey.persistence.sqlite.size }}
+  {{- if .Values.huey.persistence.sqlite.storageClass }}
+  storageClassName: {{ .Values.huey.persistence.sqlite.storageClass }}
+  {{- end }}
+{{- end }}

--- a/charts/ciso-assistant-next/templates/huey/service.yaml
+++ b/charts/ciso-assistant-next/templates/huey/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ciso-assistant.fullname" . }}-huey
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.huey.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "ciso-assistant.labels" (dict "context" . "component" "huey") | nindent 4 }}
+spec:
+  ports:
+  - name: {{ .Values.huey.service.portName }}
+    protocol: TCP
+    port: {{ .Values.huey.service.port }}
+    targetPort: http
+  selector:
+    {{- include "ciso-assistant.selectorLabels" (dict "context" . "component" "huey") | nindent 4 }}

--- a/charts/ciso-assistant-next/templates/ingress/ingress.yaml
+++ b/charts/ciso-assistant-next/templates/ingress/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "ciso-assistant.labels" (dict "context" . "component" .Values.frontend.name) | nindent 4 }}
+    {{- include "ciso-assistant.labels" (dict "context" .) | nindent 4 }}
 spec:
   {{- with .Values.ingress.ingressClassName }}
   ingressClassName: {{ . }}

--- a/charts/ciso-assistant-next/templates/ingress/tls-secret.yaml
+++ b/charts/ciso-assistant-next/templates/ingress/tls-secret.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: {{ include "ciso-assistant.fullname" . }}-tls
   labels:
-    {{- include "ciso-assistant.labels" (dict "context" . "component" .Values.frontend.name) | nindent 4 }}
+    {{- include "ciso-assistant.labels" (dict "context" . "component" "frontend") | nindent 4 }}
 type: kubernetes.io/tls
 data:
   tls.crt: {{ .Values.ingress.certificateSecret.certificate | b64enc }}

--- a/charts/ciso-assistant-next/values.yaml
+++ b/charts/ciso-assistant-next/values.yaml
@@ -15,6 +15,9 @@ global:
   # -- Globally enable TLS (Ingress, URLs, etc.)
   tls: false
 
+  # -- Extra allowed hosts (comma separated, without spaces)
+  extraAllowedHosts: ""
+
   # Default image used by all components
   image:
     # -- If defined, a registry applied to all CISO Assistant deployments

--- a/charts/ciso-assistant-next/values.yaml
+++ b/charts/ciso-assistant-next/values.yaml
@@ -65,7 +65,6 @@ backend:
       # -- Default from email address
       defaultFrom: no-reply@ciso-assistant.net
       # -- Name of an existing secret resource containing the primary SMTP password in a 'email-primary-password' key
-      # -- and the rescue SMTP username in a 'email-rescue-username' key
       existingSecret: ""
       primary:
         # -- Primary SMTP hostname
@@ -78,19 +77,6 @@ backend:
         username: apikey
         # -- Primary SMTP password
         password: "primary_password_here"
-      rescue:
-        # -- Rescue SMTP hostname
-        enabled: true
-        # -- Rescue SMTP hostname
-        host: smtp.secondary.mailer.cloud
-        # -- Rescue SMTP hostname
-        port: 587
-        # -- Enable TLS for rescue SMTP
-        useTls: true
-        # -- Rescue SMTP hostname
-        username: username
-        # -- Rescue SMTP hostname
-        password: "rescue_password_here"
 
     # -- Set the database type (sqlite, pgsql or externalPgsql)
     ## Note : PostgreSQL database configuration at `postgresql` or `externalPgsql` section
@@ -104,11 +90,11 @@ backend:
     # -- Enable Django debug mode
     djangoDebug: false
 
-  ## Backend persistence configuration (used for sqlitedb and local storage)
+  ## Backend persistence configuration (used for sqlite db and local storage)
   persistence:
     sqlite:
       # -- Enable SQLite persistence
-      # Note: only when `backend.config.databaseType` use `sqlite` value
+      ## Note: only when `backend.config.databaseType` use `sqlite` value
       enabled: true
       # -- SQLite persistant volume size
       size: 5Gi
@@ -180,6 +166,83 @@ backend:
     # -- Backend service http port
     port: 80
     # -- Backend service port name
+    portName: http
+
+## CISO Assistant Huey
+## Note : Huey will use config from backend
+huey:
+  # -- Huey name
+  name: huey
+
+  # -- The number of frontend pods to run
+  replicas: 1
+
+  ## Backend persistence configuration (used for sqlite db and local storage)
+  persistence:
+    sqlite:
+      # -- Enable SQLite persistence (for Huey)
+      enabled: true
+      # -- SQLite persistant volume size
+      size: 1Gi
+      # -- SQLite persistant volume storageClass
+      storageClass: ""
+      # -- SQLite persistant volume accessMode
+      accessMode: ReadWriteOnce
+
+  ## Huey image
+  image:
+    # -- Registry to use for the Huey
+    # @default -- `""` (defaults to global.image.registry)
+    registry: ""
+    # -- Repository to use for the Huey
+    repository: intuitem/ciso-assistant-community/backend
+    # -- Tag to use for the Huey
+    # @default -- `""` (defaults to global.image.tag)
+    tag: ""
+    # -- Image pull policy for the Huey
+    # @default -- `""` (defaults to global.image.imagePullPolicy)
+    imagePullPolicy: ""
+
+  # -- Secrets with credentials to pull images from a private registry
+  # @default -- `[]` (defaults to global.imagePullSecrets)
+  imagePullSecrets: []
+
+  # -- Resources for the Huey
+  resources: {}
+    #   requests:
+    #     cpu: 100m
+    #     memory: 512Mi
+    #   limits:
+    #     cpu: 256m
+    #     memory: 1024Mi
+
+  # -- Environment variables to pass to Huey
+  env: []
+
+  # -- Toggle and define container-level security context
+  # @default -- `{}`
+  containerSecurityContext: {}
+  #  seLinuxOptions: {}
+  #  runAsUser: 1001
+  #  runAsGroup: 1001
+  #  runAsNonRoot: true
+  #  privileged: false
+  #  readOnlyRootFilesystem: true
+  #  allowPrivilegeEscalation: false
+  #  capabilities:
+  #    drop: ["ALL"]
+  #  seccompProfile:
+  #    type: "RuntimeDefault"
+
+  ## Huey service configuration
+  service:
+    # -- Huey service annotations
+    annotations: {}
+    # -- Huey service labels
+    labels: {}
+    # -- Huey service http port
+    port: 80
+    # -- Huey service port name
     portName: http
 
 

--- a/charts/ciso-assistant-next/values.yaml
+++ b/charts/ciso-assistant-next/values.yaml
@@ -177,7 +177,7 @@ huey:
   # -- Huey name
   name: huey
 
-  # -- The number of frontend pods to run
+  # -- The number of Huey pods to run
   replicas: 1
 
   ## Backend persistence configuration (used for sqlite db and local storage)


### PR DESCRIPTION
Add Huey pod !

If persistance is disabled for Huey, it will use /tmp/ folder, same for backend if databaseType is sqlite but persistance is disabled.

Added HUEY_FILE_PATH to /tmp/huey.db as a workaround, because backend code run some huey database code at startup, even though backend not using Huey db.

Other changes : 
- Also, SMTP rescue config is removed, I don't think it was really needed in production.
- Some helm cleanups to remove useless things (on labels).
- Add extraAllowedHosts (resolves #1667)


Resolves #1653 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated configuration guidance for primary SMTP secrets and clarified settings.
  - Removed outdated rescue SMTP documentation.
  - Added new configuration section for the Huey component, detailing its settings and options.

- **New Features**
  - Introduced a new background processing component (Huey) with dedicated deployment, storage, and service options.

- **Refactor**
  - Standardized labels and streamlined environment variable settings across services for enhanced consistency.
  - Simplified label generation by removing dynamic references to component names in several configurations.
  - Restructured SMTP configuration by removing rescue settings and clarifying existing secret references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->