### PR TITLE
fix: missed ETA counter doesn't exclude active controls

### DIFF
--- a/backend/core/helpers.py
+++ b/backend/core/helpers.py
@@ -900,9 +900,13 @@ def get_metrics(user: User):
     progress_avg = math.ceil(
         mean([x.progress() for x in viewable_items(ComplianceAssessment)] or [0])
     )
-    missed_eta_count = viewable_controls.filter(
-        eta__lt=date.today(),
-    ).count()
+    missed_eta_count = (
+        viewable_controls.filter(
+            eta__lt=date.today(),
+        )
+        .exclude(status="active")
+        .count()
+    )
 
     data = {
         "controls": {

--- a/frontend/src/routes/(app)/(internal)/analytics/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/analytics/+page.svelte
@@ -168,7 +168,9 @@
 						<Card
 							count={metrics.controls.eta_missed}
 							label={m.sumpageEtaMissed()}
-							href="/applied-controls/?eta__lte={new Date().toISOString().split('T')[0]}"
+							href="/applied-controls/?status=to_do&status=deprecated&status=in_progress&status=--&status=on_hold&eta__lte={new Date()
+								.toISOString()
+								.split('T')[0]}"
 							icon="fa-solid fa-shield-halved"
 							section={m.sumpageSectionControls()}
 							emphasis={true}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Refined the overdue items count to exclude currently active entries for more accurate analytics.

- **New Features**
  - Expanded filtering options on the analytics dashboard to include a broader range of statuses, offering a more comprehensive view of applied items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->