### PR TITLE
build: disable automatic arm runner dummy build

### DIFF
--- a/.github/workflows/docker-build-and-push-dummy.yml
+++ b/.github/workflows/docker-build-and-push-dummy.yml
@@ -1,8 +1,5 @@
 name: Build and Push Docker Images Dummy
 on:
-  push:
-    tags:
-      - "v*"
   workflow_dispatch:
 env:
   UBUNTU_VERSION: "ubuntu-24.04"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the deployment automation triggers so that image build and push processes now require manual initiation rather than being automatically triggered on version tag events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->