### PR TITLE
doc: update node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ For docker setup on a remote server or hypervisor, checkout the [specific instru
 - Python 3.11+
 - pip 20.3+
 - poetry 2.0+
-- node 18+
+- node 21+
 - npm 10.2+
 - pnpm 9.0+
 - yaml-cpp (brew install yaml-cpp libyaml or apt install libyaml-cpp-dev)


### PR DESCRIPTION
Updated node from 18+ to 21+ in requirements since `@lix-js/sdk@0.4.1(babel-plugin-macros@3.1.0)` requires node >= 21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the project’s Node.js requirement from version 18+ to 21+ to ensure compatibility with the latest standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->