### PR TITLE
feat: allow importing existing PV claim

### DIFF
--- a/charts/ciso-assistant-next/Chart.yaml
+++ b/charts/ciso-assistant-next/Chart.yaml
@@ -3,7 +3,7 @@ name: ciso-assistant
 description: A Helm chart for CISO Assistant k8s's deployment
 type: application
 version: 0.3.4
-appVersion: "v2.2.8"
+appVersion: "v2.2.12"
 icon: https://intuitem.com/ciso-assistant.svg
 home: https://intuitem.com
 sources:

--- a/charts/ciso-assistant-next/README.md
+++ b/charts/ciso-assistant-next/README.md
@@ -1,6 +1,6 @@
 # ciso-assistant
 
-![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.2.8](https://img.shields.io/badge/AppVersion-v2.2.8-informational?style=flat-square)
+![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.2.12](https://img.shields.io/badge/AppVersion-v2.2.12-informational?style=flat-square)
 
 A Helm chart for CISO Assistant k8s's deployment
 
@@ -60,11 +60,12 @@ helm install ciso-assistant-release oci://ghcr.io/intuitem/helm-charts/ce/ciso-a
 | backend.name | string | `"backend"` | Backend container name |
 | backend.persistence.localStorage.accessMode | string | `"ReadWriteOnce"` | Local Storage persistant volume accessMode |
 | backend.persistence.localStorage.enabled | bool | `true` | Enable Local Storage persistence |
+| backend.persistence.localStorage.existingClaim | string | `""` | Name of an existing PersistentVolumeClaim for local storage. Must be different from sqlite PVC |
 | backend.persistence.localStorage.size | string | `"5Gi"` | Local Storage persistant volume size |
 | backend.persistence.localStorage.storageClass | string | `""` | Local Storage persistant volume storageClass |
-| backend.persistence.localStorage.existingClaim | string | `""` | Use existing pvc |
 | backend.persistence.sqlite.accessMode | string | `"ReadWriteOnce"` | SQLite persistant volume accessMode |
 | backend.persistence.sqlite.enabled | bool | `true` | Enable SQLite persistence (for backend and/or Huey) # Note: Needed for Huey, also when `backend.config.databaseType` is not set to `sqlite` |
+| backend.persistence.sqlite.existingClaim | string | `""` | Name of an existing PersistentVolumeClaim for sqlite |
 | backend.persistence.sqlite.size | string | `"5Gi"` | SQLite persistant volume size |
 | backend.persistence.sqlite.storageClass | string | `""` | SQLite persistant volume storageClass |
 | backend.replicas | int | `1` | The number of backend pods to run |

--- a/charts/ciso-assistant-next/README.md
+++ b/charts/ciso-assistant-next/README.md
@@ -62,6 +62,7 @@ helm install ciso-assistant-release oci://ghcr.io/intuitem/helm-charts/ce/ciso-a
 | backend.persistence.localStorage.enabled | bool | `true` | Enable Local Storage persistence |
 | backend.persistence.localStorage.size | string | `"5Gi"` | Local Storage persistant volume size |
 | backend.persistence.localStorage.storageClass | string | `""` | Local Storage persistant volume storageClass |
+| backend.persistence.localStorage.existingClaim | string | `""` | Use existing pvc |
 | backend.persistence.sqlite.accessMode | string | `"ReadWriteOnce"` | SQLite persistant volume accessMode |
 | backend.persistence.sqlite.enabled | bool | `true` | Enable SQLite persistence (for backend and/or Huey) # Note: Needed for Huey, also when `backend.config.databaseType` is not set to `sqlite` |
 | backend.persistence.sqlite.size | string | `"5Gi"` | SQLite persistant volume size |

--- a/charts/ciso-assistant-next/templates/backend/deployment.yaml
+++ b/charts/ciso-assistant-next/templates/backend/deployment.yaml
@@ -125,8 +125,13 @@ spec:
         - name: tmp-data
           mountPath: /tmp
         {{- if and (eq .Values.backend.config.databaseType "sqlite") .Values.backend.persistence.sqlite.enabled }}
+        {{- if not .Values.backend.persistence.existingClaim }}
         - name: sqlite-data
           mountPath: /ciso/db
+        {{- else }}
+        - name: localstorage-data
+          mountPath: /ciso/db
+        {{- end }}
         {{- end }}
         {{- if .Values.backend.persistence.localStorage.enabled }}
         - name: localstorage-data
@@ -249,8 +254,13 @@ spec:
         - name: tmp-data
           mountPath: /tmp
         {{- if .Values.backend.persistence.sqlite.enabled }}
+        {{- if not .Values.backend.persistence.existingClaim }}
         - name: sqlite-data
           mountPath: /ciso/db
+        {{- else }}
+        - name: localstorage-data
+          mountPath: /ciso/db
+        {{- end }}
         {{- end }}
         {{- if .Values.backend.huey.resources }}
         resources:
@@ -272,7 +282,7 @@ spec:
       - name: tmp-data
         emptyDir:
           sizeLimit: 256Mi
-      {{- if .Values.backend.persistence.sqlite.enabled }}
+      {{- if and .Values.backend.persistence.sqlite.enabled (not .Values.backend.persistence.existingClaim) }}
       - name: sqlite-data
         persistentVolumeClaim:
           claimName: {{ include "ciso-assistant.fullname" . }}-sqlite
@@ -280,7 +290,7 @@ spec:
       {{- if .Values.backend.persistence.localStorage.enabled }}
       - name: localstorage-data
         persistentVolumeClaim:
-          {{- if eq .Values.backend.persistence.existingClaim "" }}
+          {{- if not .Values.backend.persistence.existingClaim }}
             claimName: {{ include "ciso-assistant.fullname" . }}-localstorage
           {{- else }}
             claimName: {{ .Values.backend.persistence.existingClaim }}

--- a/charts/ciso-assistant-next/templates/backend/deployment.yaml
+++ b/charts/ciso-assistant-next/templates/backend/deployment.yaml
@@ -275,11 +275,7 @@ spec:
       {{- if .Values.backend.persistence.sqlite.enabled }}
       - name: sqlite-data
         persistentVolumeClaim:
-          {{- if eq .Values.backend.persistence.existingClaim "" }}
-            claimName: {{ include "ciso-assistant.fullname" . }}-sqlite
-          {{- else }}
-            claimName: {{ .Values.backend.persistence.existingClaim }}
-          {{- end }}
+          claimName: {{ include "ciso-assistant.fullname" . }}-sqlite
       {{- end }}
       {{- if .Values.backend.persistence.localStorage.enabled }}
       - name: localstorage-data

--- a/charts/ciso-assistant-next/templates/backend/deployment.yaml
+++ b/charts/ciso-assistant-next/templates/backend/deployment.yaml
@@ -272,21 +272,21 @@ spec:
       - name: tmp-data
         emptyDir:
           sizeLimit: 256Mi
-      {{- if and .Values.backend.persistence.sqlite.enabled }}
+      {{- if .Values.backend.persistence.sqlite.enabled }}
       - name: sqlite-data
         persistentVolumeClaim:
-          {{- if not .Values.backend.persistence.sqlite.existingClaim }}
-          claimName: {{ include "ciso-assistant.fullname" . }}-sqlite
-          {{- else }}
+          {{- if .Values.backend.persistence.sqlite.existingClaim }}
           claimName: {{ .Values.backend.persistence.sqlite.existingClaim }}
+          {{- else }}
+          claimName: {{ include "ciso-assistant.fullname" . }}-sqlite
           {{- end }}
       {{- end }}
       {{- if .Values.backend.persistence.localStorage.enabled }}
       - name: localstorage-data
         persistentVolumeClaim:
-          {{- if not .Values.backend.persistence.localStorage.existingClaim }}
-          claimName: {{ include "ciso-assistant.fullname" . }}-localstorage
-          {{- else }}
+          {{- if .Values.backend.persistence.localStorage.existingClaim }}
           claimName: {{ .Values.backend.persistence.localStorage.existingClaim }}
+          {{- else }}
+          claimName: {{ include "ciso-assistant.fullname" . }}-localstorage
           {{- end }}
       {{- end }}

--- a/charts/ciso-assistant-next/templates/backend/deployment.yaml
+++ b/charts/ciso-assistant-next/templates/backend/deployment.yaml
@@ -125,13 +125,8 @@ spec:
         - name: tmp-data
           mountPath: /tmp
         {{- if and (eq .Values.backend.config.databaseType "sqlite") .Values.backend.persistence.sqlite.enabled }}
-        {{- if not .Values.backend.persistence.existingClaim }}
         - name: sqlite-data
           mountPath: /ciso/db
-        {{- else }}
-        - name: localstorage-data
-          mountPath: /ciso/db
-        {{- end }}
         {{- end }}
         {{- if .Values.backend.persistence.localStorage.enabled }}
         - name: localstorage-data
@@ -254,13 +249,8 @@ spec:
         - name: tmp-data
           mountPath: /tmp
         {{- if .Values.backend.persistence.sqlite.enabled }}
-        {{- if not .Values.backend.persistence.existingClaim }}
         - name: sqlite-data
           mountPath: /ciso/db
-        {{- else }}
-        - name: localstorage-data
-          mountPath: /ciso/db
-        {{- end }}
         {{- end }}
         {{- if .Values.backend.huey.resources }}
         resources:
@@ -282,17 +272,21 @@ spec:
       - name: tmp-data
         emptyDir:
           sizeLimit: 256Mi
-      {{- if and .Values.backend.persistence.sqlite.enabled (not .Values.backend.persistence.existingClaim) }}
+      {{- if and .Values.backend.persistence.sqlite.enabled }}
       - name: sqlite-data
         persistentVolumeClaim:
+          {{- if not .Values.backend.persistence.sqlite.existingClaim }}
           claimName: {{ include "ciso-assistant.fullname" . }}-sqlite
+          {{- else }}
+          claimName: {{ .Values.backend.persistence.sqlite.existingClaim }}
+          {{- end }}
       {{- end }}
       {{- if .Values.backend.persistence.localStorage.enabled }}
       - name: localstorage-data
         persistentVolumeClaim:
-          {{- if not .Values.backend.persistence.existingClaim }}
-            claimName: {{ include "ciso-assistant.fullname" . }}-localstorage
+          {{- if not .Values.backend.persistence.localStorage.existingClaim }}
+          claimName: {{ include "ciso-assistant.fullname" . }}-localstorage
           {{- else }}
-            claimName: {{ .Values.backend.persistence.existingClaim }}
+          claimName: {{ .Values.backend.persistence.localStorage.existingClaim }}
           {{- end }}
       {{- end }}

--- a/charts/ciso-assistant-next/templates/backend/deployment.yaml
+++ b/charts/ciso-assistant-next/templates/backend/deployment.yaml
@@ -275,10 +275,18 @@ spec:
       {{- if .Values.backend.persistence.sqlite.enabled }}
       - name: sqlite-data
         persistentVolumeClaim:
-          claimName: {{ include "ciso-assistant.fullname" . }}-sqlite
+          {{- if eq .Values.backend.persistence.existingClaim "" }}
+            claimName: {{ include "ciso-assistant.fullname" . }}-sqlite
+          {{- else }}
+            claimName: {{ .Values.backend.persistence.existingClaim }}
+          {{- end }}
       {{- end }}
       {{- if .Values.backend.persistence.localStorage.enabled }}
       - name: localstorage-data
         persistentVolumeClaim:
-          claimName: {{ include "ciso-assistant.fullname" . }}-localstorage
+          {{- if eq .Values.backend.persistence.existingClaim "" }}
+            claimName: {{ include "ciso-assistant.fullname" . }}-localstorage
+          {{- else }}
+            claimName: {{ .Values.backend.persistence.existingClaim }}
+          {{- end }}
       {{- end }}

--- a/charts/ciso-assistant-next/templates/backend/persistentvolumeclaim.yaml
+++ b/charts/ciso-assistant-next/templates/backend/persistentvolumeclaim.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.backend.persistence.sqlite.enabled (not .Values.backend.persistence.existingClaim) }}
+{{- if and .Values.backend.persistence.sqlite.enabled (not .Values.backend.persistence.sqlite.existingClaim) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -17,7 +17,7 @@ spec:
   {{- end }}
 {{- end }}
 ---
-{{- if and .Values.backend.persistence.localStorage.enabled (not .Values.backend.persistence.existingClaim) }}
+{{- if and .Values.backend.persistence.localStorage.enabled (not .Values.backend.persistence.localStorage.existingClaim) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/charts/ciso-assistant-next/templates/backend/persistentvolumeclaim.yaml
+++ b/charts/ciso-assistant-next/templates/backend/persistentvolumeclaim.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.backend.persistence.sqlite.enabled }}
+{{- and if .Values.backend.persistence.sqlite.enabled (eq .Values.backend.persistence.existingClaim "") }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -17,7 +17,7 @@ spec:
   {{- end }}
 {{- end }}
 ---
-{{- if .Values.backend.persistence.localStorage.enabled }}
+{{- and if .Values.backend.persistence.localStorage.enabled (eq .Values.backend.persistence.existingClaim "") }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/charts/ciso-assistant-next/templates/backend/persistentvolumeclaim.yaml
+++ b/charts/ciso-assistant-next/templates/backend/persistentvolumeclaim.yaml
@@ -1,4 +1,4 @@
-{{- and if .Values.backend.persistence.sqlite.enabled (eq .Values.backend.persistence.existingClaim "") }}
+{{- if and .Values.backend.persistence.sqlite.enabled (eq .Values.backend.persistence.existingClaim "") }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -17,7 +17,7 @@ spec:
   {{- end }}
 {{- end }}
 ---
-{{- and if .Values.backend.persistence.localStorage.enabled (eq .Values.backend.persistence.existingClaim "") }}
+{{- if and .Values.backend.persistence.localStorage.enabled (eq .Values.backend.persistence.existingClaim "") }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/charts/ciso-assistant-next/templates/backend/persistentvolumeclaim.yaml
+++ b/charts/ciso-assistant-next/templates/backend/persistentvolumeclaim.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.backend.persistence.sqlite.enabled (eq .Values.backend.persistence.existingClaim "") }}
+{{- if .Values.backend.persistence.sqlite.enabled }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/charts/ciso-assistant-next/templates/backend/persistentvolumeclaim.yaml
+++ b/charts/ciso-assistant-next/templates/backend/persistentvolumeclaim.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.backend.persistence.sqlite.enabled }}
+{{- if and .Values.backend.persistence.sqlite.enabled (not .Values.backend.persistence.existingClaim) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -17,7 +17,7 @@ spec:
   {{- end }}
 {{- end }}
 ---
-{{- if and .Values.backend.persistence.localStorage.enabled (eq .Values.backend.persistence.existingClaim "") }}
+{{- if and .Values.backend.persistence.localStorage.enabled (not .Values.backend.persistence.existingClaim) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/charts/ciso-assistant-next/values.yaml
+++ b/charts/ciso-assistant-next/values.yaml
@@ -112,6 +112,7 @@ backend:
 
   ## Backend persistence configuration (used for sqlite DBs and local storage)
   persistence:
+    existingClaim: ""
     sqlite:
       # -- Enable SQLite persistence (for backend and/or Huey)
       ## Note: Needed for Huey, also when `backend.config.databaseType` is not set to `sqlite`

--- a/charts/ciso-assistant-next/values.yaml
+++ b/charts/ciso-assistant-next/values.yaml
@@ -112,7 +112,6 @@ backend:
 
   ## Backend persistence configuration (used for sqlite DBs and local storage)
   persistence:
-    existingClaim: ""
     sqlite:
       # -- Enable SQLite persistence (for backend and/or Huey)
       ## Note: Needed for Huey, also when `backend.config.databaseType` is not set to `sqlite`
@@ -132,6 +131,8 @@ backend:
       storageClass: ""
       # -- Local Storage persistant volume accessMode
       accessMode: ReadWriteOnce
+      # -- Name of an existing PersistentVolumeClaim
+      existingClaim: ""
 
   ## Backend image
   image:

--- a/charts/ciso-assistant-next/values.yaml
+++ b/charts/ciso-assistant-next/values.yaml
@@ -131,8 +131,8 @@ backend:
       storageClass: ""
       # -- Local Storage persistant volume accessMode
       accessMode: ReadWriteOnce
-      # -- Name of an existing PersistentVolumeClaim
-      existingClaim: ""
+    # -- Name of an existing PersistentVolumeClaim for both sqlite and local storage
+    existingClaim: ""
 
   ## Backend image
   image:

--- a/charts/ciso-assistant-next/values.yaml
+++ b/charts/ciso-assistant-next/values.yaml
@@ -122,6 +122,8 @@ backend:
       storageClass: ""
       # -- SQLite persistant volume accessMode
       accessMode: ReadWriteOnce
+      # -- Name of an existing PersistentVolumeClaim for sqlite
+      existingClaim: ""
     localStorage:
       # -- Enable Local Storage persistence
       enabled: true
@@ -131,8 +133,8 @@ backend:
       storageClass: ""
       # -- Local Storage persistant volume accessMode
       accessMode: ReadWriteOnce
-    # -- Name of an existing PersistentVolumeClaim for both sqlite and local storage
-    existingClaim: ""
+      # -- Name of an existing PersistentVolumeClaim for local storage. Must be different from sqlite PVC
+      existingClaim: ""
 
   ## Backend image
   image:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced configurable options for backend local storage and SQLite persistence that allow users to specify existing persistent volume claims, preventing the creation of new claims during deployment.

- **Documentation**
  - Updated the README to include new configuration options for local storage persistence and SQLite, ensuring users can easily leverage this flexibility in their deployments.

- **Chores**
  - Updated application version to v2.2.12 in the Helm chart.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->