### PR TITLE
fix: add missing entry on EE navbar

### DIFF
--- a/enterprise/frontend/src/lib/components/SideBar/navData.ts
+++ b/enterprise/frontend/src/lib/components/SideBar/navData.ts
@@ -235,6 +235,12 @@ export const navData = {
 					name: 'evidences',
 					fa_icon: 'fa-solid fa-receipt',
 					href: '/evidences'
+				},
+				{
+					name: 'recap',
+					fa_icon: 'fa-solid fa-clipboard-list',
+					href: '/recap',
+					permissions: ['view_complianceassessment']
 				}
 			]
 		},


### PR DESCRIPTION
add missing section for /recap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new “Recap” navigation entry in the compliance section, complete with a clipboard list icon for easy identification and access.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->