### PR TITLE
fix: filter associated findings on Applied control view

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -4890,6 +4890,7 @@ class FindingViewSet(BaseModelViewSet):
         "status",
         "findings_assessment",
         "filtering_labels",
+        "applied_controls",
     ]
 
     @action(detail=False, name="Get status choices")

--- a/frontend/src/lib/utils/crud.ts
+++ b/frontend/src/lib/utils/crud.ts
@@ -274,9 +274,13 @@ export const URL_MODEL_MAP: ModelMap = {
 		],
 		reverseForeignKeyFields: [
 			{ field: 'applied_controls', urlModel: 'evidences' },
-			{ field: 'applied_controls', urlModel: 'requirement-assessments' },
-			{ field: 'applied_controls', urlModel: 'risk-scenarios' },
-			{ field: 'applied_controls', urlModel: 'findings' }
+			{
+				field: 'applied_controls',
+				urlModel: 'requirement-assessments',
+				disableAddDeleteButtons: true
+			},
+			{ field: 'applied_controls', urlModel: 'risk-scenarios', disableAddDeleteButtons: true },
+			{ field: 'applied_controls', urlModel: 'findings', disableAddDeleteButtons: true }
 		],
 		selectFields: [
 			{ field: 'status' },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced filtering capabilities by adding an option to filter findings based on applied controls, allowing for more precise search results without altering existing functionality.
  
- **User Interface Changes**
  - Disabled add and delete buttons for specific reverse foreign key relationships in the applied-controls model, affecting the entries for requirement assessments, risk scenarios, and findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->