### PR TITLE
feat: add [folder]/ in autocompleteselect audit in entity assessement form 

### DIFF
--- a/frontend/src/lib/components/Forms/ModelForm/EntityAssessmentForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/EntityAssessmentForm.svelte
@@ -172,6 +172,7 @@
 <AutocompleteSelect
 	{form}
 	optionsEndpoint="compliance-assessments"
+	optionsExtraFields={[['folder', 'str']]}
 	field="compliance_assessment"
 	cacheLock={cacheLocks['compliance_assessment']}
 	bind:cachedValue={formDataCache['compliance_assessment']}


### PR DESCRIPTION
The audits in the audit autocompleteselect of an entity assessment form did not have any informations about their Domain. 

ex, if TEST is the folder:
Example Audit -> TEST/Example Audit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the autocomplete selection for compliance assessments with additional configurable fields to display more detailed and expressive options.
	- Improved data presentation for a richer interactive experience while maintaining consistent functionality with previous behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->