### PR TITLE
fix: whitespaces detailview elements showing correctly & ellipses for too big descriptions in modeltable.

### DIFF
--- a/frontend/src/lib/components/DetailView/DetailView.svelte
+++ b/frontend/src/lib/components/DetailView/DetailView.svelte
@@ -365,6 +365,8 @@
 												>
 											{:else if ISO_8601_REGEX.test(value) && (key === 'created_at' || key === 'updated_at' || key === 'expiry_date' || key === 'accepted_at' || key === 'rejected_at' || key === 'revoked_at' || key === 'eta' || key === 'expiration_date')}
 												{formatDateOrDateTime(value, getLocale())}
+											{:else if key === 'description'}
+												<p class="whitespace-pre-line">{value}</p>
 											{:else if m[toCamelCase(value.str || value.name)]}
 												{safeTranslate((value.str || value.name) ?? value)}
 											{:else}

--- a/frontend/src/lib/components/DetailView/DetailView.svelte
+++ b/frontend/src/lib/components/DetailView/DetailView.svelte
@@ -259,7 +259,7 @@
 							<dd class="text-gray-700 sm:col-span-2">
 								<ul class="">
 									<li
-										class="list-none"
+										class="list-none whitespace-pre-line"
 										data-testid={!(value instanceof Array)
 											? key.replace('_', '-') + '-field-value'
 											: null}
@@ -365,8 +365,6 @@
 												>
 											{:else if ISO_8601_REGEX.test(value) && (key === 'created_at' || key === 'updated_at' || key === 'expiry_date' || key === 'accepted_at' || key === 'rejected_at' || key === 'revoked_at' || key === 'eta' || key === 'expiration_date')}
 												{formatDateOrDateTime(value, getLocale())}
-											{:else if key === 'description'}
-												<p class="whitespace-pre-line">{value}</p>
 											{:else if m[toCamelCase(value.str || value.name)]}
 												{safeTranslate((value.str || value.name) ?? value)}
 											{:else}

--- a/frontend/src/lib/components/ModelTable/ModelTable.svelte
+++ b/frontend/src/lib/components/ModelTable/ModelTable.svelte
@@ -363,7 +363,7 @@
 											</div>
 										{:else}
 											<!-- NOTE: We will have to handle the ellipses for RTL languages-->
-											{#if value.length > 300}
+											{#if value?.length > 300}
 												{safeTranslate(value ?? '-').slice(0, 300)}...
 											{:else}
 												{safeTranslate(value ?? '-')}

--- a/frontend/src/lib/components/ModelTable/ModelTable.svelte
+++ b/frontend/src/lib/components/ModelTable/ModelTable.svelte
@@ -362,7 +362,12 @@
 												</span>
 											</div>
 										{:else}
-											{safeTranslate(value ?? '-')}
+											<!-- NOTE: We will have to handle the ellipses for RTL languages-->
+											{#if value.length > 300}
+												{safeTranslate(value ?? '-').slice(0, 300)}...
+											{:else}
+												{safeTranslate(value ?? '-')}
+											{/if}
 										{/if}
 									</span>
 								{/if}


### PR DESCRIPTION
Fixed elements white spaces in the detailviews that were not showing properly. (ex: threats detailview)

Added a condition in ModelTable in the case an element have more than 300 chars;  it crop it to add "..." for a more digestive UI (ex: threats modeltable).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Refined list display to preserve line breaks, improving readability.

- **New Features**
  - Introduced automatic truncation for lengthy text in table cells, showing an ellipsis when content exceeds 300 characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->