### PR TITLE
fix: prep_cis.py ignores controls tab in latest CIS Controls xlsx due to exact title match failure

### DIFF
--- a/tools/cis/prep_cis.py
+++ b/tools/cis/prep_cis.py
@@ -31,7 +31,10 @@ for tab in dataframe:
     title = tab.title
     if title == "License for Use":
         library_copyright = tab["B11"].value + "\n" + tab["B13"].value
-    elif title.startswith("Controls V"): """The script ignored the controls sheet because the title wasn't an exact match in the latest version of the CIS Controls .xlsx file. The title currently reads Controls V8.1.2 instead of Controls V8. Initial workaround as pointed out by my colleague Jak, was to rename the sheet to Controls V8. The fix I applied was to use the startswith function to prompt the script to parse the sheet as long as the title start with Controls V. This should accommodate all version changes going forward."""
+    # The script previously ignored the controls sheet because the title wasn't an exact match 
+    # in the latest version of the CIS Controls .xlsx file (e.g., "Controls V8.1.2" instead of "Controls V8").
+    # Using startswith() allows the script to work with all version changes going forward.
+    elif title.startswith("Controls V"):
         for row in tab:
             (control, safeguard, asset_type, sf, title, description, ig1, ig2, ig3) = (
                 r.value for r in row

--- a/tools/cis/prep_cis.py
+++ b/tools/cis/prep_cis.py
@@ -31,7 +31,7 @@ for tab in dataframe:
     title = tab.title
     if title == "License for Use":
         library_copyright = tab["B11"].value + "\n" + tab["B13"].value
-    elif title == "Controls V8":
+    elif title.startswith("Controls V8"): """The script ignored the controls sheet because the title wasn't an exact match in the latest version of the CIS Controls .xlsx file. The title currently reads Controls V8.1.2 instead of Controls V8. Initial workaround as pointed out by my colleague Jak, was to rename the sheet to Controls V8. The fix I applied was to use the startswith function to prompt the script to parse the sheet as long as the title start with Controls V8"""
         for row in tab:
             (control, safeguard, asset_type, sf, title, description, ig1, ig2, ig3) = (
                 r.value for r in row

--- a/tools/cis/prep_cis.py
+++ b/tools/cis/prep_cis.py
@@ -31,7 +31,7 @@ for tab in dataframe:
     title = tab.title
     if title == "License for Use":
         library_copyright = tab["B11"].value + "\n" + tab["B13"].value
-    elif title.startswith("Controls V8"): """The script ignored the controls sheet because the title wasn't an exact match in the latest version of the CIS Controls .xlsx file. The title currently reads Controls V8.1.2 instead of Controls V8. Initial workaround as pointed out by my colleague Jak, was to rename the sheet to Controls V8. The fix I applied was to use the startswith function to prompt the script to parse the sheet as long as the title start with Controls V8"""
+    elif title.startswith("Controls V"): """The script ignored the controls sheet because the title wasn't an exact match in the latest version of the CIS Controls .xlsx file. The title currently reads Controls V8.1.2 instead of Controls V8. Initial workaround as pointed out by my colleague Jak, was to rename the sheet to Controls V8. The fix I applied was to use the startswith function to prompt the script to parse the sheet as long as the title start with Controls V. This should accommodate all version changes going forward."""
         for row in tab:
             (control, safeguard, asset_type, sf, title, description, ig1, ig2, ig3) = (
                 r.value for r in row


### PR DESCRIPTION
The script ignored the controls sheet because the title wasn't an exact match in the latest version of the CIS Controls .xlsx file. The title currently reads "Controls V8.1.2" instead of "Controls V8". The Initial workaround as pointed out by my colleague Jak, was to rename the sheet to Controls V8. The fix I applied was to use the startswith() function to prompt the script to parse the sheet as long as the title starts with "Controls V". This should accommodate future version changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the processing of Excel workbook tab titles by allowing flexible matching for variations like "Controls V8.1.2", ensuring improved handling of sheet recognition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->