### PR TITLE
fix: add superusers to admin group

### DIFF
--- a/backend/core/startup.py
+++ b/backend/core/startup.py
@@ -721,6 +721,13 @@ def startup(sender: AppConfig, **kwargs):
         except Exception as e:
             logger.error("Error creating superuser", exc_info=e)
 
+    # add administrators group to superusers (for resiliency)
+    administrators = UserGroup.objects.get(
+        name="BI-UG-ADM", folder=Folder.get_root_folder()
+    )
+    for u in User.objects.filter(is_superuser=True):
+        u.user_groups.add(administrators)
+
 
 class CoreConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"


### PR DESCRIPTION
Add superusers to admin group if they already exist. This can repair a broken database where the admin group has been deleted and is recreated. CA#941

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced system initialization to automatically assign superusers to the administrators group, ensuring consistent administrative access even if the group is recreated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->