### PR TITLE
feat: allow reuse of ro/to couples in strategic scenarios

### DIFF
--- a/backend/ebios_rm/views.py
+++ b/backend/ebios_rm/views.py
@@ -124,19 +124,11 @@ class FearedEventViewSet(BaseModelViewSet):
 
 
 class RoToFilter(df.FilterSet):
-    used = df.BooleanFilter(method="is_used", label="Used")
-
-    def is_used(self, queryset, name, value):
-        if value:
-            return queryset.filter(strategicscenario__isnull=False)
-        return queryset.filter(strategicscenario__isnull=True)
-
     class Meta:
         model = RoTo
         fields = [
             "ebios_rm_study",
             "is_selected",
-            "used",
             "risk_origin",
             "motivation",
             "feared_events",

--- a/frontend/src/lib/components/Forms/ModelForm/StrategicScenarioForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/StrategicScenarioForm.svelte
@@ -17,7 +17,7 @@
 {#if context !== 'edit'}
 	<AutocompleteSelect
 		{form}
-		optionsEndpoint="ro-to?is_selected=true&used=false"
+		optionsEndpoint="ro-to?is_selected=true"
 		optionsDetailedUrlParameters={[['ebios_rm_study', initialData.ebios_rm_study]]}
 		optionsLabelField="str"
 		field="ro_to_couple"


### PR DESCRIPTION
Stopping the limitation of one strategic scenario per SROV.
Erased the use of the filter 'used'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed an outdated filtering condition that previously limited result sets.
  - Updated the strategic scenario selection process by modifying the criteria used to retrieve available options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->