### PR TITLE
fix: ref id should be single line for strategic scenarios

### DIFF
--- a/backend/ebios_rm/views.py
+++ b/backend/ebios_rm/views.py
@@ -124,19 +124,11 @@ class FearedEventViewSet(BaseModelViewSet):
 
 
 class RoToFilter(df.FilterSet):
-    used = df.BooleanFilter(method="is_used", label="Used")
-
-    def is_used(self, queryset, name, value):
-        if value:
-            return queryset.filter(strategicscenario__isnull=False)
-        return queryset.filter(strategicscenario__isnull=True)
-
     class Meta:
         model = RoTo
         fields = [
             "ebios_rm_study",
             "is_selected",
-            "used",
             "risk_origin",
             "motivation",
             "feared_events",

--- a/backend/ebios_rm/views.py
+++ b/backend/ebios_rm/views.py
@@ -124,11 +124,19 @@ class FearedEventViewSet(BaseModelViewSet):
 
 
 class RoToFilter(df.FilterSet):
+    used = df.BooleanFilter(method="is_used", label="Used")
+
+    def is_used(self, queryset, name, value):
+        if value:
+            return queryset.filter(strategicscenario__isnull=False)
+        return queryset.filter(strategicscenario__isnull=True)
+
     class Meta:
         model = RoTo
         fields = [
             "ebios_rm_study",
             "is_selected",
+            "used",
             "risk_origin",
             "motivation",
             "feared_events",

--- a/frontend/src/lib/components/Forms/ModelForm/StrategicScenarioForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/StrategicScenarioForm.svelte
@@ -3,7 +3,7 @@
 	import type { CacheLock, ModelInfo } from '$lib/utils/types';
 	import { m } from '$paraglide/messages';
 	import type { SuperValidated } from 'sveltekit-superforms';
-	import TextField from '../TextArea.svelte';
+	import TextField from '$lib/components/Forms/TextField.svelte';
 
 	export let form: SuperValidated<any>;
 	export let model: ModelInfo;

--- a/frontend/src/lib/components/Forms/ModelForm/StrategicScenarioForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/StrategicScenarioForm.svelte
@@ -17,7 +17,7 @@
 {#if context !== 'edit'}
 	<AutocompleteSelect
 		{form}
-		optionsEndpoint="ro-to?is_selected=true&used=false"
+		optionsEndpoint="ro-to?is_selected=true"
 		optionsDetailedUrlParameters={[['ebios_rm_study', initialData.ebios_rm_study]]}
 		optionsLabelField="str"
 		field="ro_to_couple"

--- a/frontend/src/lib/components/Forms/ModelForm/StrategicScenarioForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/StrategicScenarioForm.svelte
@@ -17,7 +17,7 @@
 {#if context !== 'edit'}
 	<AutocompleteSelect
 		{form}
-		optionsEndpoint="ro-to?is_selected=true"
+		optionsEndpoint="ro-to?is_selected=true&used=false"
 		optionsDetailedUrlParameters={[['ebios_rm_study', initialData.ebios_rm_study]]}
 		optionsLabelField="str"
 		field="ro_to_couple"


### PR DESCRIPTION
Ref id is now in single line in strategic scenarios instead of multiple lines like description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the integration of a form component to ensure a more consistent sourcing approach.
  - These adjustments are entirely behind-the-scenes and do not affect end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->