### PR TITLE
feat(chart-next): add annotations option to deployments, pods

### DIFF
--- a/charts/ciso-assistant-next/README.md
+++ b/charts/ciso-assistant-next/README.md
@@ -35,6 +35,7 @@ helm install ciso-assistant-release oci://ghcr.io/intuitem/helm-charts/ce/ciso-a
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| backend.annotations | object | `{}` | Backend deployment annotations |
 | backend.config.databaseType | string | `"sqlite"` | Set the database type (sqlite, pgsql or externalPgsql) # Note : PostgreSQL database configuration at `postgresql` or `externalPgsql` section |
 | backend.config.djangoDebug | bool | `false` | Enable Django debug mode |
 | backend.config.djangoExistingSecretKey | string | `""` | Name of an existing secret resource containing the django secret in a 'django-secret-key' key |
@@ -68,6 +69,7 @@ helm install ciso-assistant-release oci://ghcr.io/intuitem/helm-charts/ce/ciso-a
 | backend.persistence.sqlite.existingClaim | string | `""` | Name of an existing PersistentVolumeClaim for sqlite |
 | backend.persistence.sqlite.size | string | `"5Gi"` | SQLite persistant volume size |
 | backend.persistence.sqlite.storageClass | string | `""` | SQLite persistant volume storageClass |
+| backend.podAnnotations | object | `{}` | Backend pod annotations |
 | backend.replicas | int | `1` | The number of backend pods to run |
 | backend.resources | object | `{}` | Resources for the backend |
 | backend.service.annotations | object | `{}` | Backend service annotations |
@@ -80,6 +82,7 @@ helm install ciso-assistant-release oci://ghcr.io/intuitem/helm-charts/ce/ciso-a
 | externalPgsql.password | string | `""` | Password of an external PostgreSQL instance to connect |
 | externalPgsql.port | int | `5432` | Port of an external PostgreSQL to connect |
 | externalPgsql.user | string | `"ciso-assistant"` | User of an external PostgreSQL instance to connect |
+| frontend.annotations | object | `{}` | Frontend deployment annotations |
 | frontend.config.bodySizeLimit | string | `"50M"` | Configure body size limit for uploads in bytes (unit suffix like K/M/G can be used) |
 | frontend.containerSecurityContext | object | `{}` | Toggle and define container-level security context |
 | frontend.env | list | `[]` | Environment variables to pass to frontend |
@@ -89,6 +92,7 @@ helm install ciso-assistant-release oci://ghcr.io/intuitem/helm-charts/ce/ciso-a
 | frontend.image.tag | string | `""` (defaults to global.image.tag) | Tag to use for the frontend |
 | frontend.imagePullSecrets | list | `[]` (defaults to global.imagePullSecrets) | Secrets with credentials to pull images from a private registry |
 | frontend.name | string | `"frontend"` | Frontend container name |
+| frontend.podAnnotations | object | `{}` | Frontend pod annotations |
 | frontend.replicas | int | `1` | The number of frontend pods to run |
 | frontend.resources | object | `{}` | Resources for the frontend |
 | frontend.service.annotations | object | `{}` | Frontend service annotations |

--- a/charts/ciso-assistant-next/templates/backend/deployment.yaml
+++ b/charts/ciso-assistant-next/templates/backend/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ciso-assistant.labels" (dict "context" . "component" "backend") | nindent 4 }}
+  {{- with .Values.backend.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.backend.replicas }}
   selector:
@@ -14,6 +18,9 @@ spec:
     metadata:
       annotations:
         checksum/secret-backend: {{ include (print $.Template.BasePath "/backend/secret.yaml") . | sha256sum }}
+        {{- with .Values.backend.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "ciso-assistant.labels" (dict "context" . "component" "backend") | nindent 8 }}
     spec:

--- a/charts/ciso-assistant-next/templates/frontend/deployment.yaml
+++ b/charts/ciso-assistant-next/templates/frontend/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ciso-assistant.labels" (dict "context" . "component" "frontend") | nindent 4 }}
+  {{- with .Values.frontend.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.frontend.replicas }}
   selector:
@@ -14,6 +18,10 @@ spec:
     metadata:
       labels:
         {{- include "ciso-assistant.labels" (dict "context" . "component" "frontend") | nindent 8 }}
+      {{- with .Values.frontend.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.frontend.imagePullSecrets | default .Values.global.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/ciso-assistant-next/values.yaml
+++ b/charts/ciso-assistant-next/values.yaml
@@ -58,6 +58,12 @@ backend:
   # -- The number of backend pods to run
   replicas: 1
 
+  # -- Backend deployment annotations
+  annotations: {}
+
+  # -- Backend pod annotations
+  podAnnotations: {}
+
   ## Backend specific config
   config:
     # -- Admin email for initial configuration
@@ -199,6 +205,12 @@ frontend:
 
   # -- The number of frontend pods to run
   replicas: 1
+
+  # -- Frontend deployment annotations
+  annotations: {}
+
+  # -- Frontend pod annotations
+  podAnnotations: {}
 
   ## Frontend specific config
   config:


### PR DESCRIPTION
Hi,

This PR adds annotations to pod and deployment objects.

Annotations are widely used for autodiscovery and configuration of external components like log and metrics collectors, and this will enable integration with those tools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for custom Kubernetes deployment and pod annotations for both backend and frontend components, allowing greater flexibility in resource customization.
- **Documentation**
	- Updated documentation to describe new annotation configuration options for backend and frontend components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->