### PR TITLE
fix(UX): Reader can see the delete attachment button 

### DIFF
--- a/frontend/src/routes/(app)/(third-party)/evidences/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/evidences/[id=uuid]/+page.svelte
@@ -5,13 +5,14 @@
 	import { getModalStore } from '@skeletonlabs/skeleton';
 	import { onMount } from 'svelte';
 	import type { PageData } from './$types';
-
+	import { page } from '$app/stores';
 	import Anchor from '$lib/components/Anchor/Anchor.svelte';
 	import DetailView from '$lib/components/DetailView/DetailView.svelte';
 	import { m } from '$paraglide/messages';
 	import { defaults } from 'sveltekit-superforms';
 	import { z } from 'zod';
 	import { zod } from 'sveltekit-superforms/adapters';
+	import { canPerformAction } from '$lib/utils/access-control';
 
 	export let data: PageData;
 
@@ -60,6 +61,17 @@
 		};
 		attachment = data.data.attachment ? await fetchAttachment() : undefined;
 	});
+
+	const user = $page.data.user;
+	const canEditObject: boolean = canPerformAction({
+		user,
+		action: 'change',
+		model: data.model.name,
+		domain:
+			data.model.name === 'folder'
+				? data.data.id
+				: (data.data.folder?.id ?? data.data.folder ?? user.root_folder_id)
+	});
 </script>
 
 <DetailView {data} />
@@ -77,13 +89,16 @@
 					data-testid="attachment-download-button"
 					><i class="fa-solid fa-download mr-2" /> {m.download()}</Anchor
 				>
-				<button
-					on:click={(_) => {
-						modalConfirm(data.data.id, data.data.attachment, '?/deleteAttachment');
-					}}
-					on:keydown={(_) => modalConfirm(data.data.id, data.data.attachment, '?/deleteAttachment')}
-					class="btn variant-filled-tertiary h-full"><i class="fa-solid fa-trash" /></button
-				>
+				{#if canEditObject}
+					<button
+						on:click={(_) => {
+							modalConfirm(data.data.id, data.data.attachment, '?/deleteAttachment');
+						}}
+						on:keydown={(_) =>
+							modalConfirm(data.data.id, data.data.attachment, '?/deleteAttachment')}
+						class="btn variant-filled-tertiary h-full"><i class="fa-solid fa-trash" /></button
+					>
+				{/if}
 			</div>
 		</div>
 		{#if attachment}


### PR DESCRIPTION
A reader user can not anymore see the delete attachment button unless its a writer of the attachment domain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The delete attachment button is now only visible to users with the appropriate permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->