### PR TITLE
fix(UX): Reader in EbiosRM can see edit button on ro-to and operational-scenarios pages

### DIFF
--- a/frontend/src/routes/(app)/(internal)/operational-scenarios/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/operational-scenarios/[id=uuid]/+page.svelte
@@ -6,6 +6,8 @@
 	import ModelTable from '$lib/components/ModelTable/ModelTable.svelte';
 	import { popup, type PopupSettings } from '@skeletonlabs/skeleton';
 	import { safeTranslate } from '$lib/utils/i18n';
+	import { canPerformAction } from '$lib/utils/access-control';
+
 
 	export let data: PageData;
 
@@ -39,6 +41,19 @@
 		target: 'popupRiskLevel',
 		placement: 'bottom'
 	};
+
+	const user = $page.data.user;
+	import { URL_MODEL_MAP } from '$lib/utils/crud';
+	const model = URL_MODEL_MAP['operational-scenarios'];
+	const canEditObject = (operational_scenarios): boolean =>
+		canPerformAction({
+			user,
+			action: 'change',
+			model: model.name,
+			domain: operational_scenarios.folder?.id
+		});
+
+
 </script>
 
 <div class="card p-4 bg-white shadow-lg">
@@ -68,6 +83,7 @@
 					{/if}
 				</p>
 			</div>
+			{#if canEditObject(operationalScenario)}
 			<a
 				href={`${$page.url.pathname}/edit?activity=${activeActivity}&next=${$page.url.pathname}?activity=${activeActivity}`}
 				class="btn variant-filled-primary h-fit justify-self-end"
@@ -75,6 +91,7 @@
 				<i class="fa-solid fa-pen-to-square mr-2" data-testid="edit-button" />
 				{m.edit()}
 			</a>
+			{/if}
 		</div>
 		<div
 			id="activityOne"

--- a/frontend/src/routes/(app)/(internal)/operational-scenarios/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/operational-scenarios/[id=uuid]/+page.svelte
@@ -8,7 +8,6 @@
 	import { safeTranslate } from '$lib/utils/i18n';
 	import { canPerformAction } from '$lib/utils/access-control';
 
-
 	export let data: PageData;
 
 	const operationalScenario = data.data;
@@ -52,8 +51,6 @@
 			model: model.name,
 			domain: operational_scenarios.folder?.id
 		});
-
-
 </script>
 
 <div class="card p-4 bg-white shadow-lg">
@@ -84,13 +81,13 @@
 				</p>
 			</div>
 			{#if canEditObject(operationalScenario)}
-			<a
-				href={`${$page.url.pathname}/edit?activity=${activeActivity}&next=${$page.url.pathname}?activity=${activeActivity}`}
-				class="btn variant-filled-primary h-fit justify-self-end"
-			>
-				<i class="fa-solid fa-pen-to-square mr-2" data-testid="edit-button" />
-				{m.edit()}
-			</a>
+				<a
+					href={`${$page.url.pathname}/edit?activity=${activeActivity}&next=${$page.url.pathname}?activity=${activeActivity}`}
+					class="btn variant-filled-primary h-fit justify-self-end"
+				>
+					<i class="fa-solid fa-pen-to-square mr-2" data-testid="edit-button" />
+					{m.edit()}
+				</a>
 			{/if}
 		</div>
 		<div

--- a/frontend/src/routes/(app)/(internal)/ro-to/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/ro-to/[id=uuid]/+page.svelte
@@ -43,8 +43,6 @@
 			model: model.name,
 			domain: roto.folder?.id
 		});
-
-
 </script>
 
 <div class="card p-4 bg-white shadow-lg">
@@ -59,15 +57,14 @@
 				<p class="">{m.goBackToEbiosRmStudy()}</p>
 			</Anchor>
 			{#if canEditObject(roto)}
-			<Anchor
-				href={`${$page.url.pathname}/edit?activity=${activeActivity}&next=${$page.url.pathname}?activity=${activeActivity}`}
-				class="btn variant-filled-primary h-fit"
-			>
-				<i class="fa-solid fa-pen-to-square mr-2" data-testid="edit-button" />
-				{m.edit()}
-			</Anchor>
+				<Anchor
+					href={`${$page.url.pathname}/edit?activity=${activeActivity}&next=${$page.url.pathname}?activity=${activeActivity}`}
+					class="btn variant-filled-primary h-fit"
+				>
+					<i class="fa-solid fa-pen-to-square mr-2" data-testid="edit-button" />
+					{m.edit()}
+				</Anchor>
 			{/if}
-
 		</div>
 		<div
 			id="activityOne"

--- a/frontend/src/routes/(app)/(internal)/ro-to/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/ro-to/[id=uuid]/+page.svelte
@@ -6,6 +6,7 @@
 	import { safeTranslate } from '$lib/utils/i18n';
 	import ModelTable from '$lib/components/ModelTable/ModelTable.svelte';
 	import Anchor from '$lib/components/Anchor/Anchor.svelte';
+	import { canPerformAction } from '$lib/utils/access-control';
 
 	export let data: PageData;
 
@@ -31,6 +32,19 @@
 		fairly_relevant: 'bg-orange-200 text-orange-700',
 		higly_relevant: 'bg-red-200 text-red-700'
 	};
+
+	const user = $page.data.user;
+	import { URL_MODEL_MAP } from '$lib/utils/crud';
+	const model = URL_MODEL_MAP['ro-to'];
+	const canEditObject = (roto): boolean =>
+		canPerformAction({
+			user,
+			action: 'change',
+			model: model.name,
+			domain: roto.folder?.id
+		});
+
+
 </script>
 
 <div class="card p-4 bg-white shadow-lg">
@@ -44,6 +58,7 @@
 				<i class="fa-solid fa-arrow-left" />
 				<p class="">{m.goBackToEbiosRmStudy()}</p>
 			</Anchor>
+			{#if canEditObject(roto)}
 			<Anchor
 				href={`${$page.url.pathname}/edit?activity=${activeActivity}&next=${$page.url.pathname}?activity=${activeActivity}`}
 				class="btn variant-filled-primary h-fit"
@@ -51,6 +66,8 @@
 				<i class="fa-solid fa-pen-to-square mr-2" data-testid="edit-button" />
 				{m.edit()}
 			</Anchor>
+			{/if}
+
 		</div>
 		<div
 			id="activityOne"


### PR DESCRIPTION
Reader in EbiosRM can not anymore see edit button on ro-to and operational-scenarios pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Edit buttons on operational scenario and ro-to pages are now only visible to users with appropriate permissions, enhancing access control and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->