### PR TITLE
fix: sorting in user groups not working

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -2188,6 +2188,27 @@ class UserViewSet(BaseModelViewSet):
         return super().destroy(request, *args, **kwargs)
 
 
+class UserGroupOrderingFilter(filters.OrderingFilter):
+    def get_ordering(self, request, queryset, view):
+        ordering = super().get_ordering(request, queryset, view)
+        if not ordering:
+            return ordering
+
+        # Replace 'localization_dict' with 'folder'
+        mapped_ordering = []
+        for field in ordering:
+            if field.lstrip("-") == "localization_dict":
+                is_desc = field.startswith("-")
+                mapped_field = "folder"
+                if is_desc:
+                    mapped_field = "-" + mapped_field
+                mapped_ordering.append(mapped_field)
+            else:
+                mapped_ordering.append(field)
+
+        return mapped_ordering
+
+
 class UserGroupViewSet(BaseModelViewSet):
     """
     API endpoint that allows user groups to be viewed or edited
@@ -2195,7 +2216,9 @@ class UserGroupViewSet(BaseModelViewSet):
 
     model = UserGroup
     ordering = ["builtin", "name"]
+    ordering_fields = ["localization_dict"]
     filterset_fields = ["folder"]
+    filter_backends = [UserGroupOrderingFilter]
 
 
 class RoleViewSet(BaseModelViewSet):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for ordering user groups by the "localization_dict" field in the API. Users can now request results ordered by this field.
- **Chores**
  - Improved backend ordering logic for user group listings to enhance sorting options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->