### PR TITLE
fix: Action plan filters not working

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1795,7 +1795,30 @@ class AppliedControlViewSet(BaseModelViewSet):
 
 
 class ComplianceAssessmentActionPlanList(generics.ListAPIView):
-    filterset_fields = ["reference_control"]
+    filterset_fields = {
+        "folder": ["exact"],
+        "status": ["exact"],
+        "category": ["exact"],
+        "csf_function": ["exact"],
+        "priority": ["exact"],
+        "reference_control": ["exact"],
+        "effort": ["exact"],
+        "control_impact": ["exact"],
+        "cost": ["exact"],
+        "filtering_labels": ["exact"],
+        "risk_scenarios": ["exact"],
+        "risk_scenarios_e": ["exact"],
+        "requirement_assessments": ["exact"],
+        "evidences": ["exact"],
+        "assets": ["exact"],
+        "stakeholders": ["exact"],
+        "progress_field": ["exact"],
+        "security_exceptions": ["exact"],
+        "owner": ["exact"],
+        "findings": ["exact"],
+        "eta": ["exact", "lte", "gte", "lt", "gt"],
+    }
+
     serializer_class = ComplianceAssessmentActionPlanSerializer
     filter_backends = [
         DjangoFilterBackend,


### PR DESCRIPTION
This fixes issue #1867 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded filtering options available on the compliance assessment action plans list, allowing users to filter by multiple fields and date ranges for more precise results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->