### PR TITLE
fix: assigned to in task template table

### DIFF
--- a/frontend/src/lib/utils/table.ts
+++ b/frontend/src/lib/utils/table.ts
@@ -919,8 +919,8 @@ export const listViewFields = {
 		body: ['entry_type', 'entry', 'author', 'created_at', 'updated_at', 'timestamp']
 	},
 	'task-templates': {
-		head: ['name', 'description', 'owner', 'lastOccurrenceStatus', 'nextOccurrence'],
-		body: ['name', 'description', 'owner', 'last_occurrence_status', 'next_occurrence']
+		head: ['name', 'description', 'assigned_to', 'lastOccurrenceStatus', 'nextOccurrence'],
+		body: ['name', 'description', 'assigned_to', 'last_occurrence_status', 'next_occurrence']
 	},
 	'task-nodes': {
 		head: ['due_date', 'status', 'evidences'],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the "Task Templates" list view to display "Assigned To" instead of "Owner" in the table columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->