### PR TITLE
Add BW deployment option in addition to caddy and traefik

### DIFF
--- a/config/make_config.py
+++ b/config/make_config.py
@@ -62,7 +62,7 @@ def get_config():
 
     # Proxy selection
     config["proxy"] = questionary.select(
-        "Choose a proxy", choices=["caddy", "traefik"], default="caddy"
+        "Choose a proxy", choices=["caddy", "traefik", "bunkerweb"], default="caddy"
     ).ask()
 
     # Email configuration
@@ -194,7 +194,7 @@ def generate_compose_file(config):
             "[yellow]Expected template name format: docker-compose-local-<db>-<proxy>.yml.j2[/yellow]"
         )
         print("[yellow]Where <db> is one of: sqlite, postgresql[/yellow]")
-        print("[yellow]And <proxy> is one of: caddy, traefik[/yellow]")
+        print("[yellow]And <proxy> is one of: caddy, traefik, bunkerweb[/yellow]")
         raise e
 
     # Render template with configuration
@@ -250,6 +250,8 @@ def main():
         print("2. Ensure your certificate files are in place:")
         print(f"   - Certificate: {config['cert_config']['cert_path']}")
         print(f"   - Private key: {config['cert_config']['key_path']}")
+        if config["proxy"] == "bunkerweb":
+            print(f"   - You will need to adjust the ownership of the files to the user running the BunkerWeb container: chown 101:101 {config['cert_config']['cert_path']} {config['cert_config']['key_path']}")
     if config["db"] == "postgresql":
         print("3. Make sure PostgreSQL passwords are properly set")
     if config["need_mailer"]:

--- a/config/templates/docker-compose-postgresql-bunkerweb.yml.j2
+++ b/config/templates/docker-compose-postgresql-bunkerweb.yml.j2
@@ -1,0 +1,203 @@
+services:
+  postgres:
+    container_name: postgres
+    image: postgres:16
+    pull_policy: always
+    restart: always
+    environment:
+      POSTGRES_DB: {{ postgres.name }}
+      POSTGRES_USER: {{ postgres.user }}
+      {% if postgres.password is defined %}
+      POSTGRES_PASSWORD: {{ postgres.password }}
+      {% endif %}
+    volumes:
+      - ./db/pg:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U {{ postgres.user }} -d {{ postgres.name }}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    networks:
+      - bw-services
+
+  backend:
+    container_name: backend
+    image: ghcr.io/intuitem/ciso-assistant-community/backend:latest
+    pull_policy: always
+    restart: always
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      - ALLOWED_HOSTS=backend,localhost{% if fqdn != 'localhost'%},{{ fqdn }}{% endif %}
+      - CISO_ASSISTANT_URL=https://{{ fqdn }}:{{ port }}
+      - DJANGO_DEBUG={{ enable_debug }}
+      - AUTH_TOKEN_TTL=7200
+      - POSTGRES_NAME={{ postgres.name }}
+      - POSTGRES_USER={{ postgres.user }}
+      {% if postgres.password is defined %}
+      - POSTGRES_PASSWORD={{ postgres.password }}
+      {% endif %}
+      - DB_HOST=postgres
+      {% if need_mailer %}
+      - EMAIL_HOST={{ email.host }}
+      - EMAIL_PORT={{ email.port }}
+      {% if email.use_tls %}- EMAIL_USE_TLS={{ email.use_tls }}{% endif %}
+      - EMAIL_HOST_USER={{ email.user }}
+      - EMAIL_HOST_PASSWORD={{ email.password }}
+      - DEFAULT_FROM_EMAIL={{ email.from_email }}
+      {% endif %}
+    volumes:
+      - ./db:/code/db
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://backend:8000/api/build || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 100s
+    networks:
+      - bw-services
+
+  huey:
+    container_name: huey
+    image: ghcr.io/intuitem/ciso-assistant-community/backend:latest
+    pull_policy: always
+    depends_on:
+      backend:
+        condition: service_healthy
+    restart: always
+    environment:
+      - ALLOWED_HOSTS=backend,localhost
+      - CISO_ASSISTANT_URL=https://{{ fqdn }}:{{ port }}
+      - DJANGO_DEBUG=False
+      - AUTH_TOKEN_TTL=7200
+      - POSTGRES_NAME={{ postgres.name }}
+      - POSTGRES_USER={{ postgres.user }}
+      {% if postgres.password is defined %}
+      - POSTGRES_PASSWORD={{ postgres.password }}
+      {% endif %}
+      - DB_HOST=postgres
+      {% if need_mailer %}
+      - EMAIL_HOST={{ email.host }}
+      - EMAIL_PORT={{ email.port }}
+      {% if email.use_tls %}- EMAIL_USE_TLS={{ email.use_tls }}{% endif %}
+      - EMAIL_HOST_USER={{ email.user }}
+      - EMAIL_HOST_PASSWORD={{ email.password }}
+      - DEFAULT_FROM_EMAIL={{ email.from_email }}
+      {% endif %}
+    volumes:
+      - ./db:/code/db
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        poetry run python manage.py run_huey -w 2 --scheduler-interval 60
+    networks:
+      - bw-services
+
+  frontend:
+    container_name: frontend
+    environment:
+      - PUBLIC_BACKEND_API_URL=http://backend:8000/api
+      - PUBLIC_BACKEND_API_EXPOSED_URL=https://{{ fqdn }}:{{ port }}/api
+      - PROTOCOL_HEADER=x-forwarded-proto
+      - HOST_HEADER=x-forwarded-host
+    image: ghcr.io/intuitem/ciso-assistant-community/frontend:latest
+    pull_policy: always
+    depends_on:
+      backend:
+        condition: service_healthy
+    networks:
+      - bw-services
+
+  bunkerweb:
+    image: bunkerity/bunkerweb:1.6.1
+    ports:
+      {% if can_do_tls %}- "80:8080/tcp"{% endif %}
+      - "{{ port }}:8443/tcp"
+    environment:
+      - "API_WHITELIST_IP=127.0.0.0/8 10.20.30.0/24"
+    restart: unless-stopped
+    networks:
+      - bw-universe
+      - bw-services
+
+  bw-scheduler:
+    image: bunkerity/bunkerweb-scheduler:1.6.1
+    environment:
+      - "API_WHITELIST_IP=127.0.0.0/8 10.20.30.0/24"
+      - MULTISITE=yes
+      - BUNKERWEB_INSTANCES=bunkerweb
+      - SERVER_NAME={{ fqdn }}
+      - {{ fqdn }}_PROXY_BUFFER_SIZE=16k
+      - {{ fqdn }}_PROXY_BUFFERS=8 16k
+      - {{ fqdn }}_USE_TEMPLATE=low
+      - {{ fqdn }}_USE_REVERSE_PROXY=yes
+      - {{ fqdn }}_REVERSE_PROXY_URL=/
+      - {{ fqdn }}_REVERSE_PROXY_HOST=http://frontend:3000
+      - {{ fqdn }}_REVERSE_PROXY_URL_2=/api/
+      - {{ fqdn }}_REVERSE_PROXY_HOST_2=http://backend:8000
+      {% if can_do_tls %}- {{ fqdn }}_AUTO_LETS_ENCRYPT=yes{% elif use_custom_cert %}
+      - {{ fqdn }}_USE_CUSTOM_SSL=yes
+      - {{ fqdn }}_CUSTOM_SSL_CERT=/etc/bunkerweb/cert.pem
+      - {{ fqdn }}_CUSTOM_SSL_KEY=/etc/bunkerweb/key.pem{% else %}
+      - {{ fqdn }}_GENERATE_SELF_SIGNED_SSL=yes
+      {% endif %}
+    volumes:
+      - bw-storage:/data # This is used to persist the cache and other data like the backups
+      {% if use_custom_cert %}- {{ cert_config.cert_path }}:/etc/bunkerweb/cert.pem:ro
+      - {{ cert_config.key_path }}:/etc/bunkerweb/key.pem:ro{% endif %}
+    restart: unless-stopped
+    networks:
+      - bw-universe
+
+  {% if kafka_dispatcher.enabled %}
+  dispatcher:
+    container_name: dispatcher
+    image: ghcr.io/intuitem/ciso-assistant-community/dispatcher:latest
+    # build:
+    #   context: ../dispatcher
+    restart: always
+    environment:
+      - API_URL=http://backend:8000/api
+      - BOOTSTRAP_SERVERS={{ kafka_dispatcher.broker_url }}
+      - KAFKA_USE_AUTH={{ kafka_dispatcher.kafka_use_auth }}
+      {% if kafka_dispatcher.kafka_use_auth %}
+      - KAFKA_SASL_MECHANISM={{ kafka_dispatcher.kafka_sasl_mechanism }}
+      - KAFKA_USERNAME={{ kafka_dispatcher.kafka_username }}
+      - KAFKA_PASSWORD={{ kafka_dispatcher.kafka_password }}
+      {% endif %}
+      - OBSERVATION_TOPIC={{ kafka_dispatcher.observation_topic }}
+      - ERRORS_TOPIC={{ kafka_dispatcher.errors_topic }}
+      {% if kafka_dispatcher.authentication == 'credentials' %}
+      - USER_EMAIL={{ kafka_dispatcher.credentials.user_email }}
+      - USER_PASSWORD={{ kafka_dispatcher.credentials.user_password }}
+      - AUTO_RENEW_SESSION={{ kafka_dispatcher.auto_renew_session }}
+      {% elif kafka_dispatcher.authentication == 'token' %}
+      - TOKEN={{ kafka_dispatcher.token }}
+      {% endif %}
+      {% if kafka_dispatcher.s3_url %}
+      - S3_URL={{ kafka_dispatcher.s3_url }}
+      - S3_ACCESS_KEY={{ kafka_dispatcher.s3_access_key }}
+      - S3_SECRET_KEY={{ kafka_dispatcher.s3_secret_key }}
+      {% endif %}
+    depends_on:
+      backend:
+        condition: service_healthy
+    networks:
+      - bw-services
+  {% endif %}
+
+volumes:
+  bw-storage:
+
+networks:
+  bw-universe:
+    name: bw-universe
+    ipam:
+      driver: default
+      config:
+        - subnet: 10.20.30.0/24 # Make sure to set the correct IP range so the scheduler can send the configuration to the instance
+  bw-services:
+    name: bw-services

--- a/config/templates/docker-compose-sqlite-bunkerweb.yml.j2
+++ b/config/templates/docker-compose-sqlite-bunkerweb.yml.j2
@@ -1,0 +1,167 @@
+services:
+
+  backend:
+    container_name: backend
+    image: ghcr.io/intuitem/ciso-assistant-community/backend:latest
+    pull_policy: always
+    restart: always
+    environment:
+      - ALLOWED_HOSTS=backend,localhost{% if fqdn != 'localhost'%},{{ fqdn }}{% endif %}
+      - CISO_ASSISTANT_URL=https://{{ fqdn }}:{{ port }}
+      - DJANGO_DEBUG={{ enable_debug }}
+      - AUTH_TOKEN_TTL=7200
+      {% if need_mailer %}
+      - EMAIL_HOST={{ email.host }}
+      - EMAIL_PORT={{ email.port }}
+      {% if email.use_tls %}- EMAIL_USE_TLS={{ email.use_tls }}{% endif %}
+      - EMAIL_HOST_USER={{ email.user }}
+      - EMAIL_HOST_PASSWORD={{ email.password }}
+      - DEFAULT_FROM_EMAIL={{ email.from_email }}
+      {% endif %}
+    volumes:
+      - ./db:/code/db
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://backend:8000/api/build || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 100s
+    networks:
+      - bw-services
+
+  huey:
+    container_name: huey
+    image: ghcr.io/intuitem/ciso-assistant-community/backend:latest
+    pull_policy: always
+    depends_on:
+      backend:
+        condition: service_healthy
+    restart: always
+    environment:
+      - ALLOWED_HOSTS=backend,localhost
+      - CISO_ASSISTANT_URL=https://{{ fqdn }}:{{ port }}
+      - DJANGO_DEBUG=False
+      - AUTH_TOKEN_TTL=7200
+      {% if need_mailer %}
+      - EMAIL_HOST={{ email.host }}
+      - EMAIL_PORT={{ email.port }}
+      {% if email.use_tls %}- EMAIL_USE_TLS={{ email.use_tls }}{% endif %}
+      - EMAIL_HOST_USER={{ email.user }}
+      - EMAIL_HOST_PASSWORD={{ email.password }}
+      - DEFAULT_FROM_EMAIL={{ email.from_email }}
+      {% endif %}
+    volumes:
+      - ./db:/code/db
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        poetry run python manage.py run_huey -w 2 --scheduler-interval 60
+    networks:
+      - bw-services
+
+  frontend:
+    container_name: frontend
+    environment:
+      - PUBLIC_BACKEND_API_URL=http://backend:8000/api
+      - PUBLIC_BACKEND_API_EXPOSED_URL=https://{{ fqdn }}:{{ port }}/api
+      - PROTOCOL_HEADER=x-forwarded-proto
+      - HOST_HEADER=x-forwarded-host
+    image: ghcr.io/intuitem/ciso-assistant-community/frontend:latest
+    pull_policy: always
+    depends_on:
+      backend:
+        condition: service_healthy
+    networks:
+      - bw-services
+
+  bunkerweb:
+    image: bunkerity/bunkerweb:1.6.1
+    ports:
+      {% if can_do_tls %}- "80:8080/tcp"{% endif %}
+      - "{{ port }}:8443/tcp"
+    environment:
+      - "API_WHITELIST_IP=127.0.0.0/8 10.20.30.0/24"
+    restart: unless-stopped
+    networks:
+      - bw-universe
+      - bw-services
+
+  bw-scheduler:
+    image: bunkerity/bunkerweb-scheduler:1.6.1
+    environment:
+      - "API_WHITELIST_IP=127.0.0.0/8 10.20.30.0/24"
+      - MULTISITE=yes
+      - BUNKERWEB_INSTANCES=bunkerweb
+      - SERVER_NAME={{ fqdn }}
+      - {{ fqdn }}_PROXY_BUFFER_SIZE=16k
+      - {{ fqdn }}_PROXY_BUFFERS=8 16k
+      - {{ fqdn }}_USE_TEMPLATE=low
+      - {{ fqdn }}_USE_REVERSE_PROXY=yes
+      - {{ fqdn }}_REVERSE_PROXY_URL=/
+      - {{ fqdn }}_REVERSE_PROXY_HOST=http://frontend:3000
+      - {{ fqdn }}_REVERSE_PROXY_URL_2=/api/
+      - {{ fqdn }}_REVERSE_PROXY_HOST_2=http://backend:8000
+      {% if can_do_tls %}- {{ fqdn }}_AUTO_LETS_ENCRYPT=yes{% elif use_custom_cert %}
+      - {{ fqdn }}_USE_CUSTOM_SSL=yes
+      - {{ fqdn }}_CUSTOM_SSL_CERT=/etc/bunkerweb/cert.pem
+      - {{ fqdn }}_CUSTOM_SSL_KEY=/etc/bunkerweb/key.pem{% else %}
+      - {{ fqdn }}_GENERATE_SELF_SIGNED_SSL=yes
+      {% endif %}
+    volumes:
+      - bw-storage:/data # This is used to persist the cache and other data like the backups
+      {% if use_custom_cert %}- {{ cert_config.cert_path }}:/etc/bunkerweb/cert.pem:ro
+      - {{ cert_config.key_path }}:/etc/bunkerweb/key.pem:ro{% endif %}
+    restart: unless-stopped
+    networks:
+      - bw-universe
+
+  {% if kafka_dispatcher.enabled %}
+  dispatcher:
+    container_name: dispatcher
+    image: ghcr.io/intuitem/ciso-assistant-community/dispatcher:latest
+    # build:
+    #   context: ../dispatcher
+    restart: always
+    environment:
+      - API_URL=http://backend:8000/api
+      - BOOTSTRAP_SERVERS={{ kafka_dispatcher.broker_url }}
+      - KAFKA_USE_AUTH={{ kafka_dispatcher.kafka_use_auth }}
+      {% if kafka_dispatcher.kafka_use_auth %}
+      - KAFKA_SASL_MECHANISM={{ kafka_dispatcher.kafka_sasl_mechanism }}
+      - KAFKA_USERNAME={{ kafka_dispatcher.kafka_username }}
+      - KAFKA_PASSWORD={{ kafka_dispatcher.kafka_password }}
+      {% endif %}
+      - OBSERVATION_TOPIC={{ kafka_dispatcher.observation_topic }}
+      - ERRORS_TOPIC={{ kafka_dispatcher.errors_topic }}
+      {% if kafka_dispatcher.authentication == 'credentials' %}
+      - USER_EMAIL={{ kafka_dispatcher.credentials.user_email }}
+      - USER_PASSWORD={{ kafka_dispatcher.credentials.user_password }}
+      - AUTO_RENEW_SESSION={{ kafka_dispatcher.auto_renew_session }}
+      {% elif kafka_dispatcher.authentication == 'token' %}
+      - TOKEN={{ kafka_dispatcher.token }}
+      {% endif %}
+      {% if kafka_dispatcher.s3_url %}
+      - S3_URL={{ kafka_dispatcher.s3_url }}
+      - S3_ACCESS_KEY={{ kafka_dispatcher.s3_access_key }}
+      - S3_SECRET_KEY={{ kafka_dispatcher.s3_secret_key }}
+      {% endif %}
+    depends_on:
+      backend:
+        condition: service_healthy
+    networks:
+      - bw-services
+  {% endif %}
+
+volumes:
+  bw-storage:
+
+networks:
+  bw-universe:
+    name: bw-universe
+    ipam:
+      driver: default
+      config:
+        - subnet: 10.20.30.0/24 # Make sure to set the correct IP range so the scheduler can send the configuration to the instance
+  bw-services:
+    name: bw-services


### PR DESCRIPTION
Hi team,

Init work on BunkerWeb deployment to protect internet facing installation of CISO assistant.

Please note that it may have some false positive, we didn't test it throughly ATM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for "bunkerweb" as a new proxy option during configuration.
  - Introduced new Docker Compose templates for deploying with Bunkerweb, supporting both PostgreSQL and SQLite backends.
- **Improvements**
  - Updated configuration prompts and error messages to include "bunkerweb" as a valid proxy choice.
  - Added user instructions for handling custom certificates when using Bunkerweb.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->