### PR TITLE
fix: resolve warnings of Logger library

### DIFF
--- a/backend/data_wizard/views.py
+++ b/backend/data_wizard/views.py
@@ -465,7 +465,7 @@ class LoadFileView(APIView):
                                     .first()
                                 )
                             else:
-                                logger.warn("Import attempt: unknown ref_id ")
+                                logger.warning("Import attempt: unknown ref_id ")
                         elif urn:
                             ReqNode = RequirementNode.objects.filter(
                                 framework__id=framework_id, urn=urn


### PR DESCRIPTION
# PR Summary
This PR resolves the deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error logging for unknown requirement reference IDs during compliance assessment processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->