### PR TITLE
fix(toolbox): prepare_mapping.py file reading encoding enforces UTF-8

### DIFF
--- a/tools/prepare_mapping.py
+++ b/tools/prepare_mapping.py
@@ -16,9 +16,9 @@ args = parser.parse_args()
 packager = "intuitem"
 
 print("parsing", args.source_yaml, args.target_yaml)
-with open(args.source_yaml, "r") as file:
+with open(args.source_yaml, "r", encoding="utf-8") as file:
     source = yaml.safe_load(file)
-with open(args.target_yaml, "r") as file:
+with open(args.target_yaml, "r", encoding="utf-8") as file:
     target = yaml.safe_load(file)
 
 source_library_urn = source["urn"]


### PR DESCRIPTION
Fixed an issue where the encoding for reading the YAML files in "prepare_mapping.py" was not defined for calls to the "open()" function, which sometimes caused the script to crash on Windows depending on the content of the YAML files.

Problem detected indirectly by checking PR #1963 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file handling to ensure consistent UTF-8 decoding when reading YAML files, reducing the risk of encoding-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->