### PR TITLE
fix: demo domain fixture path

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -2691,9 +2691,7 @@ class FolderViewSet(BaseModelViewSet):
     def import_dummy_domain(self, request):
         domain_name = "DEMO"
         try:
-            dummy_fixture_path = (
-                Path(settings.BASE_DIR) / "fixtures" / "dummy-domain.bak"
-            )
+            dummy_fixture_path = Path("fixtures/dummy-domain.bak")
             if not dummy_fixture_path.exists():
                 logger.error("Dummy domain fixture not found", path=dummy_fixture_path)
                 return Response(


### PR DESCRIPTION
This should fix the recent hurdles we had with enterprise functional tests failing in CI because demo domain fixture could not be loaded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when importing the dummy domain fixture by updating how the fixture file path is constructed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->