### PR TITLE
feat: changed disposition for third party nav bar

### DIFF
--- a/frontend/src/lib/components/SideBar/navData.ts
+++ b/frontend/src/lib/components/SideBar/navData.ts
@@ -259,11 +259,6 @@ export const navData = {
 					href: '/entities'
 				},
 				{
-					name: 'entityAssessments',
-					fa_icon: 'fa-solid fa-clipboard-list',
-					href: '/entity-assessments'
-				},
-				{
 					name: 'representatives',
 					fa_icon: 'fa-solid fa-user-tie',
 					href: '/representatives'
@@ -272,6 +267,11 @@ export const navData = {
 					name: 'solutions',
 					fa_icon: 'fa-solid fa-box',
 					href: '/solutions'
+				},
+				{
+					name: 'entityAssessments',
+					fa_icon: 'fa-solid fa-clipboard-list',
+					href: '/entity-assessments'
 				}
 			]
 		},


### PR DESCRIPTION
Brought solution and representatives before entity assessment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Reordered the "entityAssessments" navigation item to appear last within the third-party category menu. No changes to its content or permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->