### PR TITLE
fix: refresh forms values on applied control or evidences edition

### DIFF
--- a/frontend/src/lib/components/Forms/ModelForm/AppliedControlPolicyForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/AppliedControlPolicyForm.svelte
@@ -30,12 +30,13 @@
 			};
 			model.selectOptions = selectOptions;
 		}
-		if (model?.selectOptions?.priority) {
-			model.selectOptions.priority.forEach((element) => {
-				element.value = parseInt(element.value);
-			});
-		}
 	});
+
+	$: if (model?.selectOptions?.priority) {
+		model.selectOptions.priority.forEach((element) => {
+			element.value = parseInt(element.value);
+		});
+	}
 </script>
 
 {#if !duplicate}

--- a/frontend/src/lib/components/Forms/ModelForm/AppliedControlPolicyForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/AppliedControlPolicyForm.svelte
@@ -20,14 +20,16 @@
 	export let initialData: Record<string, any> = {};
 
 	onMount(async () => {
-		const selectOptions = {
-			status: await fetch('/applied-controls/status').then((r) => r.json()),
-			priority: await fetch('/applied-controls/priority').then((r) => r.json()),
-			category: await fetch('/applied-controls/category').then((r) => r.json()),
-			csf_function: await fetch('/applied-controls/csf_function').then((r) => r.json()),
-			effort: await fetch('/applied-controls/effort').then((r) => r.json())
-		};
-		model.selectOptions = selectOptions;
+		if (!model.selectOptions) {
+			const selectOptions = {
+				status: await fetch('/applied-controls/status').then((r) => r.json()),
+				priority: await fetch('/applied-controls/priority').then((r) => r.json()),
+				category: await fetch('/applied-controls/category').then((r) => r.json()),
+				csf_function: await fetch('/applied-controls/csf_function').then((r) => r.json()),
+				effort: await fetch('/applied-controls/effort').then((r) => r.json())
+			};
+			model.selectOptions = selectOptions;
+		}
 		if (model.selectOptions && 'priority' in model.selectOptions) {
 			model.selectOptions['priority'].forEach((element) => {
 				element.value = parseInt(element.value);

--- a/frontend/src/lib/components/Forms/ModelForm/AppliedControlPolicyForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/AppliedControlPolicyForm.svelte
@@ -30,8 +30,8 @@
 			};
 			model.selectOptions = selectOptions;
 		}
-		if (model.selectOptions && 'priority' in model.selectOptions) {
-			model.selectOptions['priority'].forEach((element) => {
+		if (model?.selectOptions?.priority) {
+			model.selectOptions.priority.forEach((element) => {
 				element.value = parseInt(element.value);
 			});
 		}

--- a/frontend/src/lib/utils/crud.ts
+++ b/frontend/src/lib/utils/crud.ts
@@ -1021,12 +1021,15 @@ export const URL_MODEL_MAP: ModelMap = {
 		localNamePlural: 'findings',
 		verboseName: 'Finding',
 		verboseNamePlural: 'Findings',
-		foreignKeyFields: [{ field: 'findings_assessment', urlModel: 'findings-assessments' }],
-		// reverseForeignKeyFields: [
-		// 	{ field: 'findings', urlModel: 'vulnerabilities' },
-		// 	{ field: 'findings', urlModel: 'reference-controls' },
-		// 	{ field: 'findings', urlModel: 'applied-controls' }
-		// ],
+		foreignKeyFields: [
+			{ field: 'findings_assessment', urlModel: 'findings-assessments' },
+			{ field: 'applied_controls', urlModel: 'applied-controls' }
+		],
+		reverseForeignKeyFields: [
+			// 	{ field: 'findings', urlModel: 'vulnerabilities' },
+			// 	{ field: 'findings', urlModel: 'reference-controls' },
+			{ field: 'findings', urlModel: 'applied-controls' }
+		],
 		selectFields: [{ field: 'severity', valueType: 'number' }, { field: 'status' }]
 	},
 	incidents: {

--- a/frontend/src/lib/utils/table.ts
+++ b/frontend/src/lib/utils/table.ts
@@ -980,13 +980,13 @@ export const listViewFields = {
 		body: ['ref_id', 'name', 'description', 'category', 'findings_count', 'perimeter']
 	},
 	findings: {
-		head: ['ref_id', 'name', 'description', 'findings_assessment', 'severity', 'status', 'labels'],
+		head: ['ref_id', 'name', 'findings_assessment', 'severity', 'owner', 'status', 'labels'],
 		body: [
 			'ref_id',
 			'name',
-			'description',
 			'findings_assessment',
 			'severity',
+			'owner',
 			'status',
 			'filtering_labels'
 		],

--- a/frontend/src/routes/(app)/(internal)/[model=urlmodel]/[filter=filters]/+server.ts
+++ b/frontend/src/routes/(app)/(internal)/[model=urlmodel]/[filter=filters]/+server.ts
@@ -15,12 +15,10 @@ export const GET: RequestHandler = async ({ fetch, params }) => {
 
 	const options =
 		typeof Object.values(optionsResponse)[0] === 'string'
-			? Object.keys(optionsResponse)
-					.map((key) => ({
-						label: optionsResponse[key],
-						value: key
-					}))
-					.sort((a, b) => a.label.localeCompare(b.label))
+			? Object.keys(optionsResponse).map((key) => ({
+					label: optionsResponse[key],
+					value: key
+				}))
 			: optionsResponse;
 
 	return new Response(JSON.stringify(options), {


### PR DESCRIPTION
- **only fetch options on applied control creation**
- **stop ordering choices in api passthrough**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Reduced redundant network requests when loading select options in forms, resulting in improved efficiency.  
- **Behavior Changes**
  - Option lists in certain dropdowns are no longer sorted alphabetically; they will appear in their original order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->