### PR TITLE
Fix: Chart schema allow PostgreSQL properties

### DIFF
--- a/charts/ciso-assistant-next/values.schema.json
+++ b/charts/ciso-assistant-next/values.schema.json
@@ -410,19 +410,19 @@
             "type": "string"
         },
         "postgresql": {
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
                 "enabled": {
                     "type": "boolean"
                 },
                 "global": {
-                    "additionalProperties": false,
+                    "additionalProperties": true,
                     "properties": {
                         "postgresql": {
-                            "additionalProperties": false,
+                            "additionalProperties": true,
                             "properties": {
                                 "auth": {
-                                    "additionalProperties": false,
+                                    "additionalProperties": true,
                                     "properties": {
                                         "database": {
                                             "type": "string"
@@ -446,10 +446,10 @@
                     "type": "object"
                 },
                 "primary": {
-                    "additionalProperties": false,
+                    "additionalProperties": true,
                     "properties": {
                         "persistence": {
-                            "additionalProperties": false,
+                            "additionalProperties": true,
                             "properties": {
                                 "size": {
                                     "type": "string"

--- a/charts/ciso-assistant-next/values.yaml
+++ b/charts/ciso-assistant-next/values.yaml
@@ -309,12 +309,12 @@ ingress:
 ## Bundeled PostgreSQL database configuration (Bitnami chart)
 ## Ref: https://artifacthub.io/packages/helm/bitnami/postgresql
 ## Note: Don't enable if you use SQLite mode or external PgSQL database
-postgresql:
+postgresql: # @schema additionalProperties: true
   # -- Enable to deploy PostgreSQL.
   enabled: false
-  global:
-    postgresql:
-      auth:
+  global: # @schema additionalProperties: true
+    postgresql: # @schema additionalProperties: true
+      auth: # @schema additionalProperties: true
         # -- Super-user postgres account password
         ## Note: if not set, it will be dynamically generated
         postgresPassword: ""
@@ -325,8 +325,8 @@ postgresql:
         # -- Database user account password
         ## Note: if not set, it will be dynamically generated
         password: ""
-  primary:
-    persistence:
+  primary: # @schema additionalProperties: true
+    persistence: # @schema additionalProperties: true
       # -- PostgreSQL persistant volume size (default 8Gi).
       size: 5Gi
 


### PR DESCRIPTION
Additional properties from the Bitnami PostgreSQL chart make the validation fail.

Fixes #2072 