### PR TITLE
fix: urn generation for mappings in case of whitespace

### DIFF
--- a/tools/convert_library_v1.py
+++ b/tools/convert_library_v1.py
@@ -893,8 +893,8 @@ for tab in dataframe:
                     print(
                         f"WARNING: this target node id: {tgt_node_id} is not recognized. Fix it and try again before uploading your file."
                     )
-                source_requirement_urn = source_prefix + ":" + src_node_id
-                target_requirement_urn = target_prefix + ":" + tgt_node_id
+                source_requirement_urn = source_prefix + ":" + src_node_id.lower().replace(" ", "-")
+                target_requirement_urn = target_prefix + ":" + tgt_node_id.lower().replace(" ", "-")
                 relationship = row[header["relationship"]].value
                 rationale = (
                     row[header["rationale"]].value if "rationale" in header else None

--- a/tools/convert_library_v2.py
+++ b/tools/convert_library_v2.py
@@ -779,8 +779,8 @@ def create_library(input_file: str, output_file: str, compat: bool = False):
                     "relationship": data.get("relationship").strip(),
                 }
                 entry_revert = {
-                    "source_requirement_urn": target_node_base_urn + ":" + target_node_id,
-                    "target_requirement_urn": source_node_base_urn + ":" + source_node_id,
+                    "source_requirement_urn": target_node_base_urn + ":" + target_node_id.lower().replace(" ", "-"),
+                    "target_requirement_urn": source_node_base_urn + ":" + source_node_id.lower().replace(" ", "-"),
                     "relationship": revert_relationship(data.get("relationship").strip()),
                 }
                 if "rationale" in data and data["rationale"]:

--- a/tools/convert_library_v2.py
+++ b/tools/convert_library_v2.py
@@ -774,8 +774,8 @@ def create_library(input_file: str, output_file: str, compat: bool = False):
                 source_node_id = str(data.get("source_node_id", "")).strip()
                 target_node_id = str(data.get("target_node_id", "")).strip()
                 entry = {
-                    "source_requirement_urn": source_node_base_urn + ":" + source_node_id,
-                    "target_requirement_urn": target_node_base_urn + ":" + target_node_id,
+                    "source_requirement_urn": source_node_base_urn + ":" + source_node_id.lower().replace(" ", "-"),
+                    "target_requirement_urn": target_node_base_urn + ":" + target_node_id.lower().replace(" ", "-"),
                     "relationship": data.get("relationship").strip(),
                 }
                 entry_revert = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved consistency in URN formatting by converting node IDs to lowercase and replacing spaces with hyphens when generating URNs for mappings and requirement mappings. This change ensures uniformity in how URNs are displayed to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->