### PR TITLE
Fix "convert_library_v2.py" + small doc bug

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -145,6 +145,7 @@ A _meta of type "reference_controls" contains the following keys:
 - ref_id (*)
 - name (*)
 - description (*)
+- base_urn
 
 The _content tab for a "reference_controls" object contains the following columns:
 - ref_id (*)

--- a/tools/convert_library_v2.py
+++ b/tools/convert_library_v2.py
@@ -523,7 +523,7 @@ def create_library(input_file: str, output_file: str, compat: bool = False):
 
             # --- Retrieve answers block if declared ---
             answers_dict = {}
-            answers_block_name = meta.get("answers")
+            answers_block_name = meta.get("answers_definition")
             if answers_block_name:
                 if answers_block_name not in object_blocks:
                     raise ValueError(f"❌ Missing answers sheet: '{answers_block_name}'")


### PR DESCRIPTION
- convert_library_v2.py refers "answers" instead of "answers_definition" tab (line 526)
- Custom Reference controls documentation (README.md) lacks base_urn field in meta sheet (line 148)