### PR TITLE
fix: convert_library_v2.py and README.md in tools

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -127,6 +127,7 @@ This is a topological representation. The display on the screen (transposition, 
 A _meta of type "threats" contains the following keys:
 - type (*): must be "threats"
 - urn (*)
+- base_urn (*)
 - ref_id (*)
 - name (*)
 - description (*)
@@ -142,6 +143,7 @@ The _content tab for a "threats" object contains the following columns:
 A _meta of type "reference_controls" contains the following keys:
 - type (*): must be "reference_controls"
 - urn (*)
+- base_urn (*)
 - ref_id (*)
 - name (*)
 - description (*)

--- a/tools/convert_library_v2.py
+++ b/tools/convert_library_v2.py
@@ -523,7 +523,7 @@ def create_library(input_file: str, output_file: str, compat: bool = False):
 
             # --- Retrieve answers block if declared ---
             answers_dict = {}
-            answers_block_name = meta.get("answers")
+            answers_block_name = meta.get("answers_definition")
             if answers_block_name:
                 if answers_block_name not in object_blocks:
                     raise ValueError(f"❌ Missing answers sheet: '{answers_block_name}'")


### PR DESCRIPTION
* convert_library_v2.py refers "answers" instead of "answers_definition" tab (line 526)
* Custom Reference controls documentation (README.md) lacks base_urn field in meta sheet (line 148)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to specify that the `base_urn` key is now required in the `_meta` tabs for "threats" and "reference_controls" in the Excel file format.

- **Bug Fixes**
  - Adjusted processing logic to correctly retrieve the answers block name from `answers_definition` instead of `answers` in framework objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->