### PR TITLE
fix: add 0 to scenario ref_id for consistent ordering

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -3462,7 +3462,7 @@ class RiskScenario(NameDescriptionMixin):
         """return associated risk assessment id"""
         scenarios_ref_ids = [x.ref_id for x in risk_assessment.risk_scenarios.all()]
         nb_scenarios = len(scenarios_ref_ids) + 1
-        candidates = [f"R.{i}" for i in range(1, nb_scenarios + 1)]
+        candidates = [f"R.{i:02d}" for i in range(1, nb_scenarios + 1)]
         return next(x for x in candidates if x not in scenarios_ref_ids)
 
     def parent_perimeter(self):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the format of generated reference IDs for risk scenarios to use zero-padded two-digit numbers (e.g., "R.01", "R.02") for improved consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->