### PR TITLE
feat: added state to table.ts in risk acceptance

### DIFF
--- a/frontend/src/lib/utils/table.ts
+++ b/frontend/src/lib/utils/table.ts
@@ -602,8 +602,8 @@ export const listViewFields = {
 		}
 	},
 	'risk-acceptances': {
-		head: ['name', 'description', 'riskScenarios'],
-		body: ['name', 'description', 'risk_scenarios'],
+		head: ['name', 'description', 'riskScenarios', 'state'],
+		body: ['name', 'description', 'risk_scenarios', 'state'],
 		filters: {
 			folder: DOMAIN_FILTER,
 			state: STATE_FILTER,


### PR DESCRIPTION
added state to table.ts in risk acceptance to have more easy visibility on the state of the risk acceptance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the "state" field to the risk acceptances list view, making this information visible in the table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->