### PR TITLE
feat: bring label when duplicate applied control

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1757,6 +1757,9 @@ class AppliedControlViewSet(BaseModelViewSet):
             progress_field=applied_control.progress_field,
         )
         duplicate_applied_control.owner.set(applied_control.owner.all())
+        duplicate_applied_control.filtering_labels.set(
+            applied_control.filtering_labels.all()
+        )
         if data["duplicate_evidences"]:
             duplicate_related_objects(
                 applied_control, duplicate_applied_control, new_folder, "evidences"

--- a/frontend/src/lib/components/ModelTable/ModelTable.svelte
+++ b/frontend/src/lib/components/ModelTable/ModelTable.svelte
@@ -90,7 +90,11 @@
 		if (!rowMetaData[identifierField] || !URLModel) return;
 		goto(`/${URLModel}/${rowMetaData[identifierField]}${detailQueryParameter}`, {
 			label:
-				rowMetaData.str ?? rowMetaData.name ?? rowMetaData.email ?? rowMetaData[identifierField],
+				rowMetaData.str ??
+				rowMetaData.name ??
+				rowMetaData.email ??
+				rowMetaData.label ??
+				rowMetaData[identifierField],
 			breadcrumbAction: 'push'
 		});
 	}

--- a/frontend/src/lib/utils/load.ts
+++ b/frontend/src/lib/utils/load.ts
@@ -132,7 +132,7 @@ export const loadDetail = async ({ event, model, id }) => {
 	}
 	return {
 		data,
-		title: data.str || data.name || data.email || data.id,
+		title: data.str || data.name || data.email || data.label || data.id,
 		form,
 		relatedModels,
 		urlModel: model.urlModel as urlModel,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Filtering labels are now preserved when duplicating applied controls.
- **Enhancements**
  - Breadcrumb navigation and detail views now use an expanded set of properties, including "label", to generate more descriptive titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->