### PR TITLE
fix: align loaded libraries object_type filter with stored libraries

### DIFF
--- a/backend/library/views.py
+++ b/backend/library/views.py
@@ -361,10 +361,12 @@ class LoadedLibraryFilterSet(LibraryMixinFilterSet):
 
     def filter_object_type(self, queryset, name, value: list[str]):
         # For backward compatibility
-        if "risk_matrix" in value:
-            value.append("risk_matrices")
-        if "requirement_mapping_set" in value:
-            value.append("requirement_mapping_sets")
+        if "risk_matrices" in value:
+            value.append("risk_matrix")
+        if "requirement_mapping_sets" in value:
+            value.append("requirement_mapping_set")
+        if "frameworks" in value:
+            value.append("framework")
         union_qs = Q()
         _value = {
             k: v


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved filtering to better recognize plural object types and ensure their singular counterparts are included for compatibility.
  - Added support for recognizing "frameworks" and including "framework" in filters for backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->