### PR TITLE
fix(tool): Update convert_library_v1.py

### DIFF
--- a/tools/convert_library_v1.py
+++ b/tools/convert_library_v1.py
@@ -931,7 +931,11 @@ has_mappings = "mappings" in [
 lib_date = library_vars.get("library_publication_date", datetime.datetime.now())
 if type(lib_date) == datetime.datetime:
     lib_date = lib_date.date()
+
+convert_library_version = f"v1 ; Compat Mode: [{args.compat}]"    
+
 library = {
+    "convert_library_version": convert_library_version,
     "urn": library_vars["library_urn"],
     "locale": library_vars["library_locale"],
     "ref_id": library_vars["library_ref_id"],


### PR DESCRIPTION
As for the updated "convert_library_v2.py" script (PR #2103) , the converter now prints its version and compatibility mode status at the top of the generated YAML file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a version and compatibility mode indicator for converted libraries, now visible as a new field in the output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->