### PR TITLE
fix: risk assessment ref id duplication

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1196,6 +1196,7 @@ class RiskAssessmentViewSet(BaseModelViewSet):
                 perimeter=Perimeter.objects.get(id=data["perimeter"]),
                 version=data["version"],
                 risk_matrix=risk_assessment.risk_matrix,
+                ref_id=data["ref_id"],
                 eta=risk_assessment.eta,
                 due_date=risk_assessment.due_date,
                 status=risk_assessment.status,

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1191,12 +1191,12 @@ class RiskAssessmentViewSet(BaseModelViewSet):
             data = request.data
 
             duplicate_risk_assessment = RiskAssessment.objects.create(
-                name=data["name"],
-                description=data["description"],
-                perimeter=Perimeter.objects.get(id=data["perimeter"]),
-                version=data["version"],
+                name=data.get("name"),
+                description=data.get("description"),
+                perimeter=Perimeter.objects.get(id=data.get("perimeter")),
+                version=data.get("version"),
                 risk_matrix=risk_assessment.risk_matrix,
-                ref_id=data["ref_id"],
+                ref_id=data.get("ref_id"),
                 eta=risk_assessment.eta,
                 due_date=risk_assessment.due_date,
                 status=risk_assessment.status,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Duplicated risk assessments now correctly retain the reference ID provided during duplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->