### PR TITLE
fix: action plan pdf export when no status in control

### DIFF
--- a/backend/core/templates/core/action_plan_pdf.html
+++ b/backend/core/templates/core/action_plan_pdf.html
@@ -24,7 +24,7 @@
     {{ status }}
     {% for status, applied_controls in context.items %}
         {% for status_color, color in color_map.items %}
-            {% if status_color == status and status == "no status" %}
+            {% if status_color == status and status == "--" %}
                 <p class="flex p-2 m-2 text-lg font-semibold justify-center" style="background-color: {{color}}">{% trans "No status" %}</p>
             {% else %}
                 {% for text in status_text %}
@@ -72,7 +72,7 @@
                         </tr>
                         {% empty %}
                             <tr>
-                                <td class="text-md p-2 text-center" colspan="7">
+                                <td class="text-md p-2 text-center" colspan="9">
                                     <p>{% trans "No entries found" %}</p>
                                 </td>
                             </tr>

--- a/backend/core/templates/core/risk_action_plan_pdf.html
+++ b/backend/core/templates/core/risk_action_plan_pdf.html
@@ -22,7 +22,7 @@
     {{ status }}
     {% for status, applied_controls in context.items %}
         {% for status_color, color in color_map.items %}
-            {% if status_color == status and status == "no status" %}
+            {% if status_color == status and status == "--" %}
                 <p class="flex p-2 m-2 text-lg font-semibold justify-center" style="background-color: {{color}}">{% trans "No status" %}</p>
             {% else %}
                 {% for text in status_text %}

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1155,7 +1155,7 @@ class RiskAssessmentViewSet(BaseModelViewSet):
             for applied_control in applied_controls:
                 context[applied_control.status].append(
                     applied_control
-                ) if applied_control.status else context["no status"].append(
+                ) if applied_control.status else context["--"].append(
                     applied_control
                 )
             data = {
@@ -4389,7 +4389,7 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
             for applied_control in applied_controls:
                 context[applied_control.status].append(
                     applied_control
-                ) if applied_control.status else context["no status"].append(
+                ) if applied_control.status else context["--"].append(
                     applied_control
                 )
             data = {

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1155,9 +1155,7 @@ class RiskAssessmentViewSet(BaseModelViewSet):
             for applied_control in applied_controls:
                 context[applied_control.status].append(
                     applied_control
-                ) if applied_control.status else context["--"].append(
-                    applied_control
-                )
+                ) if applied_control.status else context["--"].append(applied_control)
             data = {
                 "status_text": status,
                 "color_map": color_map,
@@ -4389,9 +4387,7 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
             for applied_control in applied_controls:
                 context[applied_control.status].append(
                     applied_control
-                ) if applied_control.status else context["--"].append(
-                    applied_control
-                )
+                ) if applied_control.status else context["--"].append(applied_control)
             data = {
                 "status_text": status,
                 "color_map": color_map,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the status label for items without a status in action plan PDFs to display as "--" instead of "No status".
  - Adjusted the table layout in action plan PDFs so that the "No entries found" message correctly spans all columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->