### PR TITLE
fix: evidence creation reactivity on timeline event create

### DIFF
--- a/frontend/src/routes/(app)/(internal)/incidents/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/incidents/[id=uuid]/+page.svelte
@@ -164,6 +164,7 @@
 				}),
 				{ taint: false }
 			);
+			form.newEvidence = undefined;
 			console.debug('formStore', $formStore);
 		}
 	});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The form now properly clears the "new evidence" field after it has been added, preventing duplicate entries and improving form behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->