### PR TITLE
fix: translate options for autocompleteselect

### DIFF
--- a/frontend/src/lib/components/Forms/AutocompleteSelect.svelte
+++ b/frontend/src/lib/components/Forms/AutocompleteSelect.svelte
@@ -337,15 +337,14 @@
 				{#if option.option.suggested}
 					<span class="text-primary-600">{option.option.label}</span>
 					<span class="text-sm text-surface-500"> {m.suggestedParentheses()}</span>
-				{:else if translateOptions && option.label}
+				{:else if translateOptions && option.option}
 					{#if field === 'ro_to_couple'}
-						{safeTranslate(toCamelCase(option.label.split(' - ')[0]))} - {option.label.split(
-							'-'
-						)[1]}
+						{@const [firstPart, ...restParts] = option.option.label.split(' - ')}
+						{safeTranslate(firstPart)} - {restParts.join(' - ')}
 					{:else}
-						{m[toCamelCase(option.value)]
-							? safeTranslate(option.value)
-							: safeTranslate(option.label)}
+						{@const translatedValue = safeTranslate(option.option.value)}
+						{@const translatedLabel = safeTranslate(option.option.label)}
+						{translatedValue !== option.option.value ? translatedValue : translatedLabel}
 					{/if}
 				{:else}
 					{option.option.label || option.option}

--- a/frontend/src/lib/components/Forms/AutocompleteSelect.svelte
+++ b/frontend/src/lib/components/Forms/AutocompleteSelect.svelte
@@ -14,6 +14,7 @@
 		label: string;
 		value: string | number;
 		suggested?: boolean;
+		translatedLabel?: string;
 	}
 
 	type FieldContext = 'form-input' | 'filter-input';
@@ -183,7 +184,8 @@
 					suggested: optionsSuggestions?.some(
 						(s) =>
 							getNestedValue(s, optionsValueField) === getNestedValue(object, optionsValueField)
-					)
+					),
+					translatedLabel: safeTranslate(fullLabel)
 				};
 			})
 			.filter(
@@ -194,7 +196,7 @@
 				// Show suggested items first
 				if (a.suggested && !b.suggested) return -1;
 				if (!a.suggested && b.suggested) return 1;
-				return 0;
+				return a.translatedLabel!.toLowerCase().localeCompare(b.translatedLabel!.toLowerCase());
 			});
 	}
 
@@ -342,9 +344,7 @@
 						{@const [firstPart, ...restParts] = option.option.label.split(' - ')}
 						{safeTranslate(firstPart)} - {restParts.join(' - ')}
 					{:else}
-						{@const translatedValue = safeTranslate(option.option.value)}
-						{@const translatedLabel = safeTranslate(option.option.label)}
-						{translatedValue !== option.option.value ? translatedValue : translatedLabel}
+						{option.option.translatedLabel}
 					{/if}
 				{:else}
 					{option.option.label || option.option}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved translation and display of option labels in the multi-select dropdown, ensuring more accurate and context-aware rendering for special and general cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->