### PR TITLE
refactor: Add flags to disable ModelTable crud actions from crud.ts

### DIFF
--- a/frontend/src/lib/components/DetailView/DetailView.svelte
+++ b/frontend/src/lib/components/DetailView/DetailView.svelte
@@ -549,10 +549,12 @@
 								(item) => item.urlModel === urlmodel
 							)}
 							{@const fieldsToUse = listViewFields[urlmodel].body.filter((v) => v !== field.field)}
-							{#if model.table && !model.disableAddDeleteButtons}
+							{#if model.table}
 								<ModelTable
 									baseEndpoint="/{model.urlModel}?{field.field}={data.data.id}"
 									source={model.table}
+									disableCreate={model.disableCreate}
+									disableDelete={model.disableDelete}
 									deleteForm={model.deleteForm}
 									URLModel={urlmodel}
 									fields={fieldsToUse}
@@ -567,13 +569,6 @@
 										>
 									{/snippet}
 								</ModelTable>
-							{:else if model.table}
-								<ModelTable
-									source={model.table}
-									URLModel={urlmodel}
-									baseEndpoint="/{model.urlModel}?{field.field}={data.data.id}"
-									fields={fieldsToUse}
-								/>
 							{/if}
 						{/key}
 					</Tabs.Panel>

--- a/frontend/src/lib/components/ModelTable/ModelTable.svelte
+++ b/frontend/src/lib/components/ModelTable/ModelTable.svelte
@@ -61,6 +61,10 @@
 		regionFoot?: string;
 		regionFootCell?: string;
 		displayActions?: boolean;
+		disableCreate?: boolean;
+		disableEdit?: boolean;
+		disableDelete?: boolean;
+		disableView?: boolean;
 		identifierField?: string;
 		deleteForm?: SuperValidated<AnyZodObject> | undefined;
 		URLModel?: urlModel | undefined;
@@ -102,6 +106,10 @@
 		regionFoot = '',
 		regionFootCell = '',
 		displayActions = true,
+		disableCreate = false,
+		disableEdit = false,
+		disableDelete = false,
+		disableView = false,
 		identifierField = 'id',
 		deleteForm = undefined,
 		URLModel = undefined,
@@ -388,7 +396,7 @@
 			{#if canSelectObject}
 				{@render selectButton?.()}
 			{/if}
-			{#if canCreateObject}
+			{#if canCreateObject && !disableCreate}
 				{@render addButton?.()}
 			{/if}
 		</div>
@@ -525,7 +533,7 @@
 											{@const actionsComponent = field_component_map[CUSTOM_ACTIONS_COMPONENT]}
 											{@const actionsURLModel = URLModel}
 											<TableRowActions
-												{deleteForm}
+												deleteForm={disableDelete ? null : deleteForm}
 												{model}
 												URLModel={actionsURLModel}
 												detailURL={`/${actionsURLModel}/${row.meta[identifierField]}${detailQueryParameter}`}
@@ -535,6 +543,8 @@
 												{row}
 												hasBody={actionsBody}
 												{identifierField}
+												{disableEdit}
+												{disableView}
 												preventDelete={preventDelete(row)}
 												preventEdit={preventEdit(row)}
 											>

--- a/frontend/src/lib/components/TableRowActions/TableRowActions.svelte
+++ b/frontend/src/lib/components/TableRowActions/TableRowActions.svelte
@@ -21,11 +21,13 @@
 
 	interface Props {
 		row: Record<string, any>;
-		model?: ModelMapEntry | undefined;
+		model?: ModelMapEntry;
 		detailURL: string;
-		editURL: string | undefined;
-		deleteForm: SuperValidated<AnyZodObject> | undefined;
-		URLModel: urlModel | string | undefined;
+		editURL?: string;
+		disableEdit?: boolean;
+		disableView?: boolean;
+		deleteForm?: SuperValidated<AnyZodObject> | null;
+		URLModel?: urlModel | string;
 		identifierField?: string;
 		preventDelete?: boolean;
 		preventEdit?: boolean;
@@ -41,7 +43,9 @@
 		model = undefined,
 		detailURL,
 		editURL,
-		deleteForm,
+		disableEdit = false,
+		disableView = false,
+		deleteForm = null,
 		URLModel,
 		identifierField = 'id',
 		preventDelete = false,
@@ -155,14 +159,15 @@
 				: false)
 	);
 
-	let displayDetail = $derived(detailURL);
+	let displayDetail = $derived(detailURL && !disableView);
 	let displayEdit = $derived(
 		canEditObject &&
+			!disableEdit &&
 			URLModel &&
 			!['frameworks', 'risk-matrices', 'ebios-rm'].includes(URLModel) &&
 			editURL
 	);
-	let displayDelete = $derived(canDeleteObject && deleteForm !== undefined);
+	let displayDelete = $derived(canDeleteObject && deleteForm !== null);
 </script>
 
 <span class={baseClass}>

--- a/frontend/src/lib/utils/crud.ts
+++ b/frontend/src/lib/utils/crud.ts
@@ -98,7 +98,8 @@ interface ForeignKeyField {
 	urlParams?: string;
 	detail?: boolean;
 	detailUrlParams?: string[]; // To prepare possible fetch for foreign keys with detail in generic views
-	disableAddDeleteButtons?: boolean;
+	disableCreate?: boolean;
+	disableDelete?: boolean;
 }
 
 interface Field {
@@ -282,11 +283,22 @@ export const URL_MODEL_MAP: ModelMap = {
 			{
 				field: 'applied_controls',
 				urlModel: 'requirement-assessments',
-				disableAddDeleteButtons: true
+				disableCreate: true,
+				disableDelete: true
 			},
-			{ field: 'applied_controls', urlModel: 'risk-scenarios', disableAddDeleteButtons: true },
-			{ field: 'applied_controls', urlModel: 'findings', disableAddDeleteButtons: true },
-			{ field: 'applied_controls', urlModel: 'assets', disableAddDeleteButtons: true }
+			{
+				field: 'applied_controls',
+				urlModel: 'risk-scenarios',
+				disableCreate: true,
+				disableDelete: true
+			},
+			{
+				field: 'applied_controls',
+				urlModel: 'findings',
+				disableCreate: true,
+				disableDelete: true
+			},
+			{ field: 'applied_controls', urlModel: 'assets', disableCreate: true, disableDelete: true }
 		],
 		selectFields: [
 			{ field: 'status' },
@@ -409,9 +421,14 @@ export const URL_MODEL_MAP: ModelMap = {
 		verboseName: 'Asset',
 		verboseNamePlural: 'Assets',
 		reverseForeignKeyFields: [
-			{ field: 'assets', urlModel: 'compliance-assessments', disableAddDeleteButtons: true },
-			{ field: 'assets', urlModel: 'vulnerabilities', disableAddDeleteButtons: false },
-			{ field: 'assets', urlModel: 'solutions', disableAddDeleteButtons: false }
+			{
+				field: 'assets',
+				urlModel: 'compliance-assessments',
+				disableCreate: true,
+				disableDelete: true
+			},
+			{ field: 'assets', urlModel: 'vulnerabilities' },
+			{ field: 'assets', urlModel: 'solutions' }
 		],
 		foreignKeyFields: [
 			{ field: 'parent_assets', urlModel: 'assets' },
@@ -501,11 +518,31 @@ export const URL_MODEL_MAP: ModelMap = {
 			{ field: 'findings_assessments', urlModel: 'findings-assessments' }
 		],
 		reverseForeignKeyFields: [
-			{ field: 'evidences', urlModel: 'applied-controls', disableAddDeleteButtons: true },
-			{ field: 'evidences', urlModel: 'compliance-assessments', disableAddDeleteButtons: true },
-			{ field: 'evidences', urlModel: 'requirement-assessments', disableAddDeleteButtons: true },
-			{ field: 'evidences', urlModel: 'findings-assessments', disableAddDeleteButtons: true },
-			{ field: 'evidences', urlModel: 'findings', disableAddDeleteButtons: true }
+			{
+				field: 'evidences',
+				urlModel: 'applied-controls',
+				disableCreate: true,
+				disableDelete: true
+			},
+			{
+				field: 'evidences',
+				urlModel: 'compliance-assessments',
+				disableCreate: true,
+				disableDelete: true
+			},
+			{
+				field: 'evidences',
+				urlModel: 'requirement-assessments',
+				disableCreate: true,
+				disableDelete: true
+			},
+			{
+				field: 'evidences',
+				urlModel: 'findings-assessments',
+				disableCreate: true,
+				disableDelete: true
+			},
+			{ field: 'evidences', urlModel: 'findings', disableCreate: true, disableDelete: true }
 		]
 	},
 	'compliance-assessments': {
@@ -1000,15 +1037,36 @@ export const URL_MODEL_MAP: ModelMap = {
 		],
 		selectFields: [{ field: 'severity', valueType: 'number' }, { field: 'status' }],
 		reverseForeignKeyFields: [
-			{ field: 'security_exceptions', urlModel: 'applied-controls', disableAddDeleteButtons: true },
-			{ field: 'security_exceptions', urlModel: 'assets', disableAddDeleteButtons: true },
-			{ field: 'security_exceptions', urlModel: 'vulnerabilities', disableAddDeleteButtons: true },
+			{
+				field: 'security_exceptions',
+				urlModel: 'applied-controls',
+				disableCreate: true,
+				disableDelete: true
+			},
+			{
+				field: 'security_exceptions',
+				urlModel: 'assets',
+				disableCreate: true,
+				disableDelete: true
+			},
+			{
+				field: 'security_exceptions',
+				urlModel: 'vulnerabilities',
+				disableCreate: true,
+				disableDelete: true
+			},
 			{
 				field: 'security_exceptions',
 				urlModel: 'requirement-assessments',
-				disableAddDeleteButtons: true
+				disableCreate: true,
+				disableDelete: true
 			},
-			{ field: 'security_exceptions', urlModel: 'risk-scenarios', disableAddDeleteButtons: true }
+			{
+				field: 'security_exceptions',
+				urlModel: 'risk-scenarios',
+				disableCreate: true,
+				disableDelete: true
+			}
 		]
 	},
 	'findings-assessments': {
@@ -1099,7 +1157,7 @@ export const URL_MODEL_MAP: ModelMap = {
 			{ field: 'findings_assessment', urlModel: 'findings-assessments' }
 		],
 		reverseForeignKeyFields: [
-			{ field: 'task_template', urlModel: 'task-nodes', disableAddDeleteButtons: true }
+			{ field: 'task_template', urlModel: 'task-nodes', disableCreate: true, disableDelete: true }
 		]
 	},
 	'task-nodes': {

--- a/frontend/src/lib/utils/load.ts
+++ b/frontend/src/lib/utils/load.ts
@@ -125,7 +125,8 @@ export const loadDetail = async ({ event, model, id }) => {
 					createForm,
 					selectOptions,
 					initialData,
-					disableAddDeleteButtons: e.disableAddDeleteButtons
+					disableCreate: e.disableCreate,
+					disableDelete: e.disableDelete
 				};
 			})
 		);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added granular controls to enable or disable create, edit, delete, and view actions for tables and related models in the interface.

- **Refactor**
  - Simplified and consolidated logic for rendering table actions, replacing a single disable flag with separate controls for create and delete actions.
  - Updated internal data structures to support the new action-specific disable flags.

- **Style**
  - Improved clarity and consistency in how action buttons are displayed based on the new controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->