### PR TITLE
fix: Add utf-8 filename support to fix crash during SecNumCloud audit export

### DIFF
--- a/frontend/src/lib/utils/actions.ts
+++ b/frontend/src/lib/utils/actions.ts
@@ -160,7 +160,7 @@ export async function defaultWriteFormAction({
 	};
 
 	if (urlModel == 'users') {
-		((flashParams.type = 'warning'), (flashParams.message += safeTranslate('userHasNoRights')));
+		(flashParams.type = 'warning'), (flashParams.message += safeTranslate('userHasNoRights'));
 	}
 	setFlash(flashParams, event);
 

--- a/frontend/src/lib/utils/actions.ts
+++ b/frontend/src/lib/utils/actions.ts
@@ -160,7 +160,7 @@ export async function defaultWriteFormAction({
 	};
 
 	if (urlModel == 'users') {
-		(flashParams.type = 'warning'), (flashParams.message += safeTranslate('userHasNoRights'));
+		((flashParams.type = 'warning'), (flashParams.message += safeTranslate('userHasNoRights')));
 	}
 	setFlash(flashParams, event);
 

--- a/frontend/src/routes/(app)/(internal)/compliance-assessments/[id=uuid]/export/+server.ts
+++ b/frontend/src/routes/(app)/(internal)/compliance-assessments/[id=uuid]/export/+server.ts
@@ -18,7 +18,7 @@ export const GET: RequestHandler = async ({ fetch, params }) => {
 	const originalFileName = `${compliance_assessment.name}-${
 		compliance_assessment.framework.str
 	}-${new Date().toISOString()}.zip`;
-	const sanitizedFilename = originalFileName.replace(/[^\x01-\x7F]/g, '');
+	const sanitizedFilename = originalFileName.replace(/[^\x01-\xFF]/g, '');
 
 	const blobData = await res.blob();
 	return new Response(blobData, {

--- a/frontend/src/routes/(app)/(internal)/compliance-assessments/[id=uuid]/export/+server.ts
+++ b/frontend/src/routes/(app)/(internal)/compliance-assessments/[id=uuid]/export/+server.ts
@@ -1,31 +1,54 @@
 import { BASE_API_URL } from '$lib/utils/constants';
-
 import { error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
+
+// Remove unsafe characters and normalize the filename (but keep Unicode letters)
+function sanitizeFileName(name: string): string {
+	return name
+		.normalize('NFKC') // Normalize Unicode
+		.replace(/[\x00-\x1F<>:"/\\|?*\u007F'`’‘“”()\[\]{}]/g, '-') // Remove dangerous characters
+		.replace(/\s+/g, '-')        // Replace whitespace with dash
+		.replace(/\.+$/g, '')        // Remove trailing dots
+		.replace(/^-+|-+$/g, '')     // Trim leading/trailing dashes
+		.replace(/-+/g, '-')         // Collapse multiple dashes
+		.substring(0, 100);          // Truncate to avoid overly long names
+}
+
+// Format date as YYYY-MM-DD_HH-MM-SS (safe and readable)
+function formatDateForFilename(date: Date = new Date()): string {
+	const pad = (n: number) => n.toString().padStart(2, '0');
+	return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}_${pad(date.getHours())}-${pad(date.getMinutes())}-${pad(date.getSeconds())}`;
+}
+
 export const GET: RequestHandler = async ({ fetch, params }) => {
 	const URLModel = 'compliance-assessments';
 	const endpoint = `${BASE_API_URL}/${URLModel}/${params.id}/export/`;
 
+	// Fetch the compliance assessment details
 	const compliance_assessment = await fetch(`${BASE_API_URL}/${URLModel}/${params.id}/`).then(
 		(res) => res.json()
 	);
 
-	const res = await fetch(endpoint);
-	if (!res.ok) {
-		error(400, 'Error fetching the ZIP file');
-	}
+	// Build and sanitize the filename
+	const namePart = `${compliance_assessment.name}-${compliance_assessment.framework.str}`;
+	const datePart = formatDateForFilename(); // e.g. 2025-06-26_16-45-12
+	const sanitizedName = sanitizeFileName(namePart);
+	const finalFileName = `${sanitizedName}-${datePart}.zip`;
+	const urlEncodedFileName = encodeURIComponent(finalFileName);
 
-	const originalFileName = `${compliance_assessment.name}-${
-		compliance_assessment.framework.str
-	}-${new Date().toISOString()}.zip`;
-	const fallbackFileName = originalFileName.replace(/[^\x01-\xFF]/g, '');
-	const urlEncodedFileName = encodeURIComponent(originalFileName);
+	// Fetch the ZIP blob
+	const blobData = await fetch(endpoint).then(res => {
+		if (!res.ok) {
+			throw error(400, 'Error fetching the ZIP file');
+		}
+		return res.blob();
+	});
 
-	const blobData = await res.blob();
+	// Return the file with proper headers
 	return new Response(blobData, {
 		headers: {
 			'Content-Type': 'application/zip',
-			'Content-Disposition': `attachment; filename*=utf-8''${urlEncodedFileName}; filename=fallback-ascii-name.txt; filename="${fallbackFileName}"`
+			'Content-Disposition': `attachment; filename*=utf-8''${urlEncodedFileName}; filename="${finalFileName}"`
 		}
 	});
 };

--- a/frontend/src/routes/(app)/(internal)/compliance-assessments/[id=uuid]/export/+server.ts
+++ b/frontend/src/routes/(app)/(internal)/compliance-assessments/[id=uuid]/export/+server.ts
@@ -18,13 +18,14 @@ export const GET: RequestHandler = async ({ fetch, params }) => {
 	const originalFileName = `${compliance_assessment.name}-${
 		compliance_assessment.framework.str
 	}-${new Date().toISOString()}.zip`;
-	const sanitizedFilename = originalFileName.replace(/[^\x01-\xFF]/g, '');
+	const fallbackFileName = originalFileName.replace(/[^\x01-\xFF]/g, '');
+	const urlEncodedFileName = encodeURIComponent(originalFileName);
 
 	const blobData = await res.blob();
 	return new Response(blobData, {
 		headers: {
 			'Content-Type': 'application/zip',
-			'Content-Disposition': `attachment; filename="${sanitizedFilename}"`
+			'Content-Disposition': `attachment; filename*=utf-8''${urlEncodedFileName}; filename=fallback-ascii-name.txt; filename="${fallbackFileName}"`
 		}
 	});
 };

--- a/frontend/src/routes/(app)/(internal)/compliance-assessments/[id=uuid]/export/+server.ts
+++ b/frontend/src/routes/(app)/(internal)/compliance-assessments/[id=uuid]/export/+server.ts
@@ -15,14 +15,16 @@ export const GET: RequestHandler = async ({ fetch, params }) => {
 		error(400, 'Error fetching the ZIP file');
 	}
 
-	const fileName = `${compliance_assessment.name}-${
+	const originalFileName = `${compliance_assessment.name}-${
 		compliance_assessment.framework.str
 	}-${new Date().toISOString()}.zip`;
+	const sanitizedFilename = originalFileName.replace(/[^\x01-\x7F]/g, '');
 
-	return new Response(await res.blob(), {
+	const blobData = await res.blob();
+	return new Response(blobData, {
 		headers: {
 			'Content-Type': 'application/zip',
-			'Content-Disposition': `attachment; filename="${fileName}"`
+			'Content-Disposition': `attachment; filename="${sanitizedFilename}"`
 		}
 	});
 };

--- a/frontend/src/routes/(app)/(internal)/compliance-assessments/[id=uuid]/export/+server.ts
+++ b/frontend/src/routes/(app)/(internal)/compliance-assessments/[id=uuid]/export/+server.ts
@@ -7,11 +7,11 @@ function sanitizeFileName(name: string): string {
 	return name
 		.normalize('NFKC') // Normalize Unicode
 		.replace(/[\x00-\x1F<>:"/\\|?*\u007F'`’‘“”()\[\]{}]/g, '-') // Remove dangerous characters
-		.replace(/\s+/g, '-')        // Replace whitespace with dash
-		.replace(/\.+$/g, '')        // Remove trailing dots
-		.replace(/^-+|-+$/g, '')     // Trim leading/trailing dashes
-		.replace(/-+/g, '-')         // Collapse multiple dashes
-		.substring(0, 100);          // Truncate to avoid overly long names
+		.replace(/\s+/g, '-') // Replace whitespace with dash
+		.replace(/\.+$/g, '') // Remove trailing dots
+		.replace(/^-+|-+$/g, '') // Trim leading/trailing dashes
+		.replace(/-+/g, '-') // Collapse multiple dashes
+		.substring(0, 100); // Truncate to avoid overly long names
 }
 
 // Format date as YYYY-MM-DD_HH-MM-SS (safe and readable)
@@ -37,7 +37,7 @@ export const GET: RequestHandler = async ({ fetch, params }) => {
 	const urlEncodedFileName = encodeURIComponent(finalFileName);
 
 	// Fetch the ZIP blob
-	const blobData = await fetch(endpoint).then(res => {
+	const blobData = await fetch(endpoint).then((res) => {
 		if (!res.ok) {
 			throw error(400, 'Error fetching the ZIP file');
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ZIP file export by sanitizing filenames to remove unsafe characters and limit length, ensuring better compatibility when downloading exported compliance assessments.
  * Enhanced filename encoding in export headers to support UTF-8 and ASCII fallbacks for improved download reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->