### PR TITLE
fix(tool): Update convert_library_v2.py

### DIFF
--- a/tools/convert_library_v2.py
+++ b/tools/convert_library_v2.py
@@ -750,7 +750,7 @@ def create_library(input_file: str, output_file: str, compat_mode: int = 0, verb
                             ref_id_urn = f"node{counter - counter_fix}-{counter_fix}"
                         else:
                             
-                            # Adds the ability to use the column "urn_id" column despite compatibility mode set to "1"
+                            # Adds the ability to use the "urn_id" column despite compatibility mode set to "1"
                             if data.get("urn_id") and data.get("urn_id").strip():
                                 ref_id_urn = data.get('urn_id').strip()
                             else:

--- a/tools/convert_library_v2.py
+++ b/tools/convert_library_v2.py
@@ -749,10 +749,16 @@ def create_library(input_file: str, output_file: str, compat_mode: int = 0, verb
                             counter_fix += 1
                             ref_id_urn = f"node{counter - counter_fix}-{counter_fix}"
                         else:
-                            ref_id_urn = ref_id.lower().replace(" ", "-") if ref_id else f"node{counter - counter_fix}"
+                            
+                            # Adds the ability to use the column "urn_id" column despite compatibility mode set to "1"
+                            if data.get("urn_id") and data.get("urn_id").strip():
+                                ref_id_urn = data.get('urn_id').strip()
+                            else:
+                                ref_id_urn = ref_id.lower().replace(" ", "-") if ref_id else f"node{counter - counter_fix}"
+                                
                         urn = f"{base_urn}:{ref_id_urn}"
                     else:                   # If compat mode = {0,2} 
-                        if data.get("urn_id"):
+                        if data.get("urn_id") and data.get("urn_id").strip():
                             urn = f"{base_urn}:{data.get('urn_id').strip()}"
                         elif ref_id:
                              # [+] Compat check
@@ -874,6 +880,20 @@ def create_library(input_file: str, output_file: str, compat_mode: int = 0, verb
                 source_node_id_raw = str(data.get("source_node_id", "")).strip()
                 target_node_id_raw = str(data.get("target_node_id", "")).strip()
                 
+                # Checks the required fields, cleaning the values first
+                required_fields = ["source_node_id", "target_node_id", "relationship"]
+                missing_fields = []
+
+                for field in required_fields:
+                    value = data.get(field)
+                    if value is None or str(value).strip() == "":
+                        missing_fields.append(field)
+
+                if missing_fields:
+                    quoted_fields = [f'"{field}"' for field in missing_fields]
+                    raise ValueError(f"(requirement_mapping_set) Missing or empty required field{'s' if len(missing_fields)>1 else ''} in row #{row[0].row}: {', '.join(quoted_fields)}")
+                
+                
                 # [+] Compat mode set to "2" so it can be compatible with every version of mappings >=v2 without having to choose a specific compat mode
                 source_node_id = clean_urn_suffix(source_node_id_raw, compat_mode=2)
                 target_node_id = clean_urn_suffix(target_node_id_raw, compat_mode=2)
@@ -984,7 +1004,9 @@ def create_library(input_file: str, output_file: str, compat_mode: int = 0, verb
 
     # Step 6: Export to YAML
     print(f"✅ YAML saved as: \"{output_file}\"")
-    print(f"💡 Tip: Use \"--verbose\" to display hidden messages. This can help to understand certain behaviors.")
+    if not verbose:
+        print(f"💡 Tip: Use \"--verbose\" to display hidden messages. This can help to understand certain behaviors.")
+
     with open(output_file, "w", encoding="utf-8") as f:
         yaml.dump(library, f, sort_keys=False, allow_unicode=False)
 


### PR DESCRIPTION
Added ability to use the `urn_id` column in compatibility mode 1 (Use legacy URN fallback logic (for requirements without ref_id)).

Updates from PR #2179 have also been transferred here, including:
- The script now checks if a mandatory field for mappings (`source_node_id`, `target_node_id` or `relationship`) is missing. If so, a readable error is raised.
- The tip printed at the end of the script about the `--verbose` option will no longer appear when `--verbose` has been used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of URN suffix generation, allowing more flexible use of the "urn_id" column in compatibility mode 1.
  * Enhanced validation for requirement mappings, ensuring required fields are present and non-empty.
* **User Experience**
  * Refined messaging for the `--verbose` flag, displaying tips only when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->