### PR TITLE
feat: keep both implementation and documentation scores on audit excel export

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -4179,6 +4179,7 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
             )
         audit = ComplianceAssessment.objects.get(id=pk)
         entries = []
+        show_documentation_score = audit.show_documentation_score
         for req in RequirementAssessment.objects.filter(compliance_assessment=pk):
             req_node = RequirementNode.objects.get(pk=req.requirement.id)
             entry = {
@@ -4189,9 +4190,13 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
                 "description": req_node.description,
                 "compliance_result": req.result,
                 "requirement_progress": req.status,
-                "score": req.score,
                 "observations": req.observation,
             }
+            if show_documentation_score:
+                entry["implementation_score"] = req.score
+                entry["documentation_score"] = req.documentation_score
+            else:
+                entry["score"] = req.score
             entries.append(entry)
 
         df = pd.DataFrame(entries)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Excel exports now display separate implementation and documentation scores when applicable.

* **Bug Fixes**
  * Improved accuracy of score representation in Excel exports based on audit settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->