### PR TITLE
fix: risk assessment duplication in separate domain

### DIFF
--- a/backend/core/helpers.py
+++ b/backend/core/helpers.py
@@ -1326,9 +1326,20 @@ def duplicate_related_objects(
         """
         Duplicate an object and link it to the duplicate object.
         """
-        new_obj.pk = None
-        new_obj.folder = target_folder
-        new_obj.save()
+        # Get the model of the object
+        model_class = new_obj.__class__
+
+        # Extract all fields except the primary key
+        field_values = {}
+        for field in new_obj._meta.fields:
+            if not field.primary_key and not field.auto_created:
+                field_values[field.name] = getattr(new_obj, field.name)
+
+        # Apply changes
+        field_values["folder"] = target_folder
+
+        # Create the new object
+        new_obj = model_class.objects.create(**field_values)
         link_existing_object(duplicate_object, new_obj, field_name)
 
     model_class = getattr(type(source_object), field_name).field.related_model

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1220,7 +1220,12 @@ class RiskAssessmentViewSet(BaseModelViewSet):
                     ref_id=scenario.ref_id,
                 )
 
-                for field in ["applied_controls", "threats", "assets"]:
+                for field in [
+                    "applied_controls",
+                    "threats",
+                    "assets",
+                    "existing_applied_controls",
+                ]:
                     duplicate_related_objects(
                         scenario,
                         duplicate_scenario,

--- a/frontend/src/lib/components/ModelTable/ModelTable.svelte
+++ b/frontend/src/lib/components/ModelTable/ModelTable.svelte
@@ -403,7 +403,7 @@
 		<thead class="table-head {regionHead}">
 			<tr>
 				{#each Object.entries(source.head) as [key, heading]}
-					{#if fields.length === 0 || fields.includes(heading)}
+					{#if fields.length === 0 || fields.includes(key)}
 						<Th {handler} orderBy={key} class={regionHeadCell}>{safeTranslate(heading)}</Th>
 					{/if}
 				{/each}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When duplicating a risk assessment, the "existing applied controls" related data is now also duplicated along with other related fields.

* **Bug Fixes**
  * Improved the duplication process for linked objects to ensure more accurate and reliable creation of duplicates.

* **Refactor**
  * Adjusted table column filtering logic to match columns by their key identifiers instead of translated heading text, ensuring consistent column display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->