### PR TITLE
feat: take description from reference control suggestion

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -4502,7 +4502,10 @@ class RequirementAssessment(AbstractBaseModel, FolderMixin, ETADueDateMixin):
                     reference_control=reference_control,
                     category=reference_control.category,
                 )
-                if reference_control.description and applied_control.description is None:
+                if (
+                    reference_control.description
+                    and applied_control.description is None
+                ):
                     applied_control.description = reference_control.description
                     applied_control.save()
                 if created:


### PR DESCRIPTION
When creating Applied controls from Reference controls in an audit, we should bring the reference description. This will fit in most cases and we'll be able to adapt/precise it if needed. This will avoid a lot of copying and pasting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that applied controls automatically inherit descriptions from their reference controls if no description is already set, improving consistency and completeness of information displayed to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->