### PR TITLE
fix: table mode topline

### DIFF
--- a/frontend/src/lib/utils/actions.ts
+++ b/frontend/src/lib/utils/actions.ts
@@ -160,7 +160,7 @@ export async function defaultWriteFormAction({
 	};
 
 	if (urlModel == 'users') {
-		((flashParams.type = 'warning'), (flashParams.message += safeTranslate('userHasNoRights')));
+		(flashParams.type = 'warning'), (flashParams.message += safeTranslate('userHasNoRights'));
 	}
 	setFlash(flashParams, event);
 

--- a/frontend/src/lib/utils/actions.ts
+++ b/frontend/src/lib/utils/actions.ts
@@ -160,7 +160,7 @@ export async function defaultWriteFormAction({
 	};
 
 	if (urlModel == 'users') {
-		(flashParams.type = 'warning'), (flashParams.message += safeTranslate('userHasNoRights'));
+		((flashParams.type = 'warning'), (flashParams.message += safeTranslate('userHasNoRights')));
 	}
 	setFlash(flashParams, event);
 

--- a/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/table-mode/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/table-mode/+page.svelte
@@ -285,17 +285,17 @@
 	<div
 		class="card px-6 py-4 bg-white flex flex-col justify-evenly shadow-lg w-full h-full space-y-2"
 	>
-		{#if !(questionnaireOnly ? hasQuestions : !hasQuestions)}
-			<div
-				class="sticky top-0 p-2 z-10 card bg-white items-center justify-evenly flex flex-row w-full"
+		<div
+			class="sticky top-0 p-2 z-10 card bg-white items-center justify-evenly flex flex-row w-full"
+		>
+			<a
+				href="/compliance-assessments/{complianceAssessment.id}"
+				class="flex items-center space-x-2 text-primary-800 hover:text-primary-600"
 			>
-				<a
-					href="/compliance-assessments/{complianceAssessment.id}"
-					class="flex items-center space-x-2 text-primary-800 hover:text-primary-600"
-				>
-					<i class="fa-solid fa-arrow-left"></i>
-					<p class="">{m.goBackToAudit()} {complianceAssessment.name}</p>
-				</a>
+				<i class="fa-solid fa-arrow-left"></i>
+				<p class="">{m.goBackToAudit()} {complianceAssessment.name}</p>
+			</a>
+			{#if !(questionnaireOnly ? hasQuestions : !hasQuestions)}
 				<div class="flex items-center justify-center space-x-4">
 					{#if questionnaireMode}
 						<p class="font-bold text-sm">{m.assessmentMode()}</p>
@@ -318,8 +318,8 @@
 						{/if}
 					</Switch>
 				</div>
-			</div>
-		{/if}
+			{/if}
+		</div>
 		{#each requirementAssessments as requirementAssessment, i}
 			<div class="w-2"></div>
 


### PR DESCRIPTION
keep line when no questions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The header is now always visible at the top of the compliance assessment table mode page, providing consistent navigation.
  * Added a back arrow and label linking to the compliance assessment overview.

* **Refactor**
  * The questionnaire mode toggle is now conditionally displayed within the header, improving layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->