### PR TITLE
feat(tool): prepare_mapping_v2.py

### DIFF
--- a/tools/prepare_mapping_v2.py
+++ b/tools/prepare_mapping_v2.py
@@ -1,0 +1,164 @@
+"""
+Prepare Mapping v2
+
+This script generates a mapping Excel file between two YAML-based frameworks
+used in CISO Assistant. It extracts relevant metadata from the source and target
+YAML files, builds a structured Excel workbook with mapping sheets, and saves it
+under a filename derived from the two frameworks' reference IDs.
+
+Usage:
+    python prepare_mapping.py source.yaml target.yaml
+"""
+
+
+import openpyxl
+import argparse
+import yaml
+
+
+def generate_mapping_excel(source_yaml, target_yaml):
+    packager = "intuitem"
+
+    print(f"⌛ Parsing \"{source_yaml}\" & \"{target_yaml}\"...")
+    # Load YAML files
+    with open(source_yaml, "r", encoding="utf-8") as file:
+        source = yaml.safe_load(file)
+    with open(target_yaml, "r", encoding="utf-8") as file:
+        target = yaml.safe_load(file)
+
+    # Extract metadata from source and target libraries and frameworks
+    source_library_urn = source["urn"]
+    target_library_urn = target["urn"]
+    source_framework = source["objects"]["framework"]
+    target_framework = target["objects"]["framework"]
+
+    source_framework_urn = source_framework["urn"]
+    target_framework_urn = target_framework["urn"]
+    source_framework_ref_id = source_framework["ref_id"]
+    target_framework_ref_id = target_framework["ref_id"]
+    source_framework_name = source_framework["name"]
+    target_framework_name = target_framework["name"]
+
+    source_ref_id = source_framework_urn.split(":")[-1]
+    target_ref_id = target_framework_urn.split(":")[-1]
+
+    # Generate common values used across sheets
+    ref_id = f"mapping-{source_ref_id}-and-{target_ref_id}"
+    name = f"{source_framework_ref_id} <-> {target_framework_ref_id}"
+    description = f"Mapping between {source_framework_name} and {target_framework_name}"
+    output_file_name = f"{ref_id}.xlsx"
+
+    library_urn = f"urn:{packager.lower()}:risk:library:{ref_id}"
+    mapping_urn = f"urn:{packager.lower()}:risk:req_mapping_set:{ref_id}"
+    source_node_base_urn = f"urn:{packager.lower()}:risk:req_node:{source_ref_id}"
+    target_node_base_urn = f"urn:{packager.lower()}:risk:req_node:{target_ref_id}"
+
+    # Create a new workbook and remove default sheet
+    wb_output = openpyxl.Workbook()
+    default_sheet = wb_output.active
+    wb_output.remove(default_sheet)
+
+    # === Sheet: library_meta ===
+    ws_meta = wb_output.create_sheet("library_meta")
+    ws_meta.append(["type", "library"])
+    ws_meta.append(["urn", library_urn])
+    ws_meta.append(["version", "1"])
+    ws_meta.append(["locale", source["locale"]])
+    ws_meta.append(["ref_id", ref_id])
+    ws_meta.append(["name", name])
+    ws_meta.append(["description", description])
+    ws_meta.append(["copyright", packager])
+    ws_meta.append(["provider", packager])
+    ws_meta.append(["packager", packager])
+    ws_meta.append(["dependencies", f"{source_library_urn}, {target_library_urn}"])
+
+    # === Sheet: mappings_meta ===
+    ws_map_meta = wb_output.create_sheet("mappings_meta")
+    ws_map_meta.append(["type", "requirement_mapping_set"])
+    ws_map_meta.append(["urn", mapping_urn])
+    ws_map_meta.append(["ref_id", ref_id])
+    ws_map_meta.append(["name", name])
+    ws_map_meta.append(["description", description])
+    ws_map_meta.append(["source_framework_urn", source_framework_urn])
+    ws_map_meta.append(["target_framework_urn", target_framework_urn])
+    ws_map_meta.append(["source_node_base_urn", source_node_base_urn])
+    ws_map_meta.append(["target_node_base_urn", target_node_base_urn])
+
+    # === Sheet: mappings_content (formerly "mappings") ===
+    ws_mappings = wb_output.create_sheet("mappings_content")
+    ws_mappings.append([
+        "source_node_id",
+        "target_node_id",
+        "relationship",
+        "rationale",
+        "strength_of_relationship",
+    ])
+    # Populate source node IDs for mapping rows (initially only source side filled)
+    for node in source_framework["requirement_nodes"]:
+        if node["assessable"]:
+            node_id = node["urn"].split(":")[-1]
+            ws_mappings.append([node_id])
+
+    # === Sheet: guidelines (instructions for mapping) ===
+    ws_guidelines = wb_output.create_sheet("guidelines")
+    ws_guidelines.append(["source_node_id", "use the last segment of the source URN"])
+    ws_guidelines.append(["target_node_id", "use the last segment of the target URN"])
+    ws_guidelines.append(["relationships", "use one of the following values"])
+    ws_guidelines.append(["", "subset"])
+    ws_guidelines.append(["", "intersect"])
+    ws_guidelines.append(["", "equal"])
+    ws_guidelines.append(["", "superset"])
+    ws_guidelines.append(["", "not_related"])
+    ws_guidelines.append(["rationale", "use one of the following values (or leave empty)"])
+    ws_guidelines.append(["", "syntactic"])
+    ws_guidelines.append(["", "semantic"])
+    ws_guidelines.append(["", "functional"])
+    ws_guidelines.append(["strength_of_relationship", "use an integer or empty value"])
+
+    # === Sheet: source (source framework requirements) ===
+    ws_source = wb_output.create_sheet("source")
+    ws_source.append(["node_id", "assessable", "urn", "ref_id", "name", "description"])
+    for node in source_framework["requirement_nodes"]:
+        node_id = node["urn"].split(":")[-1] if node["assessable"] else ""
+        ws_source.append([
+            node_id,
+            node["assessable"],
+            node["urn"],
+            node.get("ref_id"),
+            node.get("name"),
+            node.get("description"),
+        ])
+
+    # === Sheet: target (target framework requirements) ===
+    ws_target = wb_output.create_sheet("target")
+    ws_target.append(["node_id", "assessable", "urn", "ref_id", "name", "description"])
+    for node in target_framework["requirement_nodes"]:
+        node_id = node["urn"].split(":")[-1] if node["assessable"] else ""
+        ws_target.append([
+            node_id,
+            node["assessable"],
+            node["urn"],
+            node.get("ref_id"),
+            node.get("name"),
+            node.get("description"),
+        ])
+
+    # Save the workbook to disk
+    wb_output.save(output_file_name)
+    print(f"✅ Excel file created successfully: \"{output_file_name}\"")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="prepare_mapping.py",
+        description="Prepare a mapping Excel file for CISO Assistant",
+    )
+    parser.add_argument("source_yaml", help="Source YAML file")
+    parser.add_argument("target_yaml", help="Target YAML file")
+    args = parser.parse_args()
+
+    generate_mapping_excel(args.source_yaml, args.target_yaml)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/prepare_mapping_v2.py
+++ b/tools/prepare_mapping_v2.py
@@ -7,7 +7,7 @@ YAML files, builds a structured Excel workbook with mapping sheets, and saves it
 under a filename derived from the two frameworks' reference IDs.
 
 Usage:
-    python prepare_mapping.py source.yaml target.yaml
+    python prepare_mapping_v2.py source.yaml target.yaml
 """
 
 
@@ -41,6 +41,8 @@ def load_and_validate_yaml(path, label):
         raise KeyError(f"{label} file is missing the \"urn\" field.")
     if "objects" not in data or "framework" not in data["objects"]:
         raise KeyError(f"{label} file is missing the \"objects.framework\" structure.")
+    if "locale" not in data:
+        raise KeyError(f'{label} file is missing the "locale" field.')
 
     return data
 
@@ -183,7 +185,7 @@ def generate_mapping_excel(source_yaml, target_yaml):
 
 def main():
 
-    parser = argparse.ArgumentParser(prog="prepare_mapping.py", description="Prepare a mapping Excel file for CISO Assistant")
+    parser = argparse.ArgumentParser(prog="prepare_mapping_v2.py", description="Prepare a mapping Excel file for CISO Assistant")
     parser.add_argument("source_yaml", help="Source YAML file")
     parser.add_argument("target_yaml", help="Target YAML file")
     args = parser.parse_args()

--- a/tools/prepare_mapping_v2.py
+++ b/tools/prepare_mapping_v2.py
@@ -183,10 +183,7 @@ def generate_mapping_excel(source_yaml, target_yaml):
 
 def main():
 
-    parser = argparse.ArgumentParser(
-        prog="prepare_mapping.py",
-        description="Prepare a mapping Excel file for CISO Assistant",
-    )
+    parser = argparse.ArgumentParser(prog="prepare_mapping.py", description="Prepare a mapping Excel file for CISO Assistant")
     parser.add_argument("source_yaml", help="Source YAML file")
     parser.add_argument("target_yaml", help="Target YAML file")
     args = parser.parse_args()

--- a/tools/prepare_mapping_v2.py
+++ b/tools/prepare_mapping_v2.py
@@ -127,7 +127,7 @@ def generate_mapping_excel(source_yaml, target_yaml):
     # Populate source node IDs for mapping rows (initially only source side filled)
     for node in source_framework["requirement_nodes"]:
         if node["assessable"]:
-            node_id = node["urn"].split(":")[-1]
+            node_id = node["urn"].split(source_node_base_urn + ":")[-1]
             ws_mappings.append([node_id])
 
     # === Sheet: guidelines (instructions for mapping) ===
@@ -150,7 +150,7 @@ def generate_mapping_excel(source_yaml, target_yaml):
     ws_source = wb_output.create_sheet("source")
     ws_source.append(["node_id", "assessable", "urn", "ref_id", "name", "description"])
     for node in source_framework["requirement_nodes"]:
-        node_id = node["urn"].split(":")[-1] if node["assessable"] else ""
+        node_id = node["urn"].split(source_node_base_urn + ":")[-1] if node["assessable"] else ""
         ws_source.append([
             node_id,
             node["assessable"],
@@ -164,7 +164,7 @@ def generate_mapping_excel(source_yaml, target_yaml):
     ws_target = wb_output.create_sheet("target")
     ws_target.append(["node_id", "assessable", "urn", "ref_id", "name", "description"])
     for node in target_framework["requirement_nodes"]:
-        node_id = node["urn"].split(":")[-1] if node["assessable"] else ""
+        node_id = node["urn"].split(target_node_base_urn + ":")[-1] if node["assessable"] else ""
         ws_target.append([
             node_id,
             node["assessable"],


### PR DESCRIPTION
## Script
Works exactly like `prepare_mapping_v1.py`, except that it uses the v2 library format for the output Excel file.
It also has an error handling system and better code structuring than v1.

## Update
In v1, there was an issue when the URN ID was longer than the usual `node_base_urn:node_id` format. In fact, when we had nested requirements and the nested requirement didn't have a `ref_id`, the algorith making the URN (in `convert_library.py`) for the node would take the `node_base_urn`, followed by the node ID one level higher than the current one, with a number at the end to identify the node.
We could have something like this for exmaple :
```
node_base_urn:previous_node_id:1
```

The problem here is that v1 of `prepare_mapping.py` was taking the very last bit of the URN after the last `:` as the correct node ID, whereas it's completely wrong. Taking the last part of the URN in the example (here `1`) would mean that we're referring to the URN `node_base_urn:1` and not the actual URN `node_base_urn:previous_node_id:1`.

To fix this issue, the URN is now split at `target_node_base_urn:` and we take the last part of the split URN.
This way, the node ID to be used for mapping will be `previous_node_id:1` instead of `1`.

This problem occured when I wanted to make a mapping with NIS2 (requirement `12.5.1` had the node ID `12.5:1`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a command-line tool to generate an Excel mapping file between two YAML-based frameworks.
  * The generated Excel file includes metadata, mapping templates, guidelines, and detailed sheets for both source and target frameworks.
  * Provides clear error messages for invalid input files and confirms successful file creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->