### PR TITLE
fix(doc): add procedure to control category

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -152,7 +152,7 @@ The _content tab for a "reference_controls" object contains the following column
 - ref_id (*)
 - name
 - description
-- category: one among policy/process/technical/physical
+- category: one among policy/process/technical/physical/procedure
 - csf_function: one among govern/identify/protect/detect/respond/recover
 - annotation
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to include "procedure" as an allowed value for the "category" column in the "_content" tab of reference controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->