### PR TITLE
fix: translatedLabel on AutocompleteSelect

### DIFF
--- a/frontend/src/lib/components/Forms/AutocompleteSelect.svelte
+++ b/frontend/src/lib/components/Forms/AutocompleteSelect.svelte
@@ -91,7 +91,12 @@
 		options = options.map((option) => {
 			return {
 				...option,
-				translatedLabel: safeTranslate(option.label)
+				translatedLabel:
+					safeTranslate(option.label) !== option.label
+						? safeTranslate(option.label)
+						: safeTranslate(option.value) !== option.value
+							? safeTranslate(option.value)
+							: option.label
 			};
 		});
 	}

--- a/frontend/src/lib/components/Forms/AutocompleteSelect.svelte
+++ b/frontend/src/lib/components/Forms/AutocompleteSelect.svelte
@@ -87,6 +87,15 @@
 		mount = () => null
 	}: Props = $props();
 
+	if (translateOptions) {
+		options = options.map((option) => {
+			return {
+				...option,
+				translatedLabel: safeTranslate(option.label)
+			};
+		});
+	}
+
 	let optionHashmap: Record<string, Option> = {};
 	let _disabled = $state(disabled);
 

--- a/frontend/src/lib/components/Forms/ModelForm/ProcessingForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/ProcessingForm.svelte
@@ -54,7 +54,6 @@
 	options={model.selectOptions['legal_basis']}
 	cacheLock={cacheLocks['legal_basis']}
 	bind:cachedValue={formDataCache['legal_basis']}
-	translateOptions={true}
 	label={m.legalBasis()}
 />
 <AutocompleteSelect

--- a/frontend/src/routes/(app)/(internal)/risk-scenarios/[id=uuid]/edit/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/risk-scenarios/[id=uuid]/edit/+page.svelte
@@ -112,13 +112,6 @@
 		(probability) => probability.hexcolor
 	);
 	const impactColorMap = data.riskMatrix.impact.map((impact) => impact.hexcolor);
-
-	const translatedQualificationChoices = data.qualificationChoices.map((choice) => {
-		return {
-			...choice,
-			translatedLabel: safeTranslate(choice.label)
-		};
-	});
 </script>
 
 <div>
@@ -376,7 +369,7 @@
 				<div class="w-1/2">
 					<AutocompleteSelect
 						form={_form}
-						options={translatedQualificationChoices}
+						options={data.qualificationChoices}
 						multiple={true}
 						field="qualifications"
 						label={m.qualification()}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined translation handling for select options in forms by using original option labels directly.
* **Chores**
  * Simplified form components by removing redundant translation properties and intermediate translated option arrays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->