### PR TITLE
feat: select implementation groups at campaign creation

### DIFF
--- a/frontend/src/lib/components/Forms/ModelForm/CampaignForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/CampaignForm.svelte
@@ -62,7 +62,7 @@
 	onChange={async (e) => handleFrameworkChange(e)}
 	mount={async (e) => handleFrameworkChange(e)}
 />
-{#if implementationGroupsChoices.length > 0 && !initialData.frameworks}
+{#if implementationGroupsChoices.length > 0}
 	<AutocompleteSelect
 		multiple
 		translateOptions={false}
@@ -72,6 +72,7 @@
 		cacheLock={cacheLocks['selected_implementation_groups']}
 		bind:cachedValue={formDataCache['selected_implementation_groups']}
 		label={m.selectedImplementationGroups()}
+		hidden={initialData.frameworks}
 	/>
 {/if}
 <AutocompleteSelect


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the visibility logic for the implementation groups selection field to improve consistency with other form fields. Visibility is now managed internally rather than through conditional rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->