### PR TITLE
feat(tool): convert_framework_yaml_to_excel.py

### DIFF
--- a/tools/misc/convert_framework_yaml_to_excel.py
+++ b/tools/misc/convert_framework_yaml_to_excel.py
@@ -1,4 +1,6 @@
 """
+YAML to Excel Framework Converter v0.3
+
 Script to recreate a structured Excel (V2 format) from a given YAML file.
 
 Usage:
@@ -26,11 +28,31 @@ Example:
 """
 
 
+SCRIPT_VERSION = '0.3'
+
 
 import argparse
 import os
 import yaml
 from openpyxl import Workbook
+from openpyxl.styles import Font
+
+
+
+def write_info_sheet(wb, yaml_path):
+    
+    ws_info = wb.create_sheet("info", 0)  # Insert at first position
+
+    yaml_filename = os.path.basename(yaml_path)
+
+    ws_info["A1"] = f"YAML to Excel Framework Converter v{SCRIPT_VERSION}"
+    ws_info["A1"].font = Font(size=48, bold=True)
+
+    ws_info["A2"] = f"Source file : {yaml_filename}"
+    ws_info["A2"].font = Font(size=15)
+
+    ws_info["A3"] = ('Please verify and potentially adjust this Excel before using it as input to "convert_library_v2.py".')
+    ws_info["A3"].font = Font(size=20, italic=True)
 
 
 
@@ -263,9 +285,12 @@ def recreate_excel_from_yaml(yaml_path, output_excel_path):
 
     wb = Workbook()
     wb.remove(wb.active)  # Remove default sheet
+    
+    # --- [Info Sheet] ---
+    write_info_sheet(wb, yaml_path)
 
     # --- [First Sheet] library_meta ---
-    library_meta_ws = wb.create_sheet(title="library_meta", index=0)
+    library_meta_ws = wb.create_sheet(title="library_meta")
     library_meta_ws.append(["type", "library"])
 
     translations_block = data.get("translations", {})

--- a/tools/misc/convert_framework_yaml_to_excel.py
+++ b/tools/misc/convert_framework_yaml_to_excel.py
@@ -96,12 +96,37 @@ def convert_list_fields_to_string(row, obj, fields):
 
 
 
+def calculate_base_urn(items):
+    if len(items) < 2:
+        return "???"
+
+    urn1 = items[0].get("urn", "")
+    urn2 = items[1].get("urn", "")
+
+    # Find common prefix by parts (split by ':')
+    parts1 = urn1.split(":")
+    parts2 = urn2.split(":")
+
+    common_parts = []
+    for p1, p2 in zip(parts1, parts2):
+        if p1 == p2:
+            common_parts.append(p1)
+        else:
+            break
+
+    return ":".join(common_parts) if common_parts else "???"
+
+
+
 def process_reference_controls(wb, ref_controls):
+
+    # Calculate base_urn
+    base_urn = calculate_base_urn(ref_controls)
 
     # Create the meta sheet
     ref_cont_meta_ws = wb.create_sheet(title="reference_controls_meta")
     ref_cont_meta_ws.append(["type", "reference_controls"])
-    ref_cont_meta_ws.append(["base_urn", "???"])
+    ref_cont_meta_ws.append(["base_urn", str(base_urn)])
 
     # Define base columns
     headers = ["ref_id", "name", "csf_function", "category", "description", "annotation"]
@@ -127,11 +152,14 @@ def process_reference_controls(wb, ref_controls):
 
 
 def process_threats(wb, threats):
+    
+    # Calculate base_urn
+    base_urn = calculate_base_urn(threats)
 
     # Create the meta sheet
     threats_meta_ws = wb.create_sheet(title="threats_meta")
     threats_meta_ws.append(["type", "threats"])
-    threats_meta_ws.append(["base_urn", "???"])
+    threats_meta_ws.append(["base_urn", str(base_urn)])
 
     # Define base columns
     headers = ["ref_id", "name", "description", "annotation"]

--- a/tools/misc/convert_framework_yaml_to_excel.py
+++ b/tools/misc/convert_framework_yaml_to_excel.py
@@ -364,7 +364,7 @@ def recreate_excel_from_yaml(yaml_path, output_excel_path):
                 write_sheet(answers_content_ws, headers, rows)
 
 
-            # --- (optional) [SHEETS] implementation_groups_meta & implementation_groups_content ---
+            # --- [SHEETS] implementation_groups_meta & implementation_groups_content ---
             if ig_defs:
                 ig_meta_ws = wb.create_sheet(title="implementation_groups_meta")
                 ig_meta_ws.append(["type", "implementation_groups"])
@@ -379,7 +379,7 @@ def recreate_excel_from_yaml(yaml_path, output_excel_path):
                     write_sheet(ig_content_ws, ig_headers, ig_content_rows)
 
    
-            # --- (optional) [SHEETS] scores_meta & scores_content ---
+            # --- [SHEETS] scores_meta & scores_content ---
             if scores_def:
                 scores_meta_ws = wb.create_sheet(title="scores_meta")
                 scores_meta_ws.append(["type", "scores"])
@@ -393,9 +393,11 @@ def recreate_excel_from_yaml(yaml_path, output_excel_path):
                     scores_headers = list(scores_content_rows[0].keys())
                     write_sheet(scores_content_ws, scores_headers, scores_content_rows)
 
+        # --- [SHEETS] reference_controls_meta & reference_controls_content ---
         elif obj_key == "reference_controls":
             process_reference_controls(wb, obj_value)
 
+        # --- [SHEETS] threats_meta & threats_content ---
         elif obj_key == "threats":
             process_threats(wb, obj_value)
 
@@ -409,6 +411,7 @@ def recreate_excel_from_yaml(yaml_path, output_excel_path):
                 if "levels" in matrix:
                     levels_ws = wb.create_sheet(sheetname.replace("_meta", "_levels"))
                     write_sheet(levels_ws, list(matrix["levels"][0].keys()), matrix["levels"])
+
 
     # Try saving the workbook, raise error on failure
     try:

--- a/tools/misc/convert_framework_yaml_to_excel.py
+++ b/tools/misc/convert_framework_yaml_to_excel.py
@@ -4,7 +4,7 @@ YAML to Excel Framework Converter v0.3
 Script to recreate a structured Excel (V2 format) from a given YAML file.
 
 Usage:
-    python recreate_excel_from_yaml.py input.yaml [output.xlsx]
+    python convert_framework_yaml_to_excel.py input.yaml [output.xlsx]
 
 Arguments:
     input.yaml       Path to the input YAML file containing the data.
@@ -30,9 +30,12 @@ Limitations:
 Info:
     If you are trying to convert a mapping YAML file to Excel, please use the script
     "convert_mapping_yaml_to_excel.py" instead.
+    
+Requirements:
+    Python 3.9 or higher (uses str.removeprefix)
 
 Example:
-    python recreate_excel_from_yaml.py my_data.yaml
+    python convert_framework_yaml_to_excel.py my_data.yaml
 """
 
 

--- a/tools/misc/convert_framework_yaml_to_excel.py
+++ b/tools/misc/convert_framework_yaml_to_excel.py
@@ -209,8 +209,14 @@ def recreate_excel_from_yaml(yaml_path, output_excel_path):
     for k, v in data.items():
         if k == "objects":
             break
-        if not isinstance(v, (list, dict)):
+        
+        if k == "dependencies":
+            deps_str = ", ".join(str(dep) for dep in v)
+            library_meta_ws.append([k, deps_str])
+            
+        elif not isinstance(v, (list, dict)):
             library_meta_ws.append([k, v])
+
 
     write_translation_rows(library_meta_ws, translations_block, fields=("name", "description", "copyright"))
 
@@ -220,7 +226,7 @@ def recreate_excel_from_yaml(yaml_path, output_excel_path):
 
         if obj_key == "framework":
             
-             # --- [SHEET] framework_meta ---
+             # --- [Sheet] framework_meta ---
             meta_data = obj_value.copy()
             content = meta_data.pop("requirement_nodes", [])
             if "implementation_groups_definition" in meta_data:
@@ -257,7 +263,7 @@ def recreate_excel_from_yaml(yaml_path, output_excel_path):
                 meta_ws.append(["scores_definition", "scores"])
 
 
-            # --- [SHEET] framework_content ---
+            # --- [Sheet] framework_content ---
             content_ws = wb.create_sheet(title="framework_content")
             headers = [
                 "assessable", "depth", "ref_id", "urn_id", "name", "description",
@@ -350,7 +356,7 @@ def recreate_excel_from_yaml(yaml_path, output_excel_path):
             remove_empty_columns(content_ws)
 
             if answer_definitions:
-                meta_ws.append(["scores_definition", "scores"])
+                meta_ws.append(["answers_definition", "answers"])
                 answer_meta_ws = wb.create_sheet(title="answers_meta")
                 answer_meta_ws.append(["type", "answers"])
                 answer_meta_ws.append(["name", "answers"])
@@ -364,7 +370,7 @@ def recreate_excel_from_yaml(yaml_path, output_excel_path):
                 write_sheet(answers_content_ws, headers, rows)
 
 
-            # --- [SHEETS] implementation_groups_meta & implementation_groups_content ---
+            # --- [Sheets] implementation_groups_meta & implementation_groups_content ---
             if ig_defs:
                 ig_meta_ws = wb.create_sheet(title="implementation_groups_meta")
                 ig_meta_ws.append(["type", "implementation_groups"])
@@ -379,7 +385,7 @@ def recreate_excel_from_yaml(yaml_path, output_excel_path):
                     write_sheet(ig_content_ws, ig_headers, ig_content_rows)
 
    
-            # --- [SHEETS] scores_meta & scores_content ---
+            # --- [Sheets] scores_meta & scores_content ---
             if scores_def:
                 scores_meta_ws = wb.create_sheet(title="scores_meta")
                 scores_meta_ws.append(["type", "scores"])
@@ -393,11 +399,11 @@ def recreate_excel_from_yaml(yaml_path, output_excel_path):
                     scores_headers = list(scores_content_rows[0].keys())
                     write_sheet(scores_content_ws, scores_headers, scores_content_rows)
 
-        # --- [SHEETS] reference_controls_meta & reference_controls_content ---
+        # --- [Sheets] reference_controls_meta & reference_controls_content ---
         elif obj_key == "reference_controls":
             process_reference_controls(wb, obj_value)
 
-        # --- [SHEETS] threats_meta & threats_content ---
+        # --- [Sheets] threats_meta & threats_content ---
         elif obj_key == "threats":
             process_threats(wb, obj_value)
 

--- a/tools/misc/convert_framework_yaml_to_excel.py
+++ b/tools/misc/convert_framework_yaml_to_excel.py
@@ -14,8 +14,8 @@ Description:
     and reconstructs the original Excel file structure with multiple sheets such as
     'library_meta', 'framework_meta', 'framework_content', and others.
 
-    It handles special cases like answer definitions, implementation groups,
-    scores, and risk matrices, replicating the structure expected in the V2 Excel format.
+    It handles the following cases: framework, answers, implementation groups,
+    scores, threats and reference controls replicating the structure expected in the V2 Excel format.
 
 WARNING:
     The generated Excel file should be carefully verified before being used again
@@ -285,8 +285,16 @@ def recreate_excel_from_yaml(yaml_path, output_excel_path):
     write_translation_rows(library_meta_ws, translations_block, fields=("name", "description", "copyright"))
 
     for obj_key, obj_value in data.get("objects", {}).items():
-        if obj_key == "requirement_mapping_sets":
-            continue
+        
+        # --- [WARNING] Risk Matrices ---
+        if obj_key == "risk_matrix":
+            print("⚠️  [WARNING] This script can't handle risk matrices")
+        
+        # --- [WARNING] Mappings --- 
+        if obj_key == "requirement_mapping_sets" or obj_key == "requirement_mapping_set":
+            print("⚠️  [WARNING] This script can't handle mappings")
+            print('💡 Tip: Use "convert_mapping_yaml_to_excel.py" to convert a YAML mapping into an Excel mapping')
+    
 
         if obj_key == "framework":
             
@@ -426,17 +434,6 @@ def recreate_excel_from_yaml(yaml_path, output_excel_path):
         # --- [Sheets] threats_meta & threats_content ---
         elif obj_key == "threats":
             process_threats(wb, obj_value)
-
-        elif obj_key == "risk_matrix":
-            for i, matrix in enumerate(obj_value):
-                sheetname = f"risk_matrix_meta_{i+1}" if len(obj_value) > 1 else "risk_matrix_meta"
-                ws = wb.create_sheet(sheetname)
-                meta_rows = [{"key": k, "value": v} for k, v in matrix.items() if not isinstance(v, list)]
-                write_sheet(ws, ["key", "value"], meta_rows)
-
-                if "levels" in matrix:
-                    levels_ws = wb.create_sheet(sheetname.replace("_meta", "_levels"))
-                    write_sheet(levels_ws, list(matrix["levels"][0].keys()), matrix["levels"])
 
 
     # Try saving the workbook, raise error on failure

--- a/tools/misc/convert_framework_yaml_to_excel.py
+++ b/tools/misc/convert_framework_yaml_to_excel.py
@@ -17,11 +17,19 @@ Description:
     'library_meta', 'framework_meta', 'framework_content', and others.
 
     It handles the following cases: framework, answers, implementation groups,
-    scores, threats and reference controls replicating the structure expected in the V2 Excel format.
+    scores, threats and reference controls, replicating the structure expected in the V2 Excel format.
 
 WARNING:
-    The generated Excel file should be carefully verified before being used again
-    as input for "convert_library_v2.py" to ensure data integrity and compatibility.
+    The generated Excel file is not guaranteed to be directly compatible with
+    "convert_library_v2.py". Manual adjustments and verification may be required
+    to ensure correctness and compatibility.
+
+Limitations:
+    This script does not recreate the "urn_prefix" sheet nor any risk matrices.
+
+Info:
+    If you are trying to convert a mapping YAML file to Excel, please use the script
+    "convert_mapping_yaml_to_excel.py" instead.
 
 Example:
     python recreate_excel_from_yaml.py my_data.yaml


### PR DESCRIPTION
## Script
The `convert_framework_yaml_to_excel.py` script can perform a YAML to Excel conversion of a CISO Assistant Framework.

It can recreate the following sheets:
- `library_meta`
- `framework_meta`, `framework_content`
- `answers_meta`, `answers_content`
- `implementation_groups_meta`, `implementation_groups_content`
- `scores_meta`, `scores_content`
- `reference_controls_meta`, `reference_controls_content`
- `threats_meta`, `threats_content`

It can also recreate translations for the following sheets :
- `library_meta`
- `framework_meta`, `framework_content`
- `implementation_groups_content`
-  `scores_content`
- `reference_controls_content`
- `threats_content`

See the script docstring for more information.

## Notes
- The generated Excel file is not guaranteed to be directly compatible with `convert_library_v2.py`. Manual adjustments and verification may be required to ensure correctness and compatibility.
- This script does not recreate the `urn_prefix` sheet nor any risk matrices.
- To convert a YAML mapping file to Excel, use the `convert_mapping_yaml_to_excel.py` script.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tool to convert structured YAML framework files into multi-sheet Excel workbooks.
  * Supports detailed extraction of metadata, content, translations, and framework components into dedicated sheets.
  * Includes a user-friendly command-line interface with progress and error notifications.
  * Enhances Excel output by handling language translations and removing empty columns.
  * Improves reliability with comprehensive error handling for file and YAML parsing issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->