### PR TITLE
test: add 3s timeout before switching back to english

### DIFF
--- a/frontend/tests/functional/nav.test.ts
+++ b/frontend/tests/functional/nav.test.ts
@@ -82,6 +82,7 @@ test('switching locale works properly', async ({ logedPage, analyticsPage, sideB
 			await sideBar.languageSelect.selectOption(locale);
 			await logedPage.hasTitle(m.analytics({}, { locale }));
 		}
+		await page.waitForTimeout(3000);
 		await sideBar.moreButton.click();
 		await expect(sideBar.morePanel).not.toHaveAttribute('inert');
 		await expect(sideBar.languageSelect).toBeVisible();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a 3-second wait after switching locales in the navigation test to improve test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->