### PR TITLE
build(ci): cancel workflow that becomes obsolete after a new commit is pushed in an open PR

### DIFF
--- a/.github/workflows/backend-coverage.yaml
+++ b/.github/workflows/backend-coverage.yaml
@@ -6,6 +6,10 @@ on:
     branches: ["main"]
     paths:
       - "backend/**"
+# If two events are triggered within a short time in the same PR, cancel the run of the oldest event
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 env:
   GITHUB_WORKFLOW: github_actions
   POSTGRES_VERSION: "16"

--- a/.github/workflows/backend-linters.yaml
+++ b/.github/workflows/backend-linters.yaml
@@ -7,6 +7,11 @@ on:
     paths:
       - "backend/**"
 
+# If two events are triggered within a short time in the same PR, cancel the run of the oldest event
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 env:
   GITHUB_WORKFLOW: github_actions
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/frontend-linters.yaml
+++ b/.github/workflows/frontend-linters.yaml
@@ -7,6 +7,11 @@ on:
     paths:
       - "frontend/**"
 
+# If two events are triggered within a short time in the same PR, cancel the run of the oldest event
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 env:
   GITHUB_WORKFLOW: github_actions
   UBUNTU_VERSION: "ubuntu-24.04"


### PR DESCRIPTION
### Change Summary
Currently, if a PR is open and a push happens, the **Backend code coverage** workflow will start running. If, shortly after a subsequent push on the *same* PR happens, the workflow will start running again without cancelling the previous (now obsolete) run. With these changes, the first run would be cancelled, thus **saving compute resources** (see below for quantity) that can be used to **speed up your overall CI/CD**, without sacrificing functionality, since the second run will contain the changes from the first push as well. 🌱

### Example
Here is an example of the behaviour described above: the commit `d876874` triggered [this](https://github.com/intuitem/ciso-assistant-community/actions/runs/9601536159/) workflow run, and shortly after the commit `ce324d0`, that happened on top of the first commit, triggered [this](https://github.com/intuitem/ciso-assistant-community/actions/runs/9601556247/) workflow. Both workflows ran till the end, spending 3 and 9 CPU minutes respectively. With the proposed changes, the first run would be cancelled, hence saving ~3 CPU minutes and clearing the queue for other workflows. Note that this is an example of a single concurrent run; the accumulated gain for all PRs would be higher, with a lower estimate at **2 CPU hours** over the last few months.

The same holds for these workflow(s) as well: Backend Linters, Frontend Linters.

### Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on energy optimizations in GitHub Actions workflows.

Kindly let us know (here or in the email below) if you would like more details, if you want to reject the proposed changes for other reasons, or if you have any question whatsoever.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)
konstantinos.kitsios@uzh.ch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved GitHub Actions workflows for backend coverage, backend linters, and frontend linters by adding concurrency controls to automatically cancel older runs when newer ones are triggered on the same pull request. This ensures only the latest workflow run is active per PR.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->