### PR TITLE
[CI]: Add custom timeout to jobs to prevent stuck runs earlier

### DIFF
--- a/.github/workflows/startup-tests.yml
+++ b/.github/workflows/startup-tests.yml
@@ -109,6 +109,7 @@ jobs:
 
   startup-docker-compose-test:
     runs-on: ubuntu-24.04
+    timeout-minutes: 19
     env:
       COMPOSE_TEST: True
     steps:
@@ -151,6 +152,7 @@ jobs:
 
   enterprise-startup-functional-test:
     runs-on: ubuntu-24.04
+    timeout-minutes: 22
     env:
       LOG_LEVEL: DEBUG
       LOG_OUTFILE: ciso-assistant.log

--- a/.github/workflows/startup-tests.yml
+++ b/.github/workflows/startup-tests.yml
@@ -109,7 +109,7 @@ jobs:
 
   startup-docker-compose-test:
     runs-on: ubuntu-24.04
-    timeout-minutes: 19
+    timeout-minutes: 22
     env:
       COMPOSE_TEST: True
     steps:
@@ -152,7 +152,7 @@ jobs:
 
   enterprise-startup-functional-test:
     runs-on: ubuntu-24.04
-    timeout-minutes: 22
+    timeout-minutes: 19
     env:
       LOG_LEVEL: DEBUG
       LOG_OUTFILE: ciso-assistant.log


### PR DESCRIPTION
### Change Summary
Added custom timeout for `startup-docker-compose-test` job of the `Startup Tests` workflow based on historical data that could lead to resource savings and faster CI for the project.

### More details
Over the last 5100 successful runs, the `startup-docker-compose-test` job has a maximum runtime duration of 16 minutes (mean=5, std=1).

However, there are failed runs that fail after reaching the threshold of 6 hours that GitHub imposes. In other words, these jobs seem to get stuck, possibly for external or random reasons. 

One such example is [this](https://github.com/intuitem/ciso-assistant-community/actions/runs/13642139765/job/38134123096) job run, that failed after 6 hours. More stuck jobs have been observed over the last six months, which  you can see by expanding the dropdown below. With the proposed changes, a total of **102 hours** would have been saved over the last six months retrospectively, clearing the queue for other workflows and **speeding up the CI** of the project, while also **saving resources** in general 🌱.

The idea is to set a timeout to stop jobs that run much longer than their historical maximum, because such jobs are probably stuck and will simply fail after GitHub's timeout of 6 hours.

Our PR proposes to set the timeout to `max + 3*std = 19 minutes` where `max` and `std` (standard deviation) are derived from the history of 5100 successful runs. This will provide sufficient margin if the workflow gets naturally slower in the future, but if you would prefer lower/higher threshold we would be happy to do it.

<details>
<summary>Click here to see all the recently timed-out runs.</summary>

03-Mar-2025 => [timed-out run](https://github.com/intuitem/ciso-assistant-community/actions/runs/13642139765/job/38134123096)
03-Mar-2025 => [timed-out run](https://github.com/intuitem/ciso-assistant-community/actions/runs/13642139765/job/38134123096)
03-Mar-2025 => [timed-out run](https://github.com/intuitem/ciso-assistant-community/actions/runs/13642139765/job/38134123096)
02-Mar-2025 => [timed-out run](https://github.com/intuitem/ciso-assistant-community/actions/runs/13618550514/job/38064767628)
02-Mar-2025 => [timed-out run](https://github.com/intuitem/ciso-assistant-community/actions/runs/13618550514/job/38064767628)
02-Mar-2025 => [timed-out run](https://github.com/intuitem/ciso-assistant-community/actions/runs/13618550514/job/38064767628)
02-Mar-2025 => [timed-out run](https://github.com/intuitem/ciso-assistant-community/actions/runs/13614699224/job/38064024227)
02-Mar-2025 => [timed-out run](https://github.com/intuitem/ciso-assistant-community/actions/runs/13614699224/job/38064024227)
02-Mar-2025 => [timed-out run](https://github.com/intuitem/ciso-assistant-community/actions/runs/13614699224/job/38064024227)
02-Mar-2025 => [timed-out run](https://github.com/intuitem/ciso-assistant-community/actions/runs/13614667907/job/38056188167)
02-Mar-2025 => [timed-out run](https://github.com/intuitem/ciso-assistant-community/actions/runs/13614667907/job/38056188167)
02-Mar-2025 => [timed-out run](https://github.com/intuitem/ciso-assistant-community/actions/runs/13614667907/job/38056188167)
02-Mar-2025 => [timed-out run](https://github.com/intuitem/ciso-assistant-community/actions/runs/13614538283/job/38055914384)
02-Mar-2025 => [timed-out run](https://github.com/intuitem/ciso-assistant-community/actions/runs/13614538283/job/38055914384)
02-Mar-2025 => [timed-out run](https://github.com/intuitem/ciso-assistant-community/actions/runs/13614538283/job/38055914384)
02-Mar-2025 => [timed-out run](https://github.com/intuitem/ciso-assistant-community/actions/runs/13614514739/job/38055868310)
02-Mar-2025 => [timed-out run](https://github.com/intuitem/ciso-assistant-community/actions/runs/13614514739/job/38055868310)
02-Mar-2025 => [timed-out run](https://github.com/intuitem/ciso-assistant-community/actions/runs/13614514739/job/38055868310)
02-Mar-2025 => [timed-out run](https://github.com/intuitem/ciso-assistant-community/actions/runs/13614440273/job/38055707562)
02-Mar-2025 => [timed-out run](https://github.com/intuitem/ciso-assistant-community/actions/runs/13614440273/job/38055707562)
02-Mar-2025 => [timed-out run](https://github.com/intuitem/ciso-assistant-community/actions/runs/13614440273/job/38055707562)

</details>

### Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on energy optimizations in GitHub Actions workflows.

Thanks for your time on this and for your contribution to open-source software in general.

Feel free to let us know (here or in the email below) if you have any questions, and thanks for putting in the time to read this.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)
konstantinos.kitsios@uzh.ch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Set explicit timeout limits for automated test workflows to ensure jobs do not run indefinitely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->