### PR TITLE
fix: prevent audit/perimeter deletion in campaign

### DIFF
--- a/frontend/src/lib/utils/crud.ts
+++ b/frontend/src/lib/utils/crud.ts
@@ -1197,7 +1197,12 @@ export const URL_MODEL_MAP: ModelMap = {
 			{ field: 'perimeters', urlModel: 'perimeters' }
 		],
 		reverseForeignKeyFields: [
-			{ field: 'campaign', urlModel: 'compliance-assessments', disableCreate: true, disableDelete: true },
+			{
+				field: 'campaign',
+				urlModel: 'compliance-assessments',
+				disableCreate: true,
+				disableDelete: true
+			},
 			{ field: 'campaigns', urlModel: 'perimeters', disableCreate: true, disableDelete: true }
 		],
 		detailViewFields: [

--- a/frontend/src/lib/utils/crud.ts
+++ b/frontend/src/lib/utils/crud.ts
@@ -1197,8 +1197,8 @@ export const URL_MODEL_MAP: ModelMap = {
 			{ field: 'perimeters', urlModel: 'perimeters' }
 		],
 		reverseForeignKeyFields: [
-			{ field: 'campaign', urlModel: 'compliance-assessments', disableAddDeleteButtons: true },
-			{ field: 'campaigns', urlModel: 'perimeters', disableAddDeleteButtons: true }
+			{ field: 'campaign', urlModel: 'compliance-assessments', disableCreate: true, disableDelete: true },
+			{ field: 'campaigns', urlModel: 'perimeters', disableCreate: true, disableDelete: true }
 		],
 		detailViewFields: [
 			{ field: 'id' },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated permission controls for certain campaign-related fields, replacing a combined add/delete restriction with separate controls for creation and deletion actions. End-user experience remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->