### PR TITLE
fix: use full path when importing form fields in ebios rm study form

### DIFF
--- a/enterprise/frontend/src/lib/components/Forms/ModelForm/EbiosRmForm.svelte
+++ b/enterprise/frontend/src/lib/components/Forms/ModelForm/EbiosRmForm.svelte
@@ -3,8 +3,9 @@
 	import type { ModelInfo, CacheLock } from '$lib/utils/types';
 	import TextField from '$lib/components/Forms/TextField.svelte';
 	import AutocompleteSelect from '$lib/components/Forms/AutocompleteSelect.svelte';
-	import * as m from '$paraglide/messages.js';
-	import TextArea from '../TextArea.svelte';
+	import { m } from '$paraglide/messages';
+	import TextArea from '$lib/components/Forms/TextArea.svelte';
+	import Select from '$lib/components/Forms/Select.svelte';
 	import { page } from '$app/state';
 
 	interface Props {

--- a/frontend/src/lib/components/Forms/ModelForm/EbiosRmForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/EbiosRmForm.svelte
@@ -4,8 +4,8 @@
 	import TextField from '$lib/components/Forms/TextField.svelte';
 	import AutocompleteSelect from '$lib/components/Forms/AutocompleteSelect.svelte';
 	import { m } from '$paraglide/messages';
-	import TextArea from '../TextArea.svelte';
-	import Select from '../Select.svelte';
+	import TextArea from '$lib/components/Forms/TextArea.svelte';
+	import Select from '$lib/components/Forms/Select.svelte';
 	import { page } from '$app/state';
 
 	interface Props {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated component imports to use absolute paths for improved maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->