### PR TITLE
fix: personal data category translation in privacy overview

### DIFF
--- a/frontend/src/lib/components/Chart/TreemapChart.svelte
+++ b/frontend/src/lib/components/Chart/TreemapChart.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { m } from '$paraglide/messages';
+	import { safeTranslate } from '$lib/utils/i18n';
+
 	interface treeType {
 		name: string;
+		id: string;
 		children: any[];
 	}
 	interface Props {
@@ -22,6 +25,15 @@
 		name = '',
 		tree
 	}: Props = $props();
+
+	tree = tree.map((item) => ({
+		...item,
+		name: safeTranslate(item.id),
+		children: item.children?.map((child) => ({
+			...child,
+			name: safeTranslate(child.id)
+		}))
+	}));
 
 	const chart_id = `${name}_div`;
 	onMount(async () => {

--- a/frontend/src/lib/components/DataViz/WorldMap.svelte
+++ b/frontend/src/lib/components/DataViz/WorldMap.svelte
@@ -8,7 +8,7 @@
 
 	const tooltipTriggers = {
 		[TopoJSONMap.selectors.feature]: (d) =>
-			`${d.properties.name}: ${d.data.count ? d.data.count : 'no data'}`
+			`${d.properties.name}: ${d.data?.count ? d.data?.count : 'no data'}`
 	};
 </script>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Treemap chart labels are now automatically translated based on their identifiers.

* **Bug Fixes**
  * Improved world map tooltips to handle missing data more gracefully, displaying "no data" when appropriate instead of causing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->