### PR TITLE
feat: include creation date on audits

### DIFF
--- a/frontend/src/lib/utils/table.ts
+++ b/frontend/src/lib/utils/table.ts
@@ -785,16 +785,8 @@ export const listViewFields = {
 		}
 	},
 	'compliance-assessments': {
-		head: [
-			'ref_id',
-			'name',
-			'framework',
-			'description',
-			'perimeter',
-			'reviewProgress',
-			'updated_at'
-		],
-		body: ['ref_id', 'name', 'framework', 'description', 'perimeter', 'progress', 'updated_at'],
+		head: ['ref_id', 'name', 'framework', 'perimeter', 'reviewProgress', 'createdAt', 'updatedAt'],
+		body: ['ref_id', 'name', 'framework', 'perimeter', 'progress', 'created_at', 'updated_at'],
 		filters: {
 			folder: DOMAIN_FILTER,
 			perimeter: PERIMETER_FILTER,

--- a/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/+page.svelte
@@ -28,6 +28,8 @@
 
 	import { safeTranslate } from '$lib/utils/i18n';
 	import { m } from '$paraglide/messages';
+	import { formatDateOrDateTime } from '$lib/utils/datetime';
+	import { getLocale } from '$paraglide/runtime.js';
 
 	import List from '$lib/components/List/List.svelte';
 	import ConfirmModal from '$lib/components/Modals/ConfirmModal.svelte';
@@ -417,6 +419,10 @@
 					</ul>
 				</div>
 			{/each}
+			<div>
+				<div class="font-medium">{m.createdAt()}</div>
+				{formatDateOrDateTime(data.compliance_assessment.created_at, getLocale())}
+			</div>
 		</div>
 		{#key compliance_assessment_donut_values}
 			<div class="flex w-1/3 relative">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible "Created At" field to the compliance assessment details, displaying the creation date in a localized format.

* **Refactor**
  * Updated the compliance assessments list view to show "Created At" and "Updated At" fields, removed "Description," and adjusted the order of displayed columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->