### PR TITLE
feat: preset incident reporting time to now

### DIFF
--- a/frontend/src/lib/components/Forms/ModelForm/IncidentForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/IncidentForm.svelte
@@ -27,6 +27,10 @@
 		initialData = {}
 	}: Props = $props();
 	const disableDoubleDash = true;
+
+	let currentDateTime = new Date(new Date().getTime() - new Date().getTimezoneOffset() * 60000)
+		.toISOString()
+		.slice(0, 19);
 </script>
 
 <TextField
@@ -42,6 +46,7 @@
 	{form}
 	field="reported_at"
 	label={m.reportedAt()}
+	value={currentDateTime}
 	cacheLock={cacheLocks['reported_at']}
 	bind:cachedValue={formDataCache['reported_at']}
 />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The "Reported At" field in the incident form now defaults to the current local date and time when the form is opened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->