### PR TITLE
feat: Added Prometheus CISO Assistant instance metrics exporter

### DIFF
--- a/backend/core/helpers.py
+++ b/backend/core/helpers.py
@@ -7,6 +7,7 @@ from typing import Dict, List
 # from icecream import ic
 from django.core.exceptions import NON_FIELD_ERRORS as DJ_NON_FIELD_ERRORS
 from django.core.exceptions import ValidationError as DjValidationError
+from django.conf import settings
 from django.db.models import Count
 from django.shortcuts import get_object_or_404
 from rest_framework.exceptions import ValidationError as DRFValidationError
@@ -1011,6 +1012,62 @@ def get_metrics(user: User, folder_id):
         "csf_functions": csf_functions(user, folder_id),
     }
     return data
+
+
+def get_instance_metrics():
+    """
+    Returns the instance metrics such as the number of users, domains, perimeters, etc.
+    """
+    nb_users = User.objects.all().count()
+    nb_first_login = User.objects.filter(first_login=True).count()
+    nb_libraries = LoadedLibrary.objects.all().count()
+    nb_domains = Folder.objects.filter(content_type="DO").count()
+    nb_perimeters = Perimeter.objects.all().count()
+    nb_assets = Asset.objects.all().count()
+    nb_threats = Threat.objects.all().count()
+    nb_functions = ReferenceControl.objects.all().count()
+    nb_measures = AppliedControl.objects.all().count()
+    nb_evidences = Evidence.objects.all().count()
+    nb_compliance_assessments = ComplianceAssessment.objects.all().count()
+    nb_risk_assessments = RiskAssessment.objects.all().count()
+    nb_risk_scenarios = RiskScenario.objects.all().count()
+    nb_risk_acceptances = RiskAcceptance.objects.all().count()
+    nb_seats = getattr(settings, "LICENSE_SEATS", 0)
+    nb_editors = len(User.get_editors())
+    expiration = getattr(settings, "LICENSE_EXPIRATION", -1)
+
+    created_at = int(Folder.get_root_folder().created_at.timestamp())
+    last_login_dt = max(
+        [
+            x["last_login"]
+            for x in User.objects.all().values("last_login")
+            if x["last_login"]
+        ],
+        default=None,
+    )
+    last_login = int(last_login_dt.timestamp()) if last_login_dt else 0
+
+    return {
+        "nb_users": nb_users,
+        "nb_first_login": nb_first_login,
+        "nb_libraries": nb_libraries,
+        "nb_domains": nb_domains,
+        "nb_perimeters": nb_perimeters,
+        "nb_assets": nb_assets,
+        "nb_threats": nb_threats,
+        "nb_functions": nb_functions,
+        "nb_measures": nb_measures,
+        "nb_evidences": nb_evidences,
+        "nb_compliance_assessments": nb_compliance_assessments,
+        "nb_risk_assessments": nb_risk_assessments,
+        "nb_risk_scenarios": nb_risk_scenarios,
+        "nb_risk_acceptances": nb_risk_acceptances,
+        "nb_seats": nb_seats,
+        "nb_editors": nb_editors,
+        "expiration": expiration,
+        "created_at": created_at,
+        "last_login": last_login,
+    }
 
 
 def risk_status(user: User, risk_assessment_list):

--- a/backend/core/instance_metrics.py
+++ b/backend/core/instance_metrics.py
@@ -1,0 +1,122 @@
+"""
+This module defines metrics for the CISO Assistant backend using the Prometheus client library.
+It provides counters and gauges to track various instance statistics for monitoring and observability.
+"""
+
+from prometheus_client import Gauge, Info, REGISTRY
+from django.conf import settings
+
+
+# Dictionary to store metric instances to prevent duplicates
+_metrics = {}
+
+
+def get_or_create_gauge(name, description):
+    """Get existing gauge or create new one if it doesn't exist."""
+    if name not in _metrics:
+        _metrics[name] = Gauge(name, description)
+    return _metrics[name]
+
+
+def get_or_create_info(name, description):
+    """Get existing info metric or create new one if it doesn't exist."""
+    if name not in _metrics:
+        _metrics[name] = Info(name, description)
+    return _metrics[name]
+
+
+# Define Prometheus metrics for instance metrics
+nb_users_gauge = get_or_create_gauge(
+    "ciso_assistant_nb_users",
+    "Number of users in the CISO Assistant instance",
+)
+nb_first_login_gauge = get_or_create_gauge(
+    "ciso_assistant_nb_first_login",
+    "Number of users who have logged in for the first time",
+)
+nb_libraries_gauge = get_or_create_gauge(
+    "ciso_assistant_nb_libraries",
+    "Number of loaded libraries in the CISO Assistant instance",
+)
+nb_domains_gauge = get_or_create_gauge(
+    "ciso_assistant_nb_domains",
+    "Number of domains in the CISO Assistant instance",
+)
+nb_perimeters_gauge = get_or_create_gauge(
+    "ciso_assistant_nb_perimeters",
+    "Number of perimeters in the CISO Assistant instance",
+)
+nb_assets_gauge = get_or_create_gauge(
+    "ciso_assistant_nb_assets",
+    "Number of assets in the CISO Assistant instance",
+)
+nb_threats_gauge = get_or_create_gauge(
+    "ciso_assistant_nb_threats",
+    "Number of threats in the CISO Assistant instance",
+)
+nb_functions_gauge = get_or_create_gauge(
+    "ciso_assistant_nb_functions",
+    "Number of reference control functions in the CISO Assistant instance",
+)
+nb_measures_gauge = get_or_create_gauge(
+    "ciso_assistant_nb_measures",
+    "Number of applied control measures in the CISO Assistant instance",
+)
+nb_evidences_gauge = get_or_create_gauge(
+    "ciso_assistant_nb_evidences",
+    "Number of evidences in the CISO Assistant instance",
+)
+nb_compliance_assessments_gauge = get_or_create_gauge(
+    "ciso_assistant_nb_compliance_assessments",
+    "Number of compliance assessments in the CISO Assistant instance",
+)
+nb_risk_assessments_gauge = get_or_create_gauge(
+    "ciso_assistant_nb_risk_assessments",
+    "Number of risk assessments in the CISO Assistant instance",
+)
+nb_risk_scenarios_gauge = get_or_create_gauge(
+    "ciso_assistant_nb_risk_scenarios",
+    "Number of risk scenarios in the CISO Assistant instance",
+)
+nb_risk_acceptances_gauge = get_or_create_gauge(
+    "ciso_assistant_nb_risk_acceptances",
+    "Number of risk acceptances in the CISO Assistant instance",
+)
+nb_seats_gauge = get_or_create_gauge(
+    "ciso_assistant_nb_seats",
+    "Number of seats in the CISO Assistant instance",
+)
+nb_editors_gauge = get_or_create_gauge(
+    "ciso_assistant_nb_editors",
+    "Number of editors in the CISO Assistant instance",
+)
+expiration_gauge = get_or_create_gauge(
+    "ciso_assistant_license_expiration",
+    "Expiration date of the CISO Assistant license",
+)
+created_at_gauge = get_or_create_gauge(
+    "ciso_assistant_created_at",
+    "Creation date of the CISO Assistant instance",
+)
+last_login_gauge = get_or_create_gauge(
+    "ciso_assistant_last_login",
+    "Last login date of the most recent user in the instance",
+)
+
+build_info = get_or_create_info(
+    "ciso_assistant_build_info",
+    "Build information for the CISO Assistant instance",
+)
+
+# Only set the info if it hasn't been set before
+metric_names = [
+    name for names in REGISTRY._collector_to_names.values() for name in names
+]
+build_info.info(
+    {
+        "version": settings.VERSION,
+        "build": settings.BUILD,
+        "schema_version": str(settings.SCHEMA_VERSION),
+        "debug": str(settings.DEBUG),
+    }
+)

--- a/backend/core/management/commands/README_metrics_server.md
+++ b/backend/core/management/commands/README_metrics_server.md
@@ -1,0 +1,121 @@
+# Prometheus Metrics Server
+
+This document explains how to use the new Prometheus metrics server management command.
+
+## Overview
+
+The `metrics_server` management command runs a standalone HTTP server that exposes Prometheus metrics on a separate port from the main CISO Assistant application. This approach provides better security and performance by isolating metrics collection from the main application.
+
+## Usage
+
+### Basic Usage
+
+```bash
+python manage.py metrics_server
+```
+
+This starts the metrics server on `0.0.0.0:8001` by default with automatic metric updates every 60 seconds.
+
+### Command Options
+
+- `--port PORT`: Port to run the metrics server on (default: 8001)
+- `--host HOST`: Host to bind the metrics server to (default: 0.0.0.0)
+- `--update-interval SECONDS`: Interval in seconds to update metrics (default: 60)
+- `--no-update`: Disable automatic metric updates (metrics will only be updated on server startup)
+
+### Examples
+
+```bash
+# Run on a different port
+python manage.py metrics_server --port 9090
+
+# Run with custom update interval (5 minutes)
+python manage.py metrics_server --update-interval 300
+
+# Run without automatic updates
+python manage.py metrics_server --no-update
+
+# Run on localhost only
+python manage.py metrics_server --host 127.0.0.1 --port 8080
+```
+
+## Accessing Metrics
+
+Once the server is running, you can access the metrics at:
+
+```
+http://HOST:PORT/metrics
+```
+
+For example, with default settings: `http://localhost:8001/metrics`
+
+## Available Metrics
+
+The following metrics are exposed:
+
+- `ciso_assistant_nb_users`: Number of users in the instance
+- `ciso_assistant_nb_first_login`: Number of users who have logged in for the first time
+- `ciso_assistant_nb_libraries`: Number of loaded libraries
+- `ciso_assistant_nb_domains`: Number of domains
+- `ciso_assistant_nb_perimeters`: Number of perimeters
+- `ciso_assistant_nb_assets`: Number of assets
+- `ciso_assistant_nb_threats`: Number of threats
+- `ciso_assistant_nb_functions`: Number of reference control functions
+- `ciso_assistant_nb_measures`: Number of applied control measures
+- `ciso_assistant_nb_evidences`: Number of evidences
+- `ciso_assistant_nb_compliance_assessments`: Number of compliance assessments
+- `ciso_assistant_nb_risk_assessments`: Number of risk assessments
+- `ciso_assistant_nb_risk_scenarios`: Number of risk scenarios
+- `ciso_assistant_nb_risk_acceptances`: Number of risk acceptances
+- `ciso_assistant_nb_seats`: Number of seats
+- `ciso_assistant_nb_editors`: Number of editors
+- `ciso_assistant_license_expiration`: License expiration timestamp
+- `ciso_assistant_created_at`: Instance creation timestamp
+- `ciso_assistant_last_login`: Last login timestamp
+- `ciso_assistant_build_info`: Build information (version, build, schema_version, debug)
+
+## Prometheus Configuration
+
+To scrape these metrics with Prometheus, add the following job to your `prometheus.yml`:
+
+```yaml
+scrape_configs:
+  - job_name: "ciso-assistant"
+    static_configs:
+      - targets: ["ciso-assistant-host:8001"]
+    scrape_interval: 60s
+    metrics_path: /metrics
+```
+
+## Security Considerations
+
+- The metrics server runs on a separate port from the main application
+- Consider using firewall rules to restrict access to the metrics port
+- For production deployments, consider binding to `127.0.0.1` instead of `0.0.0.0` if metrics collection runs on the same host as Prometheus
+- No authentication is required for the metrics endpoint (standard for Prometheus)
+
+## Troubleshooting
+
+### Port Already in Use
+
+If you get a "Port already in use" error, either:
+
+- Use a different port with `--port`
+- Stop any service using that port
+- Check what's using the port: `sudo lsof -i :8001`
+
+### Permission Errors
+
+Ensure the user running the command has:
+
+- Read access to the Django project
+- Database connection permissions
+- Permission to bind to the specified port (ports < 1024 require root)
+
+### Database Connection Issues
+
+The metrics server requires a working database connection to collect metrics. Ensure:
+
+- Database is running and accessible
+- Django settings are properly configured
+- Database credentials are correct

--- a/backend/core/management/commands/metrics_server.py
+++ b/backend/core/management/commands/metrics_server.py
@@ -1,0 +1,222 @@
+"""
+Django management command to run a Prometheus metrics server.
+
+This command starts a standalone HTTP server that exposes Prometheus metrics
+on a separate port from the main application. It updates the metrics
+periodically and serves them in Prometheus format.
+"""
+
+import time
+import signal
+import threading
+import logging
+from django.core.management.base import BaseCommand, CommandError
+from prometheus_client import start_http_server
+
+from core.helpers import get_instance_metrics
+from core.instance_metrics import (
+    nb_users_gauge,
+    nb_first_login_gauge,
+    nb_libraries_gauge,
+    nb_domains_gauge,
+    nb_perimeters_gauge,
+    nb_assets_gauge,
+    nb_threats_gauge,
+    nb_functions_gauge,
+    nb_measures_gauge,
+    nb_evidences_gauge,
+    nb_compliance_assessments_gauge,
+    nb_risk_assessments_gauge,
+    nb_risk_scenarios_gauge,
+    nb_risk_acceptances_gauge,
+    nb_seats_gauge,
+    nb_editors_gauge,
+    expiration_gauge,
+    created_at_gauge,
+    last_login_gauge,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class MetricsUpdater:
+    """Class to handle periodic metrics updates."""
+
+    def __init__(self, update_interval=60):
+        self.update_interval = update_interval
+        self.running = False
+        self.thread = None
+
+    def update_metrics(self):
+        """Update all Prometheus metrics with current values."""
+        try:
+            metrics = get_instance_metrics()
+
+            nb_users_gauge.set(metrics.get("nb_users", 0))
+            nb_first_login_gauge.set(metrics.get("nb_first_login", 0))
+            nb_libraries_gauge.set(metrics.get("nb_libraries", 0))
+            nb_domains_gauge.set(metrics.get("nb_domains", 0))
+            nb_perimeters_gauge.set(metrics.get("nb_perimeters", 0))
+            nb_assets_gauge.set(metrics.get("nb_assets", 0))
+            nb_threats_gauge.set(metrics.get("nb_threats", 0))
+            nb_functions_gauge.set(metrics.get("nb_functions", 0))
+            nb_measures_gauge.set(metrics.get("nb_measures", 0))
+            nb_evidences_gauge.set(metrics.get("nb_evidences", 0))
+            nb_compliance_assessments_gauge.set(
+                metrics.get("nb_compliance_assessments", 0)
+            )
+            nb_risk_assessments_gauge.set(metrics.get("nb_risk_assessments", 0))
+            nb_risk_scenarios_gauge.set(metrics.get("nb_risk_scenarios", 0))
+            nb_risk_acceptances_gauge.set(metrics.get("nb_risk_acceptances", 0))
+            nb_seats_gauge.set(metrics.get("nb_seats", 0))
+            nb_editors_gauge.set(metrics.get("nb_editors", 0))
+            expiration_gauge.set(metrics.get("expiration", 0))
+            created_at_gauge.set(metrics.get("created_at", 0))
+            last_login_gauge.set(metrics.get("last_login", 0))
+
+            logger.debug("Metrics updated successfully")
+
+        except Exception as e:
+            logger.error("Error updating metrics: %s", e)
+
+    def _update_loop(self):
+        """Main loop for periodic metrics updates."""
+        while self.running:
+            self.update_metrics()
+            time.sleep(self.update_interval)
+
+    def start(self):
+        """Start the metrics update thread."""
+        if self.running:
+            return
+
+        self.running = True
+        self.thread = threading.Thread(target=self._update_loop, daemon=True)
+        self.thread.start()
+        logger.info("Started metrics updater with %ss interval", self.update_interval)
+
+    def stop(self):
+        """Stop the metrics update thread."""
+        self.running = False
+        if self.thread:
+            self.thread.join(timeout=5)
+        logger.info("Stopped metrics updater")
+
+
+class Command(BaseCommand):
+    help = "Start a Prometheus metrics server on a separate port"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--port",
+            type=int,
+            default=8001,
+            help="Port to run the metrics server on (default: 8001)",
+        )
+        parser.add_argument(
+            "--host",
+            type=str,
+            default="0.0.0.0",
+            help="Host to bind the metrics server to (default: 0.0.0.0)",
+        )
+        parser.add_argument(
+            "--update-interval",
+            type=int,
+            default=60,
+            help="Interval in seconds to update metrics (default: 60)",
+        )
+        parser.add_argument(
+            "--no-update",
+            action="store_true",
+            help="Disable automatic metric updates "
+            "(metrics will only be updated on request)",
+        )
+
+    def handle(self, *args, **options):
+        port = options["port"]
+        host = options["host"]
+        update_interval = options["update_interval"]
+        auto_update = not options["no_update"]
+
+        # Validate port range
+        if not (1 <= port <= 65535):
+            raise CommandError(f"Port must be between 1 and 65535, got {port}")
+
+        # Set up signal handlers for graceful shutdown
+        shutdown_event = threading.Event()
+        metrics_updater = None
+
+        def signal_handler(signum, _frame):
+            self.stdout.write(
+                self.style.WARNING(f"Received signal {signum}, shutting down...")
+            )
+            shutdown_event.set()
+            if metrics_updater:
+                metrics_updater.stop()
+
+        signal.signal(signal.SIGINT, signal_handler)
+        signal.signal(signal.SIGTERM, signal_handler)
+
+        try:
+            # Initialize metrics updater if auto-update is enabled
+            if auto_update:
+                metrics_updater = MetricsUpdater(update_interval)
+                metrics_updater.start()
+                # Update metrics immediately on startup
+                metrics_updater.update_metrics()
+            else:
+                # Update metrics once on startup even if auto-update
+                # is disabled
+                updater = MetricsUpdater()
+                updater.update_metrics()
+
+            # Start the Prometheus HTTP server
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Starting Prometheus metrics server on {host}:{port}"
+                )
+            )
+
+            if auto_update:
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"Metrics will be updated every {update_interval} seconds"
+                    )
+                )
+            else:
+                self.stdout.write(
+                    self.style.WARNING(
+                        "Auto-update disabled. Metrics will only be updated "
+                        "on server startup."
+                    )
+                )
+
+            # Start the server
+            start_http_server(port, addr=host)
+
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Metrics server running at http://{host}:{port}/metrics"
+                )
+            )
+            self.stdout.write("Press Ctrl+C to stop the server")
+
+            # Keep the main thread alive
+            while not shutdown_event.is_set():
+                shutdown_event.wait(1)
+
+        except OSError as e:
+            if e.errno == 98:  # Address already in use
+                raise CommandError(
+                    f"Port {port} is already in use. Please choose a different port."
+                )
+            else:
+                raise CommandError(f"Failed to start server: {e}")
+        except KeyboardInterrupt:
+            pass
+        except Exception as e:
+            raise CommandError(f"Unexpected error: {e}")
+        finally:
+            if metrics_updater:
+                metrics_updater.stop()
+            self.stdout.write(self.style.SUCCESS("Metrics server stopped"))

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -2191,6 +2191,21 @@ pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
 
 [[package]]
+name = "prometheus-client"
+version = "0.22.1"
+description = "Python client for the Prometheus monitoring system."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "prometheus_client-0.22.1-py3-none-any.whl", hash = "sha256:cca895342e308174341b2cbf99a56bef291fbc0ef7b9e5412a0f26d653ba7094"},
+    {file = "prometheus_client-0.22.1.tar.gz", hash = "sha256:190f1331e783cf21eb60bca559354e0a4d4378facecf78f5428c39b675d20d28"},
+]
+
+[package.extras]
+twisted = ["twisted"]
+
+[[package]]
 name = "psycopg2-binary"
 version = "2.9.9"
 description = "psycopg2 - Python-PostgreSQL Database Adapter"
@@ -3313,4 +3328,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "d63c877124e2e192de262781547a9c4192e5dccbd8994597c2bb6461baaa7451"
+content-hash = "e1b4e9eb810801b7fcc63667faf8ad010ad77d6e278736336d6f8eb12c985906"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -45,6 +45,7 @@ boto3 = "^1.38.1"
 django-storages = "^1.14.6"
 icecream = "^2.1.4"
 regex = "^2024.11.6"
+prometheus-client = "^0.22.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest-django = "4.8.0"


### PR DESCRIPTION
This pull request introduces functionality to track and expose instance-level metrics for the application using Prometheus. 

The metrics are exposed through a standalone webserver instance that needs to be launched separately from the backend container.

# Prometheus Metrics Server

This document explains how to use the new Prometheus metrics server management command.

## Overview

The `metrics_server` management command runs a standalone HTTP server that exposes Prometheus metrics on a separate port from the main CISO Assistant application. This approach provides better security and performance by isolating metrics collection from the main application.

### Basic Usage

```bash
python manage.py metrics_server
```

This starts the metrics server on `0.0.0.0:8001` by default with automatic metric updates every 60 seconds.

### Command Options

- `--port PORT`: Port to run the metrics server on (default: 8001)
- `--host HOST`: Host to bind the metrics server to (default: 0.0.0.0)
- `--update-interval SECONDS`: Interval in seconds to update metrics (default: 60)
- `--no-update`: Disable automatic metric updates (metrics will only be updated on server startup)

### Examples

```bash
# Run on a different port
python manage.py metrics_server --port 9090

# Run with custom update interval (5 minutes)
python manage.py metrics_server --update-interval 300

# Run without automatic updates
python manage.py metrics_server --no-update

# Run on localhost only
python manage.py metrics_server --host 127.0.0.1 --port 8080
```

## Accessing Metrics

Once the server is running, you can access the metrics at:

```
http://HOST:PORT/metrics
```

For example, with default settings: `http://localhost:8001/metrics`

## Available Metrics

The following metrics are exposed:

- `ciso_assistant_nb_users`: Number of users in the instance
- `ciso_assistant_nb_first_login`: Number of users who have logged in for the first time
- `ciso_assistant_nb_libraries`: Number of loaded libraries
- `ciso_assistant_nb_domains`: Number of domains
- `ciso_assistant_nb_perimeters`: Number of perimeters
- `ciso_assistant_nb_assets`: Number of assets
- `ciso_assistant_nb_threats`: Number of threats
- `ciso_assistant_nb_functions`: Number of reference control functions
- `ciso_assistant_nb_measures`: Number of applied control measures
- `ciso_assistant_nb_evidences`: Number of evidences
- `ciso_assistant_nb_compliance_assessments`: Number of compliance assessments
- `ciso_assistant_nb_risk_assessments`: Number of risk assessments
- `ciso_assistant_nb_risk_scenarios`: Number of risk scenarios
- `ciso_assistant_nb_risk_acceptances`: Number of risk acceptances
- `ciso_assistant_nb_seats`: Number of seats
- `ciso_assistant_nb_editors`: Number of editors
- `ciso_assistant_license_expiration`: License expiration timestamp
- `ciso_assistant_created_at`: Instance creation timestamp
- `ciso_assistant_last_login`: Last login timestamp
- `ciso_assistant_build_info`: Build information (version, build, schema_version, debug)

## Prometheus Configuration

To scrape these metrics with Prometheus, add the following job to your `prometheus.yml`:

```yaml
scrape_configs:
  - job_name: "ciso-assistant"
    static_configs:
      - targets: ["ciso-assistant-host:8001"]
    scrape_interval: 60s
    metrics_path: /metrics
```

## Security Considerations

- The metrics server runs on a separate port from the main application
- Consider using firewall rules to restrict access to the metrics port
- For production deployments, consider binding to `127.0.0.1` instead of `0.0.0.0` if metrics collection runs on the same host as Prometheus
- No authentication is required for the metrics endpoint (standard for Prometheus)

## Troubleshooting

### Port Already in Use

If you get a "Port already in use" error, either:

- Use a different port with `--port`
- Stop any service using that port
- Check what's using the port: `sudo lsof -i :8001`

### Permission Errors

Ensure the user running the command has:

- Read access to the Django project
- Database connection permissions
- Permission to bind to the specified port (ports < 1024 require root)

### Database Connection Issues

The metrics server requires a working database connection to collect metrics. Ensure:

- Database is running and accessible
- Django settings are properly configured
- Database credentials are correct

### Sample metrics

```
╰─$ curl http://localhost:8001/api/metrics/instance/
# HELP python_gc_objects_collected_total Objects collected during gc
# TYPE python_gc_objects_collected_total counter
python_gc_objects_collected_total{generation="0"} 10817.0
python_gc_objects_collected_total{generation="1"} 4315.0
python_gc_objects_collected_total{generation="2"} 603.0
# HELP python_gc_objects_uncollectable_total Uncollectable objects found during GC
# TYPE python_gc_objects_uncollectable_total counter
python_gc_objects_uncollectable_total{generation="0"} 0.0
python_gc_objects_uncollectable_total{generation="1"} 0.0
python_gc_objects_uncollectable_total{generation="2"} 0.0
# HELP python_gc_collections_total Number of times this generation was collected
# TYPE python_gc_collections_total counter
python_gc_collections_total{generation="0"} 661.0
python_gc_collections_total{generation="1"} 60.0
python_gc_collections_total{generation="2"} 5.0
# HELP python_info Python platform information
# TYPE python_info gauge
python_info{implementation="CPython",major="3",minor="12",patchlevel="3",version="3.12.3"} 1.0
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 1.807732736e+09
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 2.17833472e+08
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.7532248765e+09
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 4.13
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 7.0
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1024.0
# HELP ciso_assistant_nb_users Number of users in the CISO Assistant instance
# TYPE ciso_assistant_nb_users gauge
ciso_assistant_nb_users 8.0
# HELP ciso_assistant_nb_first_login Number of users who have logged in for the first time
# TYPE ciso_assistant_nb_first_login gauge
ciso_assistant_nb_first_login 8.0
# HELP ciso_assistant_nb_libraries Number of loaded libraries in the CISO Assistant instance
# TYPE ciso_assistant_nb_libraries gauge
ciso_assistant_nb_libraries 20.0
# HELP ciso_assistant_nb_domains Number of domains in the CISO Assistant instance
# TYPE ciso_assistant_nb_domains gauge
ciso_assistant_nb_domains 5.0
# HELP ciso_assistant_nb_perimeters Number of perimeters in the CISO Assistant instance
# TYPE ciso_assistant_nb_perimeters gauge
ciso_assistant_nb_perimeters 8.0
# HELP ciso_assistant_nb_assets Number of assets in the CISO Assistant instance
# TYPE ciso_assistant_nb_assets gauge
ciso_assistant_nb_assets 1.0
# HELP ciso_assistant_nb_threats Number of threats in the CISO Assistant instance
# TYPE ciso_assistant_nb_threats gauge
ciso_assistant_nb_threats 211.0
# HELP ciso_assistant_nb_functions Number of reference control functions in the CISO Assistant instance
# TYPE ciso_assistant_nb_functions gauge
ciso_assistant_nb_functions 112.0
# HELP ciso_assistant_nb_measures Number of applied control measures in the CISO Assistant instance
# TYPE ciso_assistant_nb_measures gauge
ciso_assistant_nb_measures 95.0
# HELP ciso_assistant_nb_evidences Number of evidences in the CISO Assistant instance
# TYPE ciso_assistant_nb_evidences gauge
ciso_assistant_nb_evidences 0.0
# HELP ciso_assistant_nb_compliance_assessments Number of compliance assessments in the CISO Assistant instance
# TYPE ciso_assistant_nb_compliance_assessments gauge
ciso_assistant_nb_compliance_assessments 16.0
# HELP ciso_assistant_nb_risk_assessments Number of risk assessments in the CISO Assistant instance
# TYPE ciso_assistant_nb_risk_assessments gauge
ciso_assistant_nb_risk_assessments 1.0
# HELP ciso_assistant_nb_risk_scenarios Number of risk scenarios in the CISO Assistant instance
# TYPE ciso_assistant_nb_risk_scenarios gauge
ciso_assistant_nb_risk_scenarios 1.0
# HELP ciso_assistant_nb_risk_acceptances Number of risk acceptances in the CISO Assistant instance
# TYPE ciso_assistant_nb_risk_acceptances gauge
ciso_assistant_nb_risk_acceptances 1.0
# HELP ciso_assistant_nb_seats Number of seats in the CISO Assistant instance
# TYPE ciso_assistant_nb_seats gauge
ciso_assistant_nb_seats 0.0
# HELP ciso_assistant_nb_editors Number of editors in the CISO Assistant instance
# TYPE ciso_assistant_nb_editors gauge
ciso_assistant_nb_editors 7.0
# HELP ciso_assistant_license_expiration Expiration date of the CISO Assistant license
# TYPE ciso_assistant_license_expiration gauge
ciso_assistant_license_expiration -1.0
# HELP ciso_assistant_created_at Creation date of the CISO Assistant instance
# TYPE ciso_assistant_created_at gauge
ciso_assistant_created_at 1.715632408e+09
# HELP ciso_assistant_last_login Last login date of the most recent user in the instance
# TYPE ciso_assistant_last_login gauge
ciso_assistant_last_login 1.753220855e+09
# HELP ciso_assistant_build_info_info Build information for the CISO Assistant instance
# TYPE ciso_assistant_build_info_info gauge
ciso_assistant_build_info_info{build="25555409d",debug="True",schema_version="2",version="25555409d"} 1.0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new management command to provide application instance metrics in Prometheus format.
* **Chores**
  * Added Prometheus client as a backend dependency for metrics exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->