### PR TITLE
fix: filtering labels display in AutocompleteSelect

### DIFF
--- a/frontend/src/lib/components/Forms/ModelForm/AppliedControlPolicyForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/AppliedControlPolicyForm.svelte
@@ -221,6 +221,7 @@
 			{form}
 			createFromSelection={true}
 			optionsEndpoint="filtering-labels"
+			translateOptions={false}
 			optionsLabelField="label"
 			field="filtering_labels"
 			helpText={m.labelsHelpText()}

--- a/frontend/src/lib/components/Forms/ModelForm/AssetForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/AssetForm.svelte
@@ -222,6 +222,7 @@
 	field="filtering_labels"
 	helpText={m.labelsHelpText()}
 	label={m.labels()}
+	translateOptions={false}
 	allowUserOptions="append"
 />
 {#if initialData.ebios_rm_studies}

--- a/frontend/src/lib/components/Forms/ModelForm/EvidenceForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/EvidenceForm.svelte
@@ -86,6 +86,7 @@
 	optionsEndpoint="filtering-labels"
 	optionsLabelField="label"
 	field="filtering_labels"
+	translateOptions={false}
 	helpText={m.labelsHelpText()}
 	label={m.labels()}
 	allowUserOptions="append"

--- a/frontend/src/lib/components/Forms/ModelForm/FindingForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/FindingForm.svelte
@@ -181,6 +181,7 @@
 		createFromSelection={true}
 		optionsEndpoint="filtering-labels"
 		optionsLabelField="label"
+		translateOptions={false}
 		field="filtering_labels"
 		helpText={m.labelsHelpText()}
 		label={m.labels()}

--- a/frontend/src/lib/components/Forms/ModelForm/ProcessingForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/ProcessingForm.svelte
@@ -71,6 +71,7 @@
 	createFromSelection={true}
 	optionsEndpoint="filtering-labels"
 	optionsLabelField="label"
+	translateOptions={false}
 	field="filtering_labels"
 	helpText={m.labelsHelpText()}
 	label={m.labels()}

--- a/frontend/src/lib/components/Forms/ModelForm/ReferenceControlForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/ReferenceControlForm.svelte
@@ -76,6 +76,7 @@
 	createFromSelection={true}
 	optionsEndpoint="filtering-labels"
 	optionsLabelField="label"
+	translateOptions={false}
 	field="filtering_labels"
 	helpText={m.labelsHelpText()}
 	label={m.labels()}

--- a/frontend/src/lib/components/Forms/ModelForm/ThreatForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/ThreatForm.svelte
@@ -60,6 +60,7 @@
 	optionsEndpoint="filtering-labels"
 	optionsLabelField="label"
 	field="filtering_labels"
+	translateOptions={false}
 	helpText={m.labelsHelpText()}
 	label={m.labels()}
 	allowUserOptions="append"

--- a/frontend/src/lib/components/Forms/ModelForm/VulnerabilitiesForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/VulnerabilitiesForm.svelte
@@ -96,6 +96,7 @@
 	{form}
 	createFromSelection={true}
 	optionsEndpoint="filtering-labels"
+	translateOptions={false}
 	optionsLabelField="label"
 	field="filtering_labels"
 	helpText={m.labelsHelpText()}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Option translation is now disabled for the "filtering_labels" autocomplete dropdown in several forms, ensuring that options are displayed in their original language. This change affects forms for assets, evidence, findings, processing, threats, vulnerabilities, applied control policies, and reference controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->