### PR TITLE
fix: "path" not translated in incidents

### DIFF
--- a/frontend/src/lib/components/DetailView/DetailView.svelte
+++ b/frontend/src/lib/components/DetailView/DetailView.svelte
@@ -31,7 +31,7 @@
 
 	const modalStore: ModalStore = getModalStore();
 
-	const defaultExcludes = ['id', 'is_published', 'localization_dict', 'str'];
+	const defaultExcludes = ['id', 'is_published', 'localization_dict', 'str', 'path'];
 
 	interface Props {
 		data: any;


### PR DESCRIPTION
Fixed path not translated in some detail views by adding it into the list of default excludes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The "path" field is now excluded from being displayed in the detail view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->