### PR TITLE
fix: risk matrix impact filter options

### DIFF
--- a/frontend/src/lib/components/Forms/AutocompleteSelect.svelte
+++ b/frontend/src/lib/components/Forms/AutocompleteSelect.svelte
@@ -126,7 +126,7 @@
 
 	let selected: typeof options = $state([]);
 	let selectedValues: (string | undefined)[] = $derived(
-		selected.map((item) => item.value || item.label || item)
+		selected.map((item) => item.value ?? item.label ?? item)
 	);
 	let isInternalUpdate = false;
 	let optionsLoaded = $state(Boolean(options.length));


### PR DESCRIPTION
This fixes filtering against risk matrix impact (e.g. in feared events or strategic scenarios)

- **properly serialize risk matrix gravity choices**
- **replace bitwise OR with null checks for autocomplete value**
