### PR TITLE
fix: add user observation during creation

### DIFF
--- a/backend/iam/models.py
+++ b/backend/iam/models.py
@@ -335,6 +335,7 @@ class UserManager(BaseUserManager):
             last_name=extra_fields.get("last_name", ""),
             is_superuser=extra_fields.get("is_superuser", False),
             is_active=extra_fields.get("is_active", True),
+            observation=extra_fields.get("observation"),
             folder=_get_root_folder(),
             keep_local_login=extra_fields.get("keep_local_login", False),
         )

--- a/frontend/src/lib/utils/schemas.ts
+++ b/frontend/src/lib/utils/schemas.ts
@@ -288,7 +288,8 @@ export const UserEditSchema = z.object({
 });
 
 export const UserCreateSchema = z.object({
-	email: z.string().email()
+	email: z.string().email(),
+	observation: z.string().optional().nullable()
 });
 
 export const ChangePasswordSchema = z.object({


### PR DESCRIPTION
Fix the issue of not saving the user observation during its creation.
It was operational only if the user exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional "observation" field when creating a new user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->