### PR TITLE
test(incidents): improve reliability

### DIFF
--- a/frontend/tests/functional/detailed/incidents.test.ts
+++ b/frontend/tests/functional/detailed/incidents.test.ts
@@ -90,6 +90,9 @@ test('Incidents full flow - creation, validation and cleanup', async ({
 			.getByTestId('form-input-observation')
 			.fill('This is an observation: I love mango juice but I prefer orange juice');
 		await page.getByText('Save').click();
+		await expect(page.getByTestId('toast')).toBeVisible();
+		await page.getByTestId('toast').getByLabel('Dismiss toast').click();
+		await expect(page.getByTestId('toast')).not.toBeVisible();
 
 		await page.getByText('Add evidence').click();
 		await page.getByTestId('form-input-name').fill('incidents-evidence-1');


### PR DESCRIPTION
Wait for success toasts to appear before running subsequent assertions
for better reliability in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved incident flow tests by verifying toast notifications appear after save actions and programmatically dismissing them before continuing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->