### PR TITLE
feat: be able to see all the applied controls attached to a reference control on its details section

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1481,7 +1481,7 @@ class AppliedControlFilterSet(GenericFilterSet):
             "category": ["exact"],
             "csf_function": ["exact"],
             "priority": ["exact"],
-            "reference_control": ["exact"],
+            "reference_control": ["exact", "isnull"],
             "effort": ["exact"],
             "control_impact": ["exact"],
             "cost": ["exact"],

--- a/frontend/src/lib/utils/crud.ts
+++ b/frontend/src/lib/utils/crud.ts
@@ -424,6 +424,14 @@ export const URL_MODEL_MAP: ModelMap = {
 			{ field: 'folder', urlModel: 'folders', urlParams: 'content_type=DO&content_type=GL' },
 			{ field: 'filtering_labels', urlModel: 'filtering-labels' }
 		],
+		reverseForeignKeyFields: [
+			{
+				field: 'reference_control',
+				urlModel: 'applied-controls',
+				disableCreate: true,
+				disableDelete: true
+			}
+		],
 		selectFields: [{ field: 'category' }, { field: 'csf_function' }],
 		filters: [{ field: 'folder' }]
 	},

--- a/frontend/src/lib/utils/table.ts
+++ b/frontend/src/lib/utils/table.ts
@@ -351,6 +351,15 @@ const RISK_ASSESSMENT_FILTER: ListViewFilterConfig = {
 	}
 };
 
+const REFERENCE_CONTROL_FILTER: ListViewFilterConfig = {
+	component: AutocompleteSelect,
+	props: {
+		label: 'referenceControl',
+		optionsEndpoint: 'reference-controls',
+		multiple: true
+	}
+};
+
 const COMPLIANCE_ASSESSMENT_FILTER: ListViewFilterConfig = {
 	component: AutocompleteSelect,
 	props: {
@@ -858,6 +867,7 @@ export const listViewFields = {
 			effort: EFFORT_FILTER,
 			control_impact: APPLIED_CONTROL_IMPACT_FILTER,
 			filtering_labels: LABELS_FILTER,
+			reference_control: REFERENCE_CONTROL_FILTER,
 			eta__lte: undefined
 		}
 	},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to filter applied controls by whether the reference control is set or not.
  * Introduced a new filter with autocomplete options for reference controls in the applied controls list view.
  * Added a reverse relationship view for reference controls, allowing users to see related applied controls (with create and delete actions disabled).

* **Enhancements**
  * Improved filtering options for applied controls, providing more flexibility in data exploration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->