### PR TITLE
fix: min width for markdown field in preview mode

### DIFF
--- a/frontend/src/lib/components/Forms/MarkdownField.svelte
+++ b/frontend/src/lib/components/Forms/MarkdownField.svelte
@@ -170,7 +170,7 @@
 				ondblclick={() => !disabled && (showPreview = false)}
 				role="button"
 				tabindex="0"
-				style="cursor: {disabled ? 'default' : 'text'}"
+				style="cursor: {disabled ? 'default' : 'text'}; min-width: {cols}ch;"
 				onkeydown={(e) => {
 					if ((e.key === 'Enter' || e.key === ' ') && !disabled) {
 						e.preventDefault();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Set a minimum width for the Markdown preview based on the configured column count to improve readability and layout stability.
  * Reduces cases where the preview appears too narrow or wraps excessively in constrained containers.
  * Ensures more consistent preview sizing across varying screen widths and responsive layouts.
  * No functional or interaction changes; this is a visual adjustment only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->