### PR TITLE
fix: ModelForm caching

### DIFF
--- a/frontend/src/lib/components/Forms/ModelForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm.svelte
@@ -153,10 +153,18 @@
 			urlModelFromPage = `${$page.url}`.replace(/^.*:\/\/[^/]+/, '');
 			createModalCache.setModelName(urlModelFromPage);
 			if (caching) {
-				createModalCache.data[model.urlModel] ??= {};
-				formDataCache = createModalCache.data[model.urlModel];
+				const currentCache = createModalCache.data[model.urlModel];
+				if (!currentCache) {
+					createModalCache.data[model.urlModel] = formDataCache;
+				} else {
+					formDataCache = currentCache;
+				}
 			}
 		}
+	});
+
+	$effect(() => {
+		createModalCache.data[model.urlModel] = formDataCache;
 	});
 
 	run(() => {

--- a/frontend/src/lib/components/Forms/ModelForm/AssetForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/AssetForm.svelte
@@ -88,14 +88,16 @@
 	optionsEndpoint="asset-class"
 	optionsLabelField="full_path"
 	field="asset_class"
+	cacheLock={cacheLocks['asset_class']}
+	bind:cachedValue={formDataCache['asset_class']}
 	label={m.assetClass()}
 />
 <TextField
 	{form}
 	field="ref_id"
-	label={m.refId()}
 	cacheLock={cacheLocks['ref_id']}
 	bind:cachedValue={formDataCache['ref_id']}
+	label={m.refId()}
 />
 
 <AutocompleteSelect

--- a/frontend/src/lib/components/Forms/TextField.svelte
+++ b/frontend/src/lib/components/Forms/TextField.svelte
@@ -50,7 +50,7 @@
 	// Store the display value separately from the actual form value
 	let displayValue: string = $state();
 
-	run(() => {
+	$effect(() => {
 		cachedValue = $value;
 	});
 

--- a/frontend/src/lib/utils/stores.ts
+++ b/frontend/src/lib/utils/stores.ts
@@ -36,6 +36,7 @@ export const expandedNodesState = persisted('expandedNodes', expandedNodes, {
 export const createModalCache = {
 	_urlModel: '',
 	_cacheToDelete: new Set(),
+	data: {},
 	deleteCache(cacheName: any) {
 		this._cacheToDelete.add(cacheName);
 	},
@@ -53,8 +54,7 @@ export const createModalCache = {
 	setModelName(urlModelFromPage: string) {
 		if (this._urlModel !== urlModelFromPage) this.clear();
 		this._urlModel = urlModelFromPage;
-	},
-	data: {}
+	}
 };
 
 export const driverInstance = writable<Driver | null>(null);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Form inputs now reliably persist per model, preventing lost changes when switching or revisiting forms.
  * Asset class selection is retained between interactions for smoother editing.

* **Refactor**
  * Updated input reactivity to improve reliability and responsiveness during form updates.

* **Chores**
  * Internal cache structure streamlined to keep shared and local form state in sync without altering public behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->