### PR TITLE
fix: safe display of ref_id for req nodes without one

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -1303,6 +1303,11 @@ class RequirementNode(ReferentialObjectMixin, I18nObjectMixin):
             "description": parent_requirement.description,
         }
 
+    @property
+    def safe_display_str(self):
+        fallback_ref = ":".join(self.urn.split(":")[5:])
+        return self.display_short if self.display_short else fallback_ref
+
     class Meta:
         verbose_name = _("RequirementNode")
         verbose_name_plural = _("RequirementNodes")
@@ -4018,7 +4023,7 @@ class ComplianceAssessment(Assessment):
                 new_result = infer_result(ac)
                 if ra.result != new_result:
                     changes[str(ra.id)] = {
-                        "str": str(ra),
+                        "str": str(ra.requirement.safe_display_str),
                         "current": ra.result,
                         "new": new_result,
                     }

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -705,7 +705,7 @@ class ComplianceAssessmentActionPlanSerializer(ActionPlanSerializer):
         )
         return [
             {
-                "str": str(req.requirement.display_short or req.requirement.urn),
+                "str": str(req.requirement.safe_display_str),
                 "id": str(req.id),
             }
             for req in requirement_assessments

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -2030,8 +2030,10 @@ class AppliedControlViewSet(BaseModelViewSet):
             for req in RequirementAssessment.objects.filter(applied_controls__id=ac.id):
                 nodes.append(
                     {
-                        "name": req.requirement.ref_id,
-                        "value": req.requirement.description,
+                        "name": req.requirement.ref_id
+                        or req.requirement.safe_display_str,
+                        "value": req.requirement.description
+                        or req.requirement.safe_display_str,
                         "category": 7,
                         "symbol": "triangle",
                     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved readability of requirement names across the app: change reports, action plans, and impact graphs now show clearer, human-friendly requirement labels with a consistent fallback when a short name isn’t available.
  * Consistent requirement display formatting ensures users see meaningful references instead of raw identifiers, improving clarity in compliance and risk summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->