### PR TITLE
feat: filters for findings table

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -5791,6 +5791,15 @@ class FindingViewSet(BaseModelViewSet):
     def severity(self, request):
         return Response(dict(Severity.choices))
 
+    @action(detail=False, name="Get all findings owners")
+    def owner(self, request):
+        return Response(
+            UserReadSerializer(
+                User.objects.filter(findings__isnull=False).distinct(),
+                many=True,
+            ).data
+        )
+
 
 class IncidentViewSet(BaseModelViewSet):
     model = Incident

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -5775,6 +5775,7 @@ class FindingViewSet(BaseModelViewSet):
         "owner",
         "folder",
         "status",
+        "severity",
         "findings_assessment",
         "filtering_labels",
         "applied_controls",

--- a/frontend/src/lib/utils/table.ts
+++ b/frontend/src/lib/utils/table.ts
@@ -750,6 +750,16 @@ const OWNER_FILTER: ListViewFilterConfig = {
 		multiple: true
 	}
 };
+const FINDINGS_OWNER_FILTER: ListViewFilterConfig = {
+	component: AutocompleteSelect,
+	props: {
+		label: 'owner',
+		optionsLabelField: 'email',
+		optionsValueField: 'id',
+		optionsEndpoint: 'findings/owner',
+		multiple: true
+	}
+};
 
 const HAS_UPDATE_FILTER: ListViewFilterConfig = {
 	component: AutocompleteSelect,
@@ -1402,7 +1412,8 @@ export const listViewFields = {
 		filters: {
 			filtering_labels: LABELS_FILTER,
 			severity: FINDINGS_SEVERITY_FILTER,
-			status: FINDINGS_STATUS_FILTER
+			status: FINDINGS_STATUS_FILTER,
+			owner: FINDINGS_OWNER_FILTER
 		}
 	},
 	incidents: {

--- a/frontend/src/lib/utils/table.ts
+++ b/frontend/src/lib/utils/table.ts
@@ -270,6 +270,28 @@ const INCIDENT_SEVERITY_FILTER: ListViewFilterConfig = {
 		multiple: true
 	}
 };
+const FINDINGS_SEVERITY_FILTER: ListViewFilterConfig = {
+	component: AutocompleteSelect,
+	props: {
+		optionsEndpoint: 'findings/severity',
+		optionsLabelField: 'label',
+		optionsValueField: 'value',
+		label: 'severity',
+		browserCache: 'force-cache',
+		multiple: true
+	}
+};
+const FINDINGS_STATUS_FILTER: ListViewFilterConfig = {
+	component: AutocompleteSelect,
+	props: {
+		optionsEndpoint: 'findings/status',
+		optionsLabelField: 'label',
+		optionsValueField: 'value',
+		label: 'status',
+		browserCache: 'force-cache',
+		multiple: true
+	}
+};
 const EXCEPTION_SEVERITY_FILTER: ListViewFilterConfig = {
 	component: AutocompleteSelect,
 	props: {
@@ -1377,7 +1399,11 @@ export const listViewFields = {
 			'applied_controls',
 			'filtering_labels'
 		],
-		filters: { filtering_labels: LABELS_FILTER }
+		filters: {
+			filtering_labels: LABELS_FILTER,
+			severity: FINDINGS_SEVERITY_FILTER,
+			status: FINDINGS_STATUS_FILTER
+		}
 	},
 	incidents: {
 		head: [


### PR DESCRIPTION
- **feat: filters on Findings view**
- **filter per owner**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Findings list now includes multi-select filters for Severity, Status, and Owner, with autocomplete dropdowns for quick selection.
  - Filtered results in the findings view reflect chosen values across all three filters.
  - API enhancements: added support to filter findings by severity and a new endpoint to retrieve users who own at least one finding, enabling owner-based filtering in clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->