### PR TITLE
feat: autolock deprecated assessments and due audits withing campaigns or third parties review

### DIFF
--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -285,6 +285,17 @@ class RiskAssessmentWriteSerializer(BaseModelSerializer):
                 )
         return super().validate(attrs)
 
+    def update(self, instance, validated_data):
+        # Check if status is changing to deprecated
+        old_status = instance.status
+        new_status = validated_data.get("status", old_status)
+
+        # Auto-lock when status changes to deprecated
+        if old_status != "deprecated" and new_status == "deprecated":
+            validated_data["is_locked"] = True
+
+        return super().update(instance, validated_data)
+
     class Meta:
         model = RiskAssessment
         exclude = ["created_at", "updated_at"]
@@ -1322,6 +1333,14 @@ class ComplianceAssessmentWriteSerializer(BaseModelSerializer):
         # Track old authors before update
         old_author_ids = set(instance.authors.values_list("id", flat=True))
 
+        # Check if status is changing to deprecated
+        old_status = instance.status
+        new_status = validated_data.get("status", old_status)
+
+        # Auto-lock when status changes to deprecated
+        if old_status != "deprecated" and new_status == "deprecated":
+            validated_data["is_locked"] = True
+
         updated_instance = super().update(instance, validated_data)
 
         # Get new authors after update
@@ -1591,6 +1610,17 @@ class FindingsAssessmentWriteSerializer(BaseModelSerializer):
                     f"⚠️ Cannot modify the findings assessment attributes when it is locked. Only the 'Locked' field can be modified."
                 )
         return super().validate(attrs)
+
+    def update(self, instance, validated_data):
+        # Check if status is changing to deprecated
+        old_status = instance.status
+        new_status = validated_data.get("status", old_status)
+
+        # Auto-lock when status changes to deprecated
+        if old_status != "deprecated" and new_status == "deprecated":
+            validated_data["is_locked"] = True
+
+        return super().update(instance, validated_data)
 
     class Meta:
         model = FindingsAssessment

--- a/backend/core/tasks.py
+++ b/backend/core/tasks.py
@@ -2,8 +2,10 @@ from datetime import date, timedelta
 from huey import crontab
 from huey.contrib.djhuey import periodic_task, task, db_periodic_task, db_task
 from core.models import AppliedControl, ComplianceAssessment
+from tprm.models import EntityAssessment
 from django.core.mail import send_mail
 from django.conf import settings
+from django.db import models
 import logging
 from global_settings.models import GlobalSettings
 
@@ -386,3 +388,36 @@ def send_applied_control_expiring_soon_notification(owner_email, controls, days)
         logger.error(
             f"Failed to render {template_name} email template for {owner_email}"
         )
+
+
+# @db_periodic_task(crontab(minute="*/1"))  # for testing
+@db_periodic_task(crontab(hour="6", minute="30"))
+def lock_overdue_compliance_assessments():
+    """Lock ComplianceAssessments that have exceeded their due_date and move status to in_review"""
+    overdue_assessments = (
+        ComplianceAssessment.objects.filter(
+            due_date__lt=date.today(), due_date__isnull=False, is_locked=False
+        )
+        .exclude(status__in=["done", "deprecated"])
+        .filter(
+            models.Q(campaign__isnull=False)  # Associated with a campaign
+            | models.Q(
+                entityassessment__isnull=False
+            )  # Or associated with an entity assessment
+        )
+    )
+
+    count = 0
+    for assessment in overdue_assessments:
+        assessment.is_locked = True
+        assessment.status = "in_review"
+        assessment.save()
+        count += 1
+        logger.info(
+            f"Locked overdue compliance assessment: {assessment.name} (ID: {assessment.id})"
+        )
+
+    if count > 0:
+        logger.info(f"Successfully locked {count} overdue compliance assessments")
+    else:
+        logger.debug("No overdue compliance assessments found to lock")

--- a/backend/core/tasks.py
+++ b/backend/core/tasks.py
@@ -391,7 +391,7 @@ def send_applied_control_expiring_soon_notification(owner_email, controls, days)
 
 
 # @db_periodic_task(crontab(minute="*/1"))  # for testing
-@db_periodic_task(crontab(hour="6", minute="30"))
+@db_periodic_task(crontab(hour="2", minute="30"))
 def lock_overdue_compliance_assessments():
     """Lock ComplianceAssessments that have exceeded their due_date and move status to in_review"""
     overdue_assessments = (
@@ -405,6 +405,7 @@ def lock_overdue_compliance_assessments():
                 entityassessment__isnull=False
             )  # Or associated with an entity assessment
         )
+        .distinct()
     )
 
     count = 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Items changing to "Deprecated" are now automatically locked to prevent further edits.
  * Overdue compliance assessments are automatically locked each morning and moved to "In Review".
  * Automation includes assessments linked to campaigns or to entity assessments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->