### PR TITLE
fix: set focus on the first field automatically for TOTP and autosubmit if all digits filled

### DIFF
--- a/frontend/src/lib/components/Forms/OTP/OTPInput.svelte
+++ b/frontend/src/lib/components/Forms/OTP/OTPInput.svelte
@@ -85,19 +85,28 @@
 	});
 
 	$effect(() => {
-		if (inputs[0]) {
-			setTimeout(() => {
+		if (!inputs[0]) return;
+		const id = setTimeout(() => {
+			if (document.activeElement !== inputs[0]) {
 				inputs[0]?.focus();
-			}, 200);
-		}
+			}
+		}, 200);
+		return () => clearTimeout(id);
 	});
 
+	let autoSubmitInFlight = false;
 	$effect(() => {
-		if (codes.length === numOfInputs && codes.every((code) => code !== '')) {
-			setTimeout(() => {
-				form.submit();
-			}, 100);
-		}
+		const complete = codes.length === numOfInputs && codes.every((code) => code !== '');
+		if (!complete || autoSubmitInFlight) return;
+
+		const id = setTimeout(() => {
+			autoSubmitInFlight = true;
+			form.submit().finally(() => {
+				autoSubmitInFlight = false;
+			});
+		}, 100);
+
+		return () => clearTimeout(id);
 	});
 </script>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OTP input now auto-focuses the first field when the component is ready, improving entry speed and reliability.
  * OTP form now auto-submits shortly after all fields are filled, streamlining verification.
  * Adds brief delays to ensure consistent focus and submit behavior across renders; complements existing manual reset focus.
  * No changes to public APIs or external behavior beyond improved UX.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->