### PR TITLE
fix: swap save <-> save and continue

### DIFF
--- a/frontend/src/lib/components/Chart/LossExceedanceCurve.svelte
+++ b/frontend/src/lib/components/Chart/LossExceedanceCurve.svelte
@@ -11,14 +11,14 @@
 		title?: string;
 		xAxisLabel?: string;
 		yAxisLabel?: string;
-    minorSplitLine?:  boolean;
-    enableTooltip?: boolean;
-    xAxisScale?: 'linear' | 'log';
-    yAxisScale?: 'linear' | 'log';
-    showXGrid?: boolean;
-    showYGrid?: boolean;
-    xMax?: number;
-    autoYMax?: boolean;
+		minorSplitLine?: boolean;
+		enableTooltip?: boolean;
+		xAxisScale?: 'linear' | 'log';
+		yAxisScale?: 'linear' | 'log';
+		showXGrid?: boolean;
+		showYGrid?: boolean;
+		xMax?: number;
+		autoYMax?: boolean;
 	}
 
 	let {
@@ -27,18 +27,18 @@
 		classesContainer = '',
 		name = 'loss-exceedance',
 		data = undefined,
-    toleranceData = undefined,
+		toleranceData = undefined,
 		title = 'Loss Exceedance Curve',
 		xAxisLabel = 'Loss Amount ($)',
 		yAxisLabel = 'Exceedance Probability',
-    minorSplitLine = false,
-    enableTooltip = false,
-    xAxisScale = 'log',
-    yAxisScale = 'linear',
-    showXGrid = true,
-    showYGrid = true,
-    xMax = 1000000,
-    autoYMax = false,
+		minorSplitLine = false,
+		enableTooltip = false,
+		xAxisScale = 'log',
+		yAxisScale = 'linear',
+		showXGrid = true,
+		showYGrid = true,
+		xMax = 1000000,
+		autoYMax = false
 	}: Props = $props();
 
 	const chart_id = `${name}_div`;
@@ -67,7 +67,7 @@
 				bottom: '15%'
 			},
 			tooltip: {
-        show: !!enableTooltip,
+				show: !!enableTooltip,
 				trigger: 'axis',
 				formatter: function (params: any) {
 					const point = params[0];
@@ -78,8 +78,8 @@
 				type: xAxisScale,
 				name: xAxisLabel,
 				nameLocation: 'middle',
-        min: xMin,
-        max: xMax,
+				min: xMin,
+				max: xMax,
 				nameGap: 30,
 				minorSplitLine: {
 					show: minorSplitLine
@@ -110,7 +110,7 @@
 				name: yAxisLabel,
 				nameLocation: 'middle',
 				nameGap: 50,
-				max: yAxisScale === 'log' ? undefined : (autoYMax ? undefined : 1),
+				max: yAxisScale === 'log' ? undefined : autoYMax ? undefined : 1,
 				axisLabel: {
 					formatter: function (value: number) {
 						return (value * 100).toFixed(0) + '%';
@@ -149,7 +149,7 @@
 						])
 					},
 					data: data
-				},
+				}
 			]
 		};
 

--- a/frontend/src/routes/(app)/(internal)/experimental/loss-exceedance/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/experimental/loss-exceedance/+page.svelte
@@ -9,33 +9,33 @@
 	const generateMonteCarloSampleData = () => {
 		// Define 25 samples organized as powers of 10
 		const percentiles = [
-			{ loss: 1, exceedance: 0.6 },      // 60% chance of exceeding $100 (10^2)
-			{ loss: 10, exceedance: 0.595 },      // 60% chance of exceeding $100 (10^2)
-			{ loss: 100, exceedance: 0.59 },      // 60% chance of exceeding $100 (10^2)
-			{ loss: 200, exceedance: 0.58 },      // 58% chance of exceeding $200
-			{ loss: 500, exceedance: 0.55 },      // 55% chance of exceeding $500
-			{ loss: 1000, exceedance: 0.52 },     // 52% chance of exceeding $1K (10^3)
-			{ loss: 2000, exceedance: 0.49 },     // 49% chance of exceeding $2K
-			{ loss: 5000, exceedance: 0.45 },     // 45% chance of exceeding $5K
-			{ loss: 10000, exceedance: 0.42 },    // 42% chance of exceeding $10K (10^4)
-			{ loss: 20000, exceedance: 0.38 },    // 38% chance of exceeding $20K
-			{ loss: 50000, exceedance: 0.34 },    // 34% chance of exceeding $50K
-			{ loss: 100000, exceedance: 0.30 },   // 30% chance of exceeding $100K (10^5)
-			{ loss: 200000, exceedance: 0.26 },   // 26% chance of exceeding $200K
-			{ loss: 500000, exceedance: 0.22 },   // 22% chance of exceeding $500K
-			{ loss: 1000000, exceedance: 0.18 },  // 18% chance of exceeding $1M (10^6)
-			{ loss: 2000000, exceedance: 0.15 },  // 15% chance of exceeding $2M
-			{ loss: 5000000, exceedance: 0.12 },  // 12% chance of exceeding $5M
+			{ loss: 1, exceedance: 0.6 }, // 60% chance of exceeding $100 (10^2)
+			{ loss: 10, exceedance: 0.595 }, // 60% chance of exceeding $100 (10^2)
+			{ loss: 100, exceedance: 0.59 }, // 60% chance of exceeding $100 (10^2)
+			{ loss: 200, exceedance: 0.58 }, // 58% chance of exceeding $200
+			{ loss: 500, exceedance: 0.55 }, // 55% chance of exceeding $500
+			{ loss: 1000, exceedance: 0.52 }, // 52% chance of exceeding $1K (10^3)
+			{ loss: 2000, exceedance: 0.49 }, // 49% chance of exceeding $2K
+			{ loss: 5000, exceedance: 0.45 }, // 45% chance of exceeding $5K
+			{ loss: 10000, exceedance: 0.42 }, // 42% chance of exceeding $10K (10^4)
+			{ loss: 20000, exceedance: 0.38 }, // 38% chance of exceeding $20K
+			{ loss: 50000, exceedance: 0.34 }, // 34% chance of exceeding $50K
+			{ loss: 100000, exceedance: 0.3 }, // 30% chance of exceeding $100K (10^5)
+			{ loss: 200000, exceedance: 0.26 }, // 26% chance of exceeding $200K
+			{ loss: 500000, exceedance: 0.22 }, // 22% chance of exceeding $500K
+			{ loss: 1000000, exceedance: 0.18 }, // 18% chance of exceeding $1M (10^6)
+			{ loss: 2000000, exceedance: 0.15 }, // 15% chance of exceeding $2M
+			{ loss: 5000000, exceedance: 0.12 }, // 12% chance of exceeding $5M
 			{ loss: 10000000, exceedance: 0.09 }, // 9% chance of exceeding $10M (10^7)
 			{ loss: 20000000, exceedance: 0.07 }, // 7% chance of exceeding $20M
 			{ loss: 50000000, exceedance: 0.05 }, // 5% chance of exceeding $50M
 			{ loss: 100000000, exceedance: 0.035 }, // 3.5% chance of exceeding $100M (10^8)
 			{ loss: 200000000, exceedance: 0.025 }, // 2.5% chance of exceeding $200M
 			{ loss: 500000000, exceedance: 0.018 }, // 1.8% chance of exceeding $500M
-			{ loss: 1000000000, exceedance: 0.012 }, // 1.2% chance of exceeding $1B (10^9)
+			{ loss: 1000000000, exceedance: 0.012 } // 1.2% chance of exceeding $1B (10^9)
 		];
 
-		return percentiles.map(p => [p.loss, p.exceedance]);
+		return percentiles.map((p) => [p.loss, p.exceedance]);
 	};
 
 	const sampleData = generateMonteCarloSampleData();
@@ -45,14 +45,16 @@
 	<div class="text-center">
 		<h1 class="text-3xl font-bold text-gray-900 mb-2">Loss Exceedance Curve Analysis</h1>
 		<p class="text-gray-600 max-w-3xl mx-auto">
-			Loss Exceedance Curves show the probability that losses will exceed a given amount.
-			These curves are essential for risk quantification and help organizations understand
-			their potential financial exposure to various risk scenarios.
+			Loss Exceedance Curves show the probability that losses will exceed a given amount. These
+			curves are essential for risk quantification and help organizations understand their potential
+			financial exposure to various risk scenarios.
 		</p>
 	</div>
 
 	<div class="bg-white rounded-lg shadow-lg p-6">
-		<h2 class="text-xl font-semibold mb-4 text-center">Chart Comparison: Full vs Light Rendering</h2>
+		<h2 class="text-xl font-semibold mb-4 text-center">
+			Chart Comparison: Full vs Light Rendering
+		</h2>
 
 		<div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
 			<!-- Full featured chart -->
@@ -67,7 +69,7 @@
 					yAxisScale="linear"
 					showXGrid={true}
 					showYGrid={true}
-          minorSplitLine={true}
+					minorSplitLine={true}
 				/>
 			</div>
 
@@ -85,8 +87,8 @@
 					showYGrid={false}
 					xAxisLabel=""
 					yAxisLabel=""
-          autoYMax={true}
-          xMax={100_000}
+					autoYMax={true}
+					xMax={100_000}
 				/>
 			</div>
 		</div>

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.svelte
@@ -638,7 +638,7 @@
 							onclick={cancel}>{m.cancel()}</button
 						>
 						<button
-							class="btn preset-filled-primary-500 font-semibold w-full"
+							class="btn preset-filled-secondary-500 font-semibold w-full"
 							data-testid="save-no-continue-button"
 							type="submit"
 							onclick={() =>
@@ -647,7 +647,7 @@
 								})}>{m.saveAndContinue()}</button
 						>
 						<button
-							class="btn preset-filled-secondary-500 font-semibold w-full"
+							class="btn preset-filled-primary-500 font-semibold w-full"
 							data-testid="save-button"
 							type="submit">{m.save()}</button
 						>

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.svelte
@@ -644,12 +644,12 @@
 							onclick={() =>
 								form.form.update((data) => {
 									return { ...data, noRedirect: true };
-								})}>{m.save()}</button
+								})}>{m.saveAndContinue()}</button
 						>
 						<button
 							class="btn preset-filled-secondary-500 font-semibold w-full"
 							data-testid="save-button"
-							type="submit">{m.saveAndContinue()}</button
+							type="submit">{m.save()}</button
 						>
 					</div>
 				</div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Swapped labels and visual emphasis of the two buttons on the Requirement Assessment edit page; primary "Save" remains the main submit action and the secondary "Save & Continue" retains its non-redirect behavior. No changes to navigation, validation, or error handling.
  * Cleaned up formatting and spacing on Loss Exceedance charts and pages; visuals and data rendering remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->