### PR TITLE
doc(spec): localization of user-defined fields

### DIFF
--- a/documentation/architecture/data-model.md
+++ b/documentation/architecture/data-model.md
@@ -1045,7 +1045,7 @@ Example:
 
 The general approach is to translate everything in the frontend. We use paraglide to faciliate this process.
 
-One notable exception is that referential objects are translated by the backend. The ACCEPT_LANGUAGE header in the request is used to indicate which language is used on the frontend side. The backend selects the most appropriate language to use (either the requested language, or the default language of the library).
+One notable exception is that referential objects are translated by the backend. The Accept-Language header in the request is used to indicate which language is used on the frontend side. The backend selects the most appropriate language to use (either the requested language, or the default language of the library).
 
 Other user-defined, non-referential objects can also be localized in the same way, by supporting the "translations" field. A dedicated mixin "CustomTranslations" will be used. The UX shall be non-intrusive, and propose localization only as an option.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded internationalization guidance to allow optional localization of user-defined (non-referential) objects via a translations field and a CustomTranslations mixin.
  * Clarified Accept-Language header usage and standardized terminology for backend-translated referential objects.
  * Revised wording to soften the translation exception phrasing.
  * Retained note about frontend/backend handling of generated documents.
  * Known issue: the new guidance appears twice and will be consolidated later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->