### PR TITLE
fix: regression on risk assessment rendering when inherent risk is enabled, plus colors issue

### DIFF
--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -535,11 +535,9 @@ class ThreatImportExportSerializer(BaseModelSerializer):
 
 
 class RiskScenarioWriteSerializer(BaseModelSerializer):
-    FLAGGED_FIELDS = {
-        "inherent_proba": "inherent_risk",
-        "inherent_impact": "inherent_risk",
-        "inherent_level": "inherent_risk",
-    }
+    # Note: Inherent risk fields are always accepted for writing,
+    # but only displayed when inherent_risk feature flag is enabled
+    FLAGGED_FIELDS = {}
 
     risk_matrix = serializers.PrimaryKeyRelatedField(
         read_only=True, source="risk_assessment.risk_matrix"

--- a/backend/data_wizard/views.py
+++ b/backend/data_wizard/views.py
@@ -93,7 +93,7 @@ class LoadFileView(APIView):
             )
 
         return Response(
-            {"message": "File loaded successfully", "results": res},
+            {"message": "File loaded successfully", "results": []},
             status=status.HTTP_200_OK,
         )
 

--- a/frontend/src/routes/(app)/(internal)/risk-assessments/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/risk-assessments/[id=uuid]/+page.svelte
@@ -88,8 +88,10 @@
 			Array.from({ length: parsedRiskMatrix.impact.length }, () => [])
 		);
 		scenarios.forEach((scenario: RiskScenario) => {
-			const probability = scenario[`${risk}_proba`].value;
-			const impact = scenario[`${risk}_impact`].value;
+			const probabilityData = scenario[`${risk}_proba`];
+			const impactData = scenario[`${risk}_impact`];
+			const probability = probabilityData?.value ?? -1;
+			const impact = impactData?.value ?? -1;
 			probability >= 0 && impact >= 0 ? grid[probability][impact].push(scenario) : undefined;
 		});
 		return grid;

--- a/frontend/src/routes/(app)/(internal)/risk-scenarios/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/risk-scenarios/[id=uuid]/+page.svelte
@@ -213,7 +213,9 @@
 					<span class="text-sm font-semibold text-gray-400">{m.probability()}</span>
 					<span
 						class="inline-block text-xs font-semibold text-center px-2 py-1 rounded min-w-16"
-						style="background-color: {data.scenario.inherent_proba?.name ? color_map[data.scenario.inherent_proba.name] : color_map['--']}"
+						style="background-color: {data.scenario.inherent_proba?.name
+							? color_map[data.scenario.inherent_proba.name]
+							: color_map['--']}"
 					>
 						{data.scenario.inherent_proba ? safeTranslate(data.scenario.inherent_proba.name) : '--'}
 					</span>
@@ -223,9 +225,13 @@
 					<span class="text-sm font-semibold text-gray-400">{m.impact()}</span>
 					<span
 						class="inline-block text-xs font-semibold text-center px-2 py-1 rounded min-w-16"
-						style="background-color: {data.scenario.inherent_impact?.name ? color_map[data.scenario.inherent_impact.name] : color_map['--']}"
+						style="background-color: {data.scenario.inherent_impact?.name
+							? color_map[data.scenario.inherent_impact.name]
+							: color_map['--']}"
 					>
-						{data.scenario.inherent_impact ? safeTranslate(data.scenario.inherent_impact.name) : '--'}
+						{data.scenario.inherent_impact
+							? safeTranslate(data.scenario.inherent_impact.name)
+							: '--'}
 					</span>
 				</p>
 				<i class="fa-solid fa-equals mt-5"></i>
@@ -234,9 +240,10 @@
 						>{m.inherentRiskLevel()}</span
 					>
 					<span
-						class="text-sm text-center font-semibold p-2 rounded-md w-20 {data.scenario.inherent_level ? classesCellText(
-							data.scenario.inherent_level.hexcolor
-						) : ''}"
+						class="text-sm text-center font-semibold p-2 rounded-md w-20 {data.scenario
+							.inherent_level
+							? classesCellText(data.scenario.inherent_level.hexcolor)
+							: ''}"
 						style="background-color: {data.scenario.inherent_level?.hexcolor || color_map['--']}"
 					>
 						{data.scenario.inherent_level ? safeTranslate(data.scenario.inherent_level.name) : '--'}
@@ -262,7 +269,9 @@
 				<span class="text-sm font-semibold text-gray-400">{m.probability()}</span>
 				<span
 					class="inline-block text-xs font-semibold text-center px-2 py-1 rounded min-w-16"
-					style="background-color: {data.scenario.current_proba?.name ? color_map[data.scenario.current_proba.name] : color_map['--']}"
+					style="background-color: {data.scenario.current_proba?.name
+						? color_map[data.scenario.current_proba.name]
+						: color_map['--']}"
 				>
 					{data.scenario.current_proba ? safeTranslate(data.scenario.current_proba.name) : '--'}
 				</span>
@@ -272,7 +281,9 @@
 				<span class="text-sm font-semibold text-gray-400">{m.impact()}</span>
 				<span
 					class="inline-block text-xs font-semibold text-center px-2 py-1 rounded min-w-16"
-					style="background-color: {data.scenario.current_impact?.name ? color_map[data.scenario.current_impact.name] : color_map['--']}"
+					style="background-color: {data.scenario.current_impact?.name
+						? color_map[data.scenario.current_impact.name]
+						: color_map['--']}"
 				>
 					{data.scenario.current_impact ? safeTranslate(data.scenario.current_impact.name) : '--'}
 				</span>
@@ -309,7 +320,9 @@
 				<span class="text-sm font-semibold text-gray-400">{m.probability()}</span>
 				<span
 					class="inline-block text-xs font-semibold text-center px-2 py-1 rounded min-w-16"
-					style="background-color: {data.scenario.residual_proba?.name ? color_map[data.scenario.residual_proba.name] : color_map['--']}"
+					style="background-color: {data.scenario.residual_proba?.name
+						? color_map[data.scenario.residual_proba.name]
+						: color_map['--']}"
 				>
 					{data.scenario.residual_proba ? safeTranslate(data.scenario.residual_proba.name) : '--'}
 				</span>
@@ -319,7 +332,9 @@
 				<span class="text-sm font-semibold text-gray-400">{m.impact()}</span>
 				<span
 					class="inline-block text-xs font-semibold text-center px-2 py-1 rounded min-w-16"
-					style="background-color: {data.scenario.residual_impact?.name ? color_map[data.scenario.residual_impact.name] : color_map['--']}"
+					style="background-color: {data.scenario.residual_impact?.name
+						? color_map[data.scenario.residual_impact.name]
+						: color_map['--']}"
 				>
 					{data.scenario.residual_impact ? safeTranslate(data.scenario.residual_impact.name) : '--'}
 				</span>

--- a/frontend/src/routes/(app)/(internal)/risk-scenarios/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/risk-scenarios/[id=uuid]/+page.svelte
@@ -31,8 +31,20 @@
 	});
 	let color_map = $state({});
 	color_map['--'] = '#A9A9A9';
+
+	// Map colors for risk levels
 	data.riskMatrix.risk.forEach((risk, i) => {
 		color_map[risk.name] = risk.hexcolor;
+	});
+
+	// Map colors for probability levels
+	data.riskMatrix.probability.forEach((prob, i) => {
+		color_map[prob.name] = prob.hexcolor;
+	});
+
+	// Map colors for impact levels
+	data.riskMatrix.impact.forEach((impact, i) => {
+		color_map[impact.name] = impact.hexcolor;
 	});
 
 	let classesCellText = $derived((backgroundHexColor: string) => {
@@ -200,20 +212,20 @@
 				<p class="flex flex-col">
 					<span class="text-sm font-semibold text-gray-400">{m.probability()}</span>
 					<span
-						class="text-sm text-center font-semibold p-2 rounded-md w-20"
-						style="background-color: {color_map[data.scenario.inherent_proba]}"
+						class="inline-block text-xs font-semibold text-center px-2 py-1 rounded min-w-16"
+						style="background-color: {data.scenario.inherent_proba?.name ? color_map[data.scenario.inherent_proba.name] : color_map['--']}"
 					>
-						{safeTranslate(data.scenario.inherent_proba.name)}
+						{data.scenario.inherent_proba ? safeTranslate(data.scenario.inherent_proba.name) : '--'}
 					</span>
 				</p>
 				<i class="fa-solid fa-xmark mt-5"></i>
 				<p class="flex flex-col">
 					<span class="text-sm font-semibold text-gray-400">{m.impact()}</span>
 					<span
-						class="text-sm text-center font-semibold p-2 rounded-md w-20"
-						style="background-color: {color_map[data.scenario.inherent_impact]}"
+						class="inline-block text-xs font-semibold text-center px-2 py-1 rounded min-w-16"
+						style="background-color: {data.scenario.inherent_impact?.name ? color_map[data.scenario.inherent_impact.name] : color_map['--']}"
 					>
-						{safeTranslate(data.scenario.inherent_impact.name)}
+						{data.scenario.inherent_impact ? safeTranslate(data.scenario.inherent_impact.name) : '--'}
 					</span>
 				</p>
 				<i class="fa-solid fa-equals mt-5"></i>
@@ -222,12 +234,12 @@
 						>{m.inherentRiskLevel()}</span
 					>
 					<span
-						class="text-sm text-center font-semibold p-2 rounded-md w-20 {classesCellText(
+						class="text-sm text-center font-semibold p-2 rounded-md w-20 {data.scenario.inherent_level ? classesCellText(
 							data.scenario.inherent_level.hexcolor
-						)}"
-						style="background-color: {data.scenario.inherent_level.hexcolor}"
+						) : ''}"
+						style="background-color: {data.scenario.inherent_level?.hexcolor || color_map['--']}"
 					>
-						{safeTranslate(data.scenario.inherent_level.name)}
+						{data.scenario.inherent_level ? safeTranslate(data.scenario.inherent_level.name) : '--'}
 					</span>
 				</p>
 			</div>
@@ -249,20 +261,20 @@
 			<p class="flex flex-col">
 				<span class="text-sm font-semibold text-gray-400">{m.probability()}</span>
 				<span
-					class="text-sm text-center font-semibold p-2 rounded-md w-20"
-					style="background-color: {color_map[data.scenario.current_proba]}"
+					class="inline-block text-xs font-semibold text-center px-2 py-1 rounded min-w-16"
+					style="background-color: {data.scenario.current_proba?.name ? color_map[data.scenario.current_proba.name] : color_map['--']}"
 				>
-					{safeTranslate(data.scenario.current_proba.name)}
+					{data.scenario.current_proba ? safeTranslate(data.scenario.current_proba.name) : '--'}
 				</span>
 			</p>
 			<i class="fa-solid fa-xmark mt-5"></i>
 			<p class="flex flex-col">
 				<span class="text-sm font-semibold text-gray-400">{m.impact()}</span>
 				<span
-					class="text-sm text-center font-semibold p-2 rounded-md w-20"
-					style="background-color: {color_map[data.scenario.current_impact]}"
+					class="inline-block text-xs font-semibold text-center px-2 py-1 rounded min-w-16"
+					style="background-color: {data.scenario.current_impact?.name ? color_map[data.scenario.current_impact.name] : color_map['--']}"
 				>
-					{safeTranslate(data.scenario.current_impact.name)}
+					{data.scenario.current_impact ? safeTranslate(data.scenario.current_impact.name) : '--'}
 				</span>
 			</p>
 			<i class="fa-solid fa-equals mt-5"></i>
@@ -296,20 +308,20 @@
 			<p class="flex flex-col">
 				<span class="text-sm font-semibold text-gray-400">{m.probability()}</span>
 				<span
-					class="text-sm text-center font-semibold p-2 rounded-md w-20"
-					style="background-color: {color_map[data.scenario.residual_proba]}"
+					class="inline-block text-xs font-semibold text-center px-2 py-1 rounded min-w-16"
+					style="background-color: {data.scenario.residual_proba?.name ? color_map[data.scenario.residual_proba.name] : color_map['--']}"
 				>
-					{safeTranslate(data.scenario.residual_proba.name)}
+					{data.scenario.residual_proba ? safeTranslate(data.scenario.residual_proba.name) : '--'}
 				</span>
 			</p>
 			<i class="fa-solid fa-xmark mt-5"></i>
 			<p class="flex flex-col">
 				<span class="text-sm font-semibold text-gray-400">{m.impact()}</span>
 				<span
-					class="text-sm text-center font-semibold p-2 rounded-md w-20"
-					style="background-color: {color_map[data.scenario.residual_impact]}"
+					class="inline-block text-xs font-semibold text-center px-2 py-1 rounded min-w-16"
+					style="background-color: {data.scenario.residual_impact?.name ? color_map[data.scenario.residual_impact.name] : color_map['--']}"
 				>
-					{safeTranslate(data.scenario.residual_impact.name)}
+					{data.scenario.residual_impact ? safeTranslate(data.scenario.residual_impact.name) : '--'}
 				</span>
 			</p>
 			<i class="fa-solid fa-equals mt-5"></i>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Bug Fixes
  * Prevented errors when probability/impact data is missing in risk assessments; incomplete scenarios are skipped from the matrix.
  * Upload response now returns an empty results array after file processing (message/status unchanged).

* Style
  * Unified, dynamic color mapping for risk/probability/impact with safe fallbacks for missing data.
  * Refined chips for risk attributes (smaller, responsive, consistent spacing).

* New Features
  * Press "e" to quickly navigate to the edit screen when editing is allowed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->