### PR TITLE
fix: error 500 on ebios rm visual analysis with Risk Origin migration

### DIFF
--- a/backend/ebios_rm/helpers.py
+++ b/backend/ebios_rm/helpers.py
@@ -152,7 +152,7 @@ def ebios_rm_visual_analysis(study):
     for ro_to in rotos:
         nodes.append(
             {
-                "name": ro_to.risk_origin,
+                "name": ro_to.risk_origin.get_name_translated,
                 "category": 2,
                 "symbolSize": 25,
             }
@@ -176,7 +176,7 @@ def ebios_rm_visual_analysis(study):
             }
         )
         entry = {
-            "ro": ro_to.risk_origin,
+            "ro": ro_to.risk_origin.get_name_translated,
             "to": ro_to.target_objective,
             "feared_events": [
                 {"name": fe.name, "assets": [a.name for a in fe.assets.all()]}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Visual analysis now displays translated risk origin names for both node labels and entry details, ensuring consistent localization throughout the view.
  * Resolves instances where unlocalized identifiers appeared, improving readability for multilingual users.
  * No changes to workflows or data; behavior and performance remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->