### PR TITLE
fix: markdown render for uneditable fields 

### DIFF
--- a/enterprise/frontend/src/routes/(app)/(internal)/frameworks/[id=uuid]/TreeViewItemContent.svelte
+++ b/enterprise/frontend/src/routes/(app)/(internal)/frameworks/[id=uuid]/TreeViewItemContent.svelte
@@ -2,6 +2,7 @@
 	import { getRequirementTitle } from '$lib/utils/helpers';
 	import { getOptions } from '$lib/utils/crud';
 	import Anchor from '$lib/components/Anchor/Anchor.svelte';
+  import MarkdownRenderer from '$lib/components/MarkdownRenderer.svelte';
 
 	interface Props {
 		ref_id: string;
@@ -75,7 +76,7 @@
 							<span style="font-weight: 600;">{title}</span>
 						{/if}
 						{#if description}
-							<p>{description}</p>
+						  <MarkdownRenderer content={description} />
 						{/if}
 					{:else if Object.keys(node.questions).length > 0}
 						<!-- This displays the first question's text -->
@@ -90,7 +91,7 @@
 						<span style="font-weight: 600;">{title}</span>
 					{/if}
 					{#if description}
-						<p>{description}</p>
+						<MarkdownRenderer content={description} />
 					{/if}
 				{:else if Object.keys(node.questions).length > 0}
 					<!-- This displays the first question's text -->

--- a/enterprise/frontend/src/routes/(app)/(internal)/frameworks/inspect-requirement/[id=uuid]/+page.svelte
+++ b/enterprise/frontend/src/routes/(app)/(internal)/frameworks/inspect-requirement/[id=uuid]/+page.svelte
@@ -9,6 +9,7 @@
 	import { page } from '$app/state';
 	import {} from '@skeletonlabs/skeleton-svelte';
 	import { displayScoreColor, formatScoreValue } from '$lib/utils/helpers';
+  import MarkdownRenderer from '$lib/components/MarkdownRenderer.svelte';
 
 	interface Props {
 		data: PageData;
@@ -63,7 +64,7 @@
 				<span class="text-2xl font-black text-gray-800">{firstAssessment.name}</span>
 			{/if}
 			{#if firstAssessment?.description}
-				<span class="text-gray-600 blockquote">{firstAssessment.description}</span>
+				<span class="text-gray-600 blockquote"><MarkdownRenderer content={firstAssessment.description} /></span>
 			{/if}
 		</div>
 

--- a/enterprise/frontend/src/routes/(app)/(internal)/frameworks/inspect-requirement/[id=uuid]/+page.svelte
+++ b/enterprise/frontend/src/routes/(app)/(internal)/frameworks/inspect-requirement/[id=uuid]/+page.svelte
@@ -64,7 +64,9 @@
 				<span class="text-2xl font-black text-gray-800">{firstAssessment.name}</span>
 			{/if}
 			{#if firstAssessment?.description}
-				<span class="text-gray-600 blockquote"><MarkdownRenderer content={firstAssessment.description} /></span>
+				<div class="text-gray-600 blockquote">
+          <MarkdownRenderer content={firstAssessment.description}/>
+        </div>
 			{/if}
 		</div>
 

--- a/frontend/src/lib/components/DetailView/DetailView.svelte
+++ b/frontend/src/lib/components/DetailView/DetailView.svelte
@@ -435,7 +435,7 @@
 												>
 											{:else if ISO_8601_REGEX.test(value) && dateFieldsToFormat.includes(key)}
 												{formatDateOrDateTime(value, getLocale())}
-											{:else if key === 'description' || key === 'observation'}
+											{:else if key === 'description' || key === 'observation' || key === 'annotation'}
 												<MarkdownRenderer content={value} />
 											{:else if m[toCamelCase(value.str || value.name)]}
 												{safeTranslate((value.str || value.name) ?? value)}

--- a/frontend/src/routes/(app)/(internal)/compliance-assessments/[id=uuid]/flash-mode/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/compliance-assessments/[id=uuid]/flash-mode/+page.svelte
@@ -3,6 +3,7 @@
 	import RadioGroup from '$lib/components/Forms/RadioGroup.svelte';
 	import { m } from '$paraglide/messages';
 	import type { PageData } from './$types';
+	import MarkdownRenderer from '$lib/components/MarkdownRenderer.svelte';
 
 	interface Props {
 		data: PageData;
@@ -202,14 +203,14 @@
 					<div class="flex flex-col space-y-4 overflow-y-auto flex-1 w-full max-w-4xl px-4">
 						{#if currentRequirementAssessment.description}
 							<div class="whitespace-pre-wrap leading-relaxed text-gray-700">
-								{currentRequirementAssessment.description}
+								<MarkdownRenderer content={currentRequirementAssessment.description} />
 							</div>
 						{/if}
 						{#if requirement.annotation}
 							<div
 								class="whitespace-pre-wrap leading-relaxed text-gray-600 italic bg-gray-50 p-4 rounded-lg border-l-4 border-blue-200 text-justify"
 							>
-								{requirement.annotation}
+								<MarkdownRenderer content={requirement.annotation} />
 							</div>
 						{/if}
 					</div>

--- a/frontend/src/routes/(app)/(internal)/frameworks/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/frameworks/[id=uuid]/+page.svelte
@@ -7,6 +7,7 @@
 	import type { PageData } from './$types';
 	import TreeViewItemContent from './TreeViewItemContent.svelte';
 	import Anchor from '$lib/components/Anchor/Anchor.svelte';
+	import MarkdownRenderer from '$lib/components/MarkdownRenderer.svelte';
 
 	interface Props {
 		data: PageData;
@@ -106,6 +107,8 @@
 											)?.urlModel
 										}/${value.id}`}
 										<Anchor href={itemHref} class="anchor">{value.str}</Anchor>
+									{:else if key === 'description'}
+										<MarkdownRenderer content={value} />
 									{:else}
 										{value.str ?? value}
 									{/if}

--- a/frontend/src/routes/(app)/(internal)/loaded-libraries/[id=uuid]/TreeViewItemContent.svelte
+++ b/frontend/src/routes/(app)/(internal)/loaded-libraries/[id=uuid]/TreeViewItemContent.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { getRequirementTitle } from '$lib/utils/helpers';
 	import { getOptions } from '$lib/utils/crud';
+	import MarkdownRenderer from '$lib/components/MarkdownRenderer.svelte';
 
 	interface Props {
 		ref_id: string;
@@ -71,7 +72,7 @@
 					<span style="font-weight: 600;">{title}</span>
 				{/if}
 				{#if description}
-					<p>{description}</p>
+					<MarkdownRenderer content={description} />
 				{/if}
 			{:else if node?.questions && Object.keys(node.questions).length > 0}
 				<!-- This displays the first question's text -->

--- a/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/TreeViewItemContent.svelte
+++ b/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/TreeViewItemContent.svelte
@@ -10,6 +10,7 @@
 	import { m } from '$paraglide/messages';
 	import { auditFiltersStore } from '$lib/utils/stores';
 	import Anchor from '$lib/components/Anchor/Anchor.svelte';
+	import MarkdownRenderer from '$lib/components/MarkdownRenderer.svelte';
 
 	interface Props {
 		ref_id: string;
@@ -183,7 +184,7 @@
 											<span style="font-weight: 600;">{title}</span>
 										{/if}
 										{#if description}
-											<p>{description}</p>
+											<MarkdownRenderer content={description} />
 										{/if}
 									{:else if Object.keys(node.questions).length > 0}
 										<!-- This displays the first question's text -->
@@ -199,7 +200,7 @@
 										<span style="font-weight: 600;">{title}</span>
 									{/if}
 									{#if description}
-										<p>{description}</p>
+										<MarkdownRenderer content={description} />
 									{/if}
 								</Anchor>
 							{/if}
@@ -210,7 +211,7 @@
 								<span style="font-weight: 600;">{title}</span>
 							{/if}
 							{#if description}
-								<p>{description}</p>
+								<MarkdownRenderer content={description} />
 							{/if}
 						</p>
 					{/if}

--- a/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/table-mode/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/table-mode/+page.svelte
@@ -340,24 +340,20 @@
 			>
 				{#if requirementAssessment.description}
 					<div class="card w-full font-light text-lg p-4 preset-tonal-primary">
-						<h2 class="font-semibold text-lg flex flex-row justify-between">
+						<h2 class="font-semibold text-base flex flex-row justify-between">
 							<div>
 								<i class="fa-solid fa-file-lines mr-2"></i>{m.description()}
 							</div>
 						</h2>
 						<MarkdownRenderer content={requirementAssessment.description} />
 					</div>
-
-					<!-- <div class="flex w-full font-semibold"> -->
-					<!-- 	<MarkdownRenderer content={requirementAssessment.description} /> -->
-					<!-- </div> -->
 				{/if}
 				{#if requirementAssessment.assessable}
 					{#if data.requirements[i].annotation || data.requirements[i].typical_evidence || requirementAssessment.mapping_inference.result}
 						<div
 							class="card p-4 preset-tonal-secondary text-sm flex flex-col justify-evenly cursor-auto w-full"
 						>
-							<h2 class="font-semibold text-lg flex flex-row justify-between">
+							<h2 class="font-semibold text-base flex flex-row justify-between">
 								<div>
 									<i class="fa-solid fa-circle-info mr-2"></i>{m.additionalInformation()}
 								</div>

--- a/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/table-mode/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/table-mode/+page.svelte
@@ -340,7 +340,7 @@
 			>
 				{#if requirementAssessment.description}
 					<div class="flex w-full font-semibold">
-						{requirementAssessment.description}
+						<MarkdownRenderer content={requirementAssessment.description} />
 					</div>
 				{/if}
 				{#if requirementAssessment.assessable}
@@ -367,9 +367,9 @@
 											<i class="fa-solid fa-pencil"></i>
 											{m.annotation()}
 										</p>
-										<p class="whitespace-pre-line py-1">
-											{data.requirements[i].annotation}
-										</p>
+										<div class="whitespace-pre-line py-1">
+											<MarkdownRenderer content={data.requirements[i].annotation} />
+										</div>
 									</div>
 								{/if}
 								{#if data.requirements[i].typical_evidence}
@@ -378,9 +378,9 @@
 											<i class="fa-solid fa-pencil"></i>
 											{m.typicalEvidence()}
 										</p>
-										<p class="whitespace-pre-line py-1">
-											{data.requirements[i].typical_evidence}
-										</p>
+										<div class="whitespace-pre-line py-1">
+											<MarkdownRenderer content={data.requirements[i].typical_evidence} />
+										</div>
 									</div>
 								{/if}
 								{#if requirementAssessment.mapping_inference.result}

--- a/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/table-mode/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/table-mode/+page.svelte
@@ -339,14 +339,23 @@
 				class="flex flex-col items-center justify-center border px-4 py-2 shadow-sm rounded-xl space-y-2"
 			>
 				{#if requirementAssessment.description}
-					<div class="flex w-full font-semibold">
+					<div class="card w-full font-light text-lg p-4 preset-tonal-primary">
+						<h2 class="font-semibold text-lg flex flex-row justify-between">
+							<div>
+								<i class="fa-solid fa-file-lines mr-2"></i>{m.description()}
+							</div>
+						</h2>
 						<MarkdownRenderer content={requirementAssessment.description} />
 					</div>
+
+					<!-- <div class="flex w-full font-semibold"> -->
+					<!-- 	<MarkdownRenderer content={requirementAssessment.description} /> -->
+					<!-- </div> -->
 				{/if}
 				{#if requirementAssessment.assessable}
 					{#if data.requirements[i].annotation || data.requirements[i].typical_evidence || requirementAssessment.mapping_inference.result}
 						<div
-							class="card p-4 preset-tonal-primary text-sm flex flex-col justify-evenly cursor-auto w-full"
+							class="card p-4 preset-tonal-secondary text-sm flex flex-col justify-evenly cursor-auto w-full"
 						>
 							<h2 class="font-semibold text-lg flex flex-row justify-between">
 								<div>
@@ -354,9 +363,9 @@
 								</div>
 								<button onclick={() => toggleSuggestion(requirementAssessment.id)}>
 									{#if !hideSuggestionHashmap[requirementAssessment.id]}
-										<i class="fa-solid fa-chevron-down"></i>
+										<i class="fa-solid fa-eye"></i>
 									{:else}
-										<i class="fa-solid fa-chevron-right"></i>
+										<i class="fa-solid fa-eye-slash"></i>
 									{/if}
 								</button>
 							</h2>

--- a/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/table-mode/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/table-mode/+page.svelte
@@ -367,7 +367,7 @@
 											<i class="fa-solid fa-pencil"></i>
 											{m.annotation()}
 										</p>
-										<div class="whitespace-pre-line py-1">
+										<div class="py-1">
 											<MarkdownRenderer content={data.requirements[i].annotation} />
 										</div>
 									</div>
@@ -378,7 +378,7 @@
 											<i class="fa-solid fa-pencil"></i>
 											{m.typicalEvidence()}
 										</p>
-										<div class="whitespace-pre-line py-1">
+										<div class="py-1">
 											<MarkdownRenderer content={data.requirements[i].typical_evidence} />
 										</div>
 									</div>

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/+page.svelte
@@ -114,7 +114,7 @@
 	</div>
 	{#if data.requirement.description}
 		<div class="font-light text-lg card p-4 preset-tonal-primary">
-			<h2 class="font-semibold text-lg flex flex-row justify-between">
+			<h2 class="font-semibold text-base flex flex-row justify-between">
 				<div>
 					<i class="fa-solid fa-file-lines mr-2"></i>{m.description()}
 				</div>
@@ -124,7 +124,7 @@
 	{/if}
 	{#if has_threats || has_reference_controls || annotation || mappingInference.result}
 		<div class="card p-4 preset-tonal-secondary text-sm flex flex-col justify-evenly cursor-auto">
-			<h2 class="font-semibold text-lg flex flex-row justify-between">
+			<h2 class="font-semibold text-base flex flex-row justify-between">
 				<div>
 					<i class="fa-solid fa-circle-info mr-2"></i>{m.additionalInformation()}
 				</div>

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/+page.svelte
@@ -113,12 +113,17 @@
 		{/if}
 	</div>
 	{#if data.requirement.description}
-		<div class="p-2 font-light text-lg">
-			👇 <MarkdownRenderer content={data.requirement.description} />
+		<div class="font-light text-lg card p-4 preset-tonal-primary">
+			<h2 class="font-semibold text-lg flex flex-row justify-between">
+				<div>
+					<i class="fa-solid fa-file-lines mr-2"></i>{m.description()}
+				</div>
+			</h2>
+			<MarkdownRenderer content={data.requirement.description} />
 		</div>
 	{/if}
 	{#if has_threats || has_reference_controls || annotation || mappingInference.result}
-		<div class="card p-4 preset-tonal-primary text-sm flex flex-col justify-evenly cursor-auto">
+		<div class="card p-4 preset-tonal-secondary text-sm flex flex-col justify-evenly cursor-auto">
 			<h2 class="font-semibold text-lg flex flex-row justify-between">
 				<div>
 					<i class="fa-solid fa-circle-info mr-2"></i>{m.additionalInformation()}

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/+page.svelte
@@ -15,6 +15,7 @@
 	import { m } from '$paraglide/messages';
 	import { ProgressRing, Tabs } from '@skeletonlabs/skeleton-svelte';
 	import type { PageData } from '../[id=uuid]/$types';
+	import MarkdownRenderer from '$lib/components/MarkdownRenderer.svelte';
 
 	interface Props {
 		data: PageData;
@@ -112,9 +113,9 @@
 		{/if}
 	</div>
 	{#if data.requirement.description}
-		<p class="whitespace-pre-line p-2 font-light text-lg">
-			👉 {data.requirement.description}
-		</p>
+		<div class="whitespace-pre-line p-2 font-light text-lg">
+			👇 <MarkdownRenderer content={data.requirement.description} />
+		</div>
 	{/if}
 	{#if has_threats || has_reference_controls || annotation || mappingInference.result}
 		<div class="card p-4 preset-tonal-primary text-sm flex flex-col justify-evenly cursor-auto">
@@ -183,9 +184,9 @@
 							<i class="fa-solid fa-pencil"></i>
 							{m.annotation()}
 						</p>
-						<p class="whitespace-pre-line py-1">
-							{annotation}
-						</p>
+						<div class="whitespace-pre-line py-1">
+							<MarkdownRenderer content={annotation} />
+						</div>
 					</div>
 				{/if}
 				{#if typical_evidence}
@@ -194,9 +195,9 @@
 							<i class="fa-solid fa-pencil"></i>
 							{m.typicalEvidence()}
 						</p>
-						<p class="whitespace-pre-line py-1">
-							{typical_evidence}
-						</p>
+						<div class="whitespace-pre-line py-1">
+							<MarkdownRenderer content={typical_evidence} />
+						</div>
 					</div>
 				{/if}
 				{#if mappingInference.result}
@@ -308,7 +309,9 @@
 	{#if data.requirementAssessment.observation}
 		<div class="card p-4 space-y-2 preset-tonal-primary">
 			<h1 class="font-semibold text-sm">{m.observation()}</h1>
-			<span class="text-sm">{data.requirementAssessment.observation}</span>
+			<span class="text-sm"
+				><MarkdownRenderer content={data.requirementAssessment.observation} /></span
+			>
 		</div>
 	{/if}
 	<div class="flex flex-row justify-between space-x-4">

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/+page.svelte
@@ -309,9 +309,9 @@
 	{#if data.requirementAssessment.observation}
 		<div class="card p-4 space-y-2 preset-tonal-primary">
 			<h1 class="font-semibold text-sm">{m.observation()}</h1>
-			<span class="text-sm"
-				><MarkdownRenderer content={data.requirementAssessment.observation} /></span
-			>
+			<div class="text-sm">
+				<MarkdownRenderer content={data.requirementAssessment.observation} />
+			</div>
 		</div>
 	{/if}
 	<div class="flex flex-row justify-between space-x-4">

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/+page.svelte
@@ -113,7 +113,7 @@
 		{/if}
 	</div>
 	{#if data.requirement.description}
-		<div class="whitespace-pre-line p-2 font-light text-lg">
+		<div class="p-2 font-light text-lg">
 			👇 <MarkdownRenderer content={data.requirement.description} />
 		</div>
 	{/if}
@@ -184,7 +184,7 @@
 							<i class="fa-solid fa-pencil"></i>
 							{m.annotation()}
 						</p>
-						<div class="whitespace-pre-line py-1">
+						<div class="py-1">
 							<MarkdownRenderer content={annotation} />
 						</div>
 					</div>
@@ -195,7 +195,7 @@
 							<i class="fa-solid fa-pencil"></i>
 							{m.typicalEvidence()}
 						</p>
-						<div class="whitespace-pre-line py-1">
+						<div class="py-1">
 							<MarkdownRenderer content={typical_evidence} />
 						</div>
 					</div>

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.svelte
@@ -273,7 +273,7 @@
 		>
 	</div>
 	{#if data.requirement.description}
-		<div class="whitespace-pre-line p-2 font-light text-lg">
+		<div class="p-2 font-light text-lg">
 			👇 <MarkdownRenderer content={data.requirement.description} />
 		</div>
 	{/if}
@@ -344,7 +344,7 @@
 							<i class="fa-solid fa-pencil"></i>
 							{m.annotation()}
 						</p>
-						<div class="whitespace-pre-line py-1">
+						<div class="py-1">
 							<MarkdownRenderer content={annotation} />
 						</div>
 					</div>
@@ -355,7 +355,7 @@
 							<i class="fa-solid fa-pencil"></i>
 							{m.typicalEvidence()}
 						</p>
-						<div class="whitespace-pre-line py-1">
+						<div class="py-1">
 							<MarkdownRenderer content={typical_evidence} />
 						</div>
 					</div>

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.svelte
@@ -273,9 +273,9 @@
 		>
 	</div>
 	{#if data.requirement.description}
-		<p class="whitespace-pre-line p-2 font-light text-lg">
-			👉 <MarkdownRenderer content={data.requirement.description} />
-		</p>
+		<div class="whitespace-pre-line p-2 font-light text-lg">
+			👇 <MarkdownRenderer content={data.requirement.description} />
+		</div>
 	{/if}
 	{#if has_threats || has_reference_controls || annotation || mappingInference.result}
 		<div class="card p-4 preset-tonal-primary text-sm flex flex-col justify-evenly cursor-auto">
@@ -344,9 +344,9 @@
 							<i class="fa-solid fa-pencil"></i>
 							{m.annotation()}
 						</p>
-						<p class="whitespace-pre-line py-1">
-							{annotation}
-						</p>
+						<div class="whitespace-pre-line py-1">
+							<MarkdownRenderer content={annotation} />
+						</div>
 					</div>
 				{/if}
 				{#if typical_evidence}
@@ -355,9 +355,9 @@
 							<i class="fa-solid fa-pencil"></i>
 							{m.typicalEvidence()}
 						</p>
-						<p class="whitespace-pre-line py-1">
-							{typical_evidence}
-						</p>
+						<div class="whitespace-pre-line py-1">
+							<MarkdownRenderer content={typical_evidence} />
+						</div>
 					</div>
 				{/if}
 				{#if mappingInference.result}

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.svelte
@@ -274,7 +274,7 @@
 	</div>
 	{#if data.requirement.description}
 		<div class="font-light text-lg card p-4 preset-tonal-primary">
-			<h2 class="font-semibold text-lg flex flex-row justify-between">
+			<h2 class="font-semibold text-base flex flex-row justify-between">
 				<div>
 					<i class="fa-solid fa-file-lines mr-2"></i>{m.description()}
 				</div>
@@ -284,7 +284,7 @@
 	{/if}
 	{#if has_threats || has_reference_controls || annotation || mappingInference.result}
 		<div class="card p-4 preset-tonal-secondary text-sm flex flex-col justify-evenly cursor-auto">
-			<h2 class="font-semibold text-lg flex flex-row justify-between">
+			<h2 class="font-semibold text-base flex flex-row justify-between">
 				<div>
 					<i class="fa-solid fa-circle-info mr-2"></i>{m.additionalInformation()}
 				</div>

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.svelte
@@ -273,12 +273,17 @@
 		>
 	</div>
 	{#if data.requirement.description}
-		<div class="p-2 font-light text-lg">
-			👇 <MarkdownRenderer content={data.requirement.description} />
+		<div class="font-light text-lg card p-4 preset-tonal-primary">
+			<h2 class="font-semibold text-lg flex flex-row justify-between">
+				<div>
+					<i class="fa-solid fa-file-lines mr-2"></i>{m.description()}
+				</div>
+			</h2>
+			<MarkdownRenderer content={data.requirement.description} />
 		</div>
 	{/if}
 	{#if has_threats || has_reference_controls || annotation || mappingInference.result}
-		<div class="card p-4 preset-tonal-primary text-sm flex flex-col justify-evenly cursor-auto">
+		<div class="card p-4 preset-tonal-secondary text-sm flex flex-col justify-evenly cursor-auto">
 			<h2 class="font-semibold text-lg flex flex-row justify-between">
 				<div>
 					<i class="fa-solid fa-circle-info mr-2"></i>{m.additionalInformation()}

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.svelte
@@ -32,6 +32,7 @@
 		type ModalSettings,
 		type ModalStore
 	} from '$lib/components/Modals/stores';
+	import MarkdownRenderer from '$lib/components/MarkdownRenderer.svelte';
 
 	interface Props {
 		data: PageData;
@@ -273,7 +274,7 @@
 	</div>
 	{#if data.requirement.description}
 		<p class="whitespace-pre-line p-2 font-light text-lg">
-			👉 {data.requirement.description}
+			👉 <MarkdownRenderer content={data.requirement.description} />
 		</p>
 	{/if}
 	{#if has_threats || has_reference_controls || annotation || mappingInference.result}


### PR DESCRIPTION
Adds markdown support for fields like description, annotation, typical evidences, ... that are imported from custom libraries 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Markdown rendering enabled for descriptions, annotations, observations, typical evidence and related text across internal and third‑party views.

* **Style**
  * Adjusted visual cues: card tone changes, header presentation and sizes refined, and expand/collapse iconography updated for clearer requirement detail and edit views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->