### PR TITLE
feat: control Terminologies entry by a feature flag

### DIFF
--- a/backend/global_settings/serializers.py
+++ b/backend/global_settings/serializers.py
@@ -100,6 +100,9 @@ class FeatureFlagsSerializer(serializers.ModelSerializer):
     organisation_issues = serializers.BooleanField(
         source="value.organisation_issues", required=False, default=True
     )
+    terminologies = serializers.BooleanField(
+        source="value.terminologies", required=False, default=True
+    )
 
     class Meta:
         model = GlobalSettings
@@ -120,6 +123,7 @@ class FeatureFlagsSerializer(serializers.ModelSerializer):
             "inherent_risk",
             "organisation_objectives",
             "organisation_issues",
+            "terminologies",
         ]
         read_only_fields = ["name"]
 

--- a/frontend/src/lib/components/Forms/ModelForm/FeatureFlagsSettingForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/FeatureFlagsSettingForm.svelte
@@ -26,7 +26,8 @@
 		{ field: 'experimental', label: m.experimental() },
 		{ field: 'inherent_risk', label: m.inherentRisk() },
 		{ field: 'organisation_objectives', label: m.organisationObjectives() },
-		{ field: 'organisation_issues', label: m.organisationIssues() }
+		{ field: 'organisation_issues', label: m.organisationIssues() },
+		{ field: 'terminologies', label: m.terminologies() }
 	];
 </script>
 

--- a/frontend/src/lib/utils/schemas.ts
+++ b/frontend/src/lib/utils/schemas.ts
@@ -399,7 +399,8 @@ export const FeatureFlagsSchema = z.object({
 	experimental: z.boolean().optional(),
 	inherent_risk: z.boolean().optional(),
 	organisation_objectives: z.boolean().optional(),
-	organisation_issues: z.boolean().optional()
+	organisation_issues: z.boolean().optional(),
+	terminologies: z.boolean().optional()
 });
 
 export const SSOSettingsSchema = z.object({

--- a/frontend/src/lib/utils/sidebar-config.ts
+++ b/frontend/src/lib/utils/sidebar-config.ts
@@ -14,6 +14,7 @@ type SidebarBackendKeys = {
 	experimental: boolean;
 	organisation_objectives: boolean;
 	organisation_issues: boolean;
+	terminologies: boolean;
 };
 
 type SidebarFrontendKeys = {
@@ -32,6 +33,7 @@ type SidebarFrontendKeys = {
 	experimental: boolean;
 	organisationObjectives: boolean;
 	organisationIssues: boolean;
+	terminologies: boolean;
 };
 
 export function getSidebarVisibleItems(
@@ -52,6 +54,7 @@ export function getSidebarVisibleItems(
 		privacy: featureFlags?.privacy ?? false,
 		experimental: featureFlags?.experimental ?? false,
 		organisationObjectives: featureFlags?.organisation_objectives ?? false,
-		organisationIssues: featureFlags?.organisation_issues ?? false
+		organisationIssues: featureFlags?.organisation_issues ?? false,
+		terminologies: featureFlags?.terminologies ?? true
 	};
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a “Terminologies” feature toggle, enabled by default.
  - Added a checkbox in Feature Flags settings to turn Terminologies on or off.
  - Sidebar now conditionally shows the Terminologies section based on this toggle (visible by default unless disabled).
  - End-to-end support ensures the setting is saved and consistently applied across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->