### PR TITLE
fix: add terminologies in EE navData

### DIFF
--- a/enterprise/frontend/src/lib/components/SideBar/navData.ts
+++ b/enterprise/frontend/src/lib/components/SideBar/navData.ts
@@ -374,6 +374,12 @@ export const navData = {
 					permissions: ['view_filteringlabel']
 				},
 				{
+					name: 'terminologies',
+					fa_icon: 'fa-solid fa-language',
+					href: '/terminologies',
+					permissions: ['view_terminology']
+				},
+				{
 					name: 'settings',
 					fa_icon: 'fa-solid fa-cog',
 					href: '/settings',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Terminologies” item to the sidebar under the Extra section for quick access to terminology management.
  * Includes a language icon and navigates to /terminologies for a consistent, recognizable entry point.
  * Visibility is permission-based, shown only to users allowed to view terminologies.
  * Improves discoverability and navigation for users managing organizational terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->