### PR TITLE
fix: duplicate call to handler.invalidate on model table load

### DIFF
--- a/frontend/src/lib/components/ModelTable/ModelTable.svelte
+++ b/frontend/src/lib/components/ModelTable/ModelTable.svelte
@@ -208,7 +208,7 @@
 		}
 	);
 	const rows = handler.getRows();
-	let invalidateTable = $state(true);
+	let invalidateTable = $state(false);
 
 	$tableHandlers[baseEndpoint] = handler;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Models table no longer auto-refreshes on page load, preventing unexpected reloads and UI flicker. Refresh occurs only when you change filters or other controls. Default sort on first load remains the same.
* **Performance**
  * Faster initial load for the models table by deferring unnecessary refresh/invalidation until user interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->