### PR TITLE
fix: backup restore with ebios rm operating modes

### DIFF
--- a/backend/ebios_rm/models.py
+++ b/backend/ebios_rm/models.py
@@ -987,13 +987,6 @@ class OperationalScenario(AbstractBaseModel, FolderMixin):
         self.likelihood = max_likelihood
         self.save(update_fields=["likelihood"])
 
-    def update_scenarios_likelihood_on_quotation_method_change(self):
-        if self.ebios_rm_study.quotation_method != "express":
-            return
-
-        for scenario in self.ebios_rm_study.operational_scenarios.all():
-            scenario.update_likelihood_from_operating_modes()
-
 
 class KillChain(AbstractBaseModel, FolderMixin):
     class LogicOperator(models.TextChoices):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Operational Scenario likelihoods now auto-refresh based on associated Operating Modes when using the express quotation method.
- Bug Fixes
  - Ensures likelihood values stay consistent when Operating Modes are added, edited, or removed.
  - Correctly handles cases with no Operating Modes by showing an unspecified likelihood.
- Performance
  - Reduces unnecessary saves during likelihood updates for smoother interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->