### PR TITLE
perf: fix n+1 queries on compliance assessments progress serialization

### DIFF
--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -1337,7 +1337,7 @@ class ComplianceAssessmentReadSerializer(AssessmentReadSerializer):
     selected_implementation_groups = serializers.ReadOnlyField(
         source="get_selected_implementation_groups"
     )
-    progress = serializers.ReadOnlyField(source="get_progress")
+    progress = serializers.ReadOnlyField()
     assets = FieldsRelatedField(many=True)
     evidences = FieldsRelatedField(many=True)
 

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -21,6 +21,7 @@ from django.db.models import (
     Q,
     ExpressionWrapper,
     FloatField,
+    IntegerField,
     Value,
     Min,
     Subquery,
@@ -4745,39 +4746,30 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
             )
         )
 
-        ordering = self.request.query_params.get("ordering", "")
-
-        if any(
-            field in ordering
-            for field in (
-                "total_requirements",
-                "assessed_requirements",
-                "progress",
-            )
-        ):
-            qs = qs.annotate(
-                total_requirements=Count(
-                    "requirement_assessments",
-                    filter=Q(requirement_assessments__requirement__assessable=True),
-                    distinct=True,
-                ),
-                assessed_requirements=Count(
-                    "requirement_assessments",
-                    filter=Q(
-                        ~Q(
-                            requirement_assessments__result=RequirementAssessment.Result.NOT_ASSESSED
-                        ),
-                        requirement_assessments__requirement__assessable=True,
+        qs = qs.annotate(
+            total_requirements=Count(
+                "requirement_assessments",
+                filter=Q(requirement_assessments__requirement__assessable=True),
+                distinct=True,
+            ),
+            assessed_requirements=Count(
+                "requirement_assessments",
+                filter=Q(
+                    ~Q(
+                        requirement_assessments__result=RequirementAssessment.Result.NOT_ASSESSED
                     ),
-                    distinct=True,
+                    requirement_assessments__requirement__assessable=True,
                 ),
-                progress=ExpressionWrapper(
-                    F("assessed_requirements")
-                    * 1.0
-                    / Greatest(Coalesce(F("total_requirements"), Value(0)), Value(1)),
-                    output_field=FloatField(),
-                ),
-            )
+                distinct=True,
+            ),
+            progress=ExpressionWrapper(
+                F("assessed_requirements")
+                * 100
+                / Greatest(Coalesce(F("total_requirements"), Value(0)), Value(1)),
+                output_field=IntegerField(),
+            ),
+        )
+
         return qs
 
     @method_decorator(cache_page(60 * LONG_CACHE_TTL))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Progress is now shown as a whole-number percentage (0–100) with safeguards to prevent calculation errors.
  * Related counts are always computed, improving consistency for sorting and filtering.

* **Refactor**
  * Simplified how progress is read and displayed to rely directly on the stored value, reducing complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->