### PR TITLE
feat: show full path in user groups dropdown

### DIFF
--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -1035,6 +1035,7 @@ class UserWriteSerializer(BaseModelSerializer):
 
 
 class UserGroupReadSerializer(BaseModelSerializer):
+    path = PathField(source="get_folder_full_path", read_only=True)
     name = serializers.CharField(source="__str__")
     localization_dict = serializers.JSONField(source="get_localization_dict")
     folder = FieldsRelatedField()

--- a/frontend/src/lib/components/Forms/ModelForm/UserForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/UserForm.svelte
@@ -56,6 +56,7 @@
 		multiple
 		optionsEndpoint="user-groups"
 		field="user_groups"
+		pathField="path"
 		cacheLock={cacheLocks['user_groups']}
 		bind:cachedValue={formDataCache['user_groups']}
 		label={m.userGroups()}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User group selection now displays the full folder path for each group in the user form, making it easier to distinguish similarly named groups.
  * Read-only folder path information is included wherever user groups are shown in the interface for added clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->