### PR TITLE
fix: prevent entity assessment creation if audit creation failed

### DIFF
--- a/backend/tprm/serializers.py
+++ b/backend/tprm/serializers.py
@@ -183,9 +183,10 @@ class EntityAssessmentWriteSerializer(BaseModelSerializer):
         with transaction.atomic():
             instance = super().update(instance, validated_data)
             self._create_or_update_audit(instance, audit_data)
-            self._assign_third_party_respondents(
-                instance, representatives, old_representatives
-            )
+            if "representatives" in validated_data:
+                self._assign_third_party_respondents(
+                    instance, representatives, old_representatives
+                )
         return instance
 
     class Meta:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - Improved reliability when creating or updating assessments by making the process atomic to prevent partial saves.
  - Prevents creation of duplicate audits for the same assessment and ensures related links and respondent assignments fully roll back on error.
  - Adds safeguards against concurrent updates to the same assessment to avoid conflicting changes.
- Refactor
  - Streamlined backend workflows to enhance data consistency during assessment creation and updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->