### PR TITLE
fix: properly set global settings default value on instance initialization

### DIFF
--- a/backend/core/startup.py
+++ b/backend/core/startup.py
@@ -1003,7 +1003,9 @@ def startup(sender: AppConfig, **kwargs):
         "interface_agg_scenario_matrix": False,
     }
     try:
-        settings, _ = GlobalSettings.objects.get_or_create(name="general")
+        settings, _ = GlobalSettings.objects.get_or_create(
+            name="general", value=default_settings
+        )
         current_value = settings.value or {}
 
         ebios_radar_max = current_value.get("ebios_radar_max")

--- a/backend/core/startup.py
+++ b/backend/core/startup.py
@@ -1004,7 +1004,7 @@ def startup(sender: AppConfig, **kwargs):
     }
     try:
         settings, _ = GlobalSettings.objects.get_or_create(
-            name="general", value=default_settings
+            name="general", defaults={"value": default_settings}
         )
         current_value = settings.value or {}
 


### PR DESCRIPTION
This solves the following untimely warning log appearing on startup:

```
2025-09-05T11:01:13.538529Z [warning  ] ebios radar settings are invalid (None or 0). Reverting to default settings. [core.startup]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup now initializes default application settings more reliably, ensuring correct values are applied when settings are missing or invalid.
  * Preserves user-customized settings while restoring only missing or corrupted values, reducing unexpected resets and improving overall startup stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->