### PR TITLE
chores: avoid CLA job auto-cancel

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -8,7 +8,7 @@ on:
 # Cancel older in-progress runs for the same PR or the same ref (branch)
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 # explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
 permissions:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated contributor license agreement workflow concurrency: in-progress runs for the same pull request/ref are no longer canceled when a new run starts, allowing multiple checks to proceed concurrently.
  * No changes to product features or documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->