### PR TITLE
fix: Pressing tab while focused on the delete icon triggers the delete modal

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -93,7 +93,7 @@
 		"svelte-multiselect": "^11.1.1",
 		"svelte-persisted-store": "^0.12.0"
 	},
-	"packageManager": "pnpm@10.12.4",
+	"packageManager": "pnpm@10.16.1",
 	"pnpm": {
 		"overrides": {
 			"esbuild": "^0.25.5",

--- a/frontend/src/lib/components/TableRowActions/TableRowActions.svelte
+++ b/frontend/src/lib/components/TableRowActions/TableRowActions.svelte
@@ -205,21 +205,29 @@
 		{#if displayDelete}
 			{#if URLModel === 'folders'}
 				<button
-					onclick={(_) => {
+					onclick={(e) => {
 						promptModalConfirmDelete(row.meta[identifierField], row);
-						stopPropagation(_);
+						stopPropagation(e);
 					}}
-					onkeydown={() => promptModalConfirmDelete(row.meta.id, row)}
+					onkeydown={(e) => {
+						if (e.key === 'Tab') return;
+						modalConfirmDelete(row.meta.id, row);
+						stopPropagation(e);
+					}}
 					class="cursor-pointer hover:text-primary-500"
 					data-testid="tablerow-delete-button"><i class="fa-solid fa-trash"></i></button
 				>
 			{:else}
 				<button
-					onclick={(_) => {
+					onclick={(e) => {
 						modalConfirmDelete(row.meta[identifierField], row);
-						stopPropagation(_);
+						stopPropagation(e);
 					}}
-					onkeydown={() => modalConfirmDelete(row.meta.id, row)}
+					onkeydown={(e) => {
+						if (e.key === 'Tab') return;
+						modalConfirmDelete(row.meta.id, row);
+						stopPropagation(e);
+					}}
 					class="cursor-pointer hover:text-primary-500"
 					data-testid="tablerow-delete-button"><i class="fa-solid fa-trash"></i></button
 				>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Delete actions now behave consistently across mouse and keyboard, always opening the standard delete confirmation.
  * Improved keyboard accessibility: activation works reliably while Tab navigation is ignored, and unintended event propagation is prevented.
* Chores
  * Updated package manager to pnpm 10.16.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->