### PR TITLE
feat: Support comma characters for floats

### DIFF
--- a/frontend/src/lib/components/Forms/ModelForm/QuantitativeRiskStudyForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/QuantitativeRiskStudyForm.svelte
@@ -132,7 +132,6 @@
 					field="risk_tolerance.points.point1.probability"
 					label="Point 1 - Probability"
 					commaSupported={true}
-					min={0.01}
 					max={0.99}
 					floatPrecision={2}
 					helpText="Probability value (0.01-0.99). You can start with 0.99 for the most frequent acceptable issues"
@@ -142,7 +141,6 @@
 					field="risk_tolerance.points.point1.acceptable_loss"
 					label="Point 1 - Tolerable Loss ({displayCurrency})"
 					commaSupported={true}
-					min={1}
 					helpText="Acceptable loss amount for point 1"
 				/>
 			</div>
@@ -152,7 +150,6 @@
 					field="risk_tolerance.points.point2.probability"
 					label="Point 2 - Probability"
 					commaSupported={true}
-					min={0.01}
 					max={0.99}
 					floatPrecision={2}
 					helpText="Probability value (0.01-0.99), You can close with 0.01 for the most rare acceptable cases"

--- a/frontend/src/lib/components/Forms/ModelForm/QuantitativeRiskStudyForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/QuantitativeRiskStudyForm.svelte
@@ -131,17 +131,18 @@
 					{form}
 					field="risk_tolerance.points.point1.probability"
 					label="Point 1 - Probability"
+					commaSupported={true}
 					min={0.01}
 					max={0.99}
-					step={0.01}
+					floatPrecision={2}
 					helpText="Probability value (0.01-0.99). You can start with 0.99 for the most frequent acceptable issues"
 				/>
 				<NumberField
 					{form}
 					field="risk_tolerance.points.point1.acceptable_loss"
 					label="Point 1 - Tolerable Loss ({displayCurrency})"
+					commaSupported={true}
 					min={1}
-					step={1}
 					helpText="Acceptable loss amount for point 1"
 				/>
 			</div>
@@ -150,17 +151,18 @@
 					{form}
 					field="risk_tolerance.points.point2.probability"
 					label="Point 2 - Probability"
+					commaSupported={true}
 					min={0.01}
 					max={0.99}
-					step={0.01}
+					floatPrecision={2}
 					helpText="Probability value (0.01-0.99), You can close with 0.01 for the most rare acceptable cases"
 				/>
 				<NumberField
 					{form}
 					field="risk_tolerance.points.point2.acceptable_loss"
 					label="Point 2 - Tolerable Loss ({displayCurrency})"
+					commaSupported={true}
 					min={1}
-					step={1}
 					helpText="Acceptable loss amount for point 2"
 				/>
 			</div>

--- a/frontend/src/lib/components/Forms/NumberField.svelte
+++ b/frontend/src/lib/components/Forms/NumberField.svelte
@@ -118,6 +118,13 @@
 					const selectionStart = targetElem.selectionStart;
 					const selectionEnd = targetElem.selectionEnd;
 
+					if (selectionStart === null || selectionEnd === null) {
+						console.error(
+							`Failed to get selection data: selectionStart=${selectionStart} selectionEnd=${selectionEnd}`
+						);
+						return;
+					}
+
 					const currentText = targetElem.value;
 					const newText =
 						currentText.slice(0, selectionStart) + e.data + currentText.slice(selectionEnd);

--- a/frontend/src/lib/components/Forms/NumberField.svelte
+++ b/frontend/src/lib/components/Forms/NumberField.svelte
@@ -74,8 +74,13 @@
 	if (commaSupported) {
 		$effect(() => {
 			if (stringifiedValue) {
-				const newValue = Number(stringifiedValue.replace(',', '.'));
-				value.set(newValue);
+				const normalizedStringifiedValue = stringifiedValue.replace(',', '.');
+				const newValue = Number(normalizedStringifiedValue);
+				if (!Number.isNaN(newValue)) {
+					value.set(newValue);
+				} else {
+					console.error(`Failed to parse string '${normalizedStringifiedValue}' to a number.`);
+				}
 			}
 		});
 	}

--- a/frontend/src/lib/components/Forms/NumberField.svelte
+++ b/frontend/src/lib/components/Forms/NumberField.svelte
@@ -135,7 +135,7 @@
 
 					const newNumber = Number(newText);
 
-					if (newNumber !== newNumber || newNumber > max) {
+					if (Number.isNaN(newNumber) || newNumber > max) {
 						e.preventDefault();
 					}
 					if (!stringifiedValueRegex.test(newText)) {

--- a/frontend/src/lib/components/Forms/NumberField.svelte
+++ b/frontend/src/lib/components/Forms/NumberField.svelte
@@ -118,9 +118,7 @@
 					const selectionStart = targetElem.selectionStart;
 					const selectionEnd = targetElem.selectionEnd;
 
-					const currentText = e.target.value;
-					// const newText = currentText + e.data;
-
+					const currentText = targetElem.value;
 					const newText =
 						currentText.slice(0, selectionStart) + e.data + currentText.slice(selectionEnd);
 					console.log('===>', newText);

--- a/frontend/src/lib/components/Forms/NumberField.svelte
+++ b/frontend/src/lib/components/Forms/NumberField.svelte
@@ -8,6 +8,8 @@
 	interface Props {
 		class?: string;
 		label?: string | undefined;
+		// There is no min parameter as it could prevent a user from rewritting its value
+		// e.g. If max=20 and the want to edit its "30" into "25" he will erase "0" from "30" which will lead to "3" which will be considered less than 20 and therefore blocked, the min should be handled by zod schemas.
 		max?: number;
 		allowNegative?: boolean;
 		floatPrecision?: number;

--- a/frontend/src/lib/components/Forms/NumberField.svelte
+++ b/frontend/src/lib/components/Forms/NumberField.svelte
@@ -71,10 +71,14 @@
 			: new RegExp(`^${allowNegative ? '\\-?' : ''}[0-9]+$`);
 	let stringifiedValue = $state(`${$value === undefined ? '' : $value}`);
 
+	function normalizeStringifiedNumber(stringifiedNumber: string): string {
+		return stringifiedNumber.replace(',', '.');
+	}
+
 	if (commaSupported) {
 		$effect(() => {
 			if (stringifiedValue) {
-				const normalizedStringifiedValue = stringifiedValue.replace(',', '.');
+				const normalizedStringifiedValue = normalizeStringifiedNumber(stringifiedValue);
 				const newValue = Number(normalizedStringifiedValue);
 				if (!Number.isNaN(newValue)) {
 					value.set(newValue);
@@ -138,7 +142,7 @@
 
 					if (!newText || (allowNegative && newText === '-')) return;
 
-					const newNumber = Number(newText);
+					const newNumber = Number(normalizeStringifiedNumber(newText));
 
 					if (Number.isNaN(newNumber) || newNumber > max) {
 						e.preventDefault();

--- a/frontend/src/lib/components/Forms/NumberField.svelte
+++ b/frontend/src/lib/components/Forms/NumberField.svelte
@@ -8,7 +8,9 @@
 	interface Props {
 		class?: string;
 		label?: string | undefined;
-		step?: number;
+		max?: number;
+		allowNegative?: boolean;
+		floatPrecision?: number;
 		field: string;
 		valuePath?: any; // the place where the value is stored in the form. This is useful for nested objects
 		helpText?: string | undefined;
@@ -18,13 +20,16 @@
 		hidden?: boolean;
 		disabled?: boolean;
 		required?: boolean;
+		commaSupported?: boolean;
 		[key: string]: any;
 	}
 
 	let {
 		class: _class = '',
 		label = $bindable(),
-		step = 1,
+		max = Infinity,
+		allowNegative = false,
+		floatPrecision = 0,
 		field,
 		valuePath = field,
 		helpText = undefined,
@@ -37,6 +42,7 @@
 		hidden = false,
 		disabled = false,
 		required = false,
+		commaSupported = false,
 		...rest
 	}: Props = $props();
 
@@ -56,6 +62,21 @@
 		const cacheResult = await cacheLock.promise;
 		if (cacheResult) $value = cacheResult;
 	});
+
+	let stringifiedValueRegex =
+		floatPrecision > 0
+			? new RegExp(`^${allowNegative ? '\\-?' : ''}[0-9]((\\.|,)([0-9]{1,${floatPrecision}})?)?$`)
+			: new RegExp(`^${allowNegative ? '\\-?' : ''}[0-9]+$`);
+	let stringifiedValue = $state(`${$value === undefined ? '' : $value}`);
+
+	if (commaSupported) {
+		$effect(() => {
+			if (stringifiedValue) {
+				const newValue = Number(stringifiedValue.replace(',', '.'));
+				value.set(newValue);
+			}
+		});
+	}
 
 	let classesTextField = $derived((errors: string[] | undefined) => (errors ? 'input-error' : ''));
 	let classesDisabled = $derived((d: boolean) => (d ? 'opacity-50' : ''));
@@ -81,20 +102,59 @@
 		{/if}
 	</div>
 	<div class="control">
-		<input
-			type="number"
-			{step}
-			class="{'input ' + _class} {classesTextField($errors)}"
-			data-testid="form-input-{field.replaceAll('_', '-')}"
-			name={field}
-			aria-invalid={$errors ? 'true' : undefined}
-			placeholder=""
-			bind:value={$value}
-			{...$constraints}
-			{...rest}
-			{disabled}
-			{required}
-		/>
+		{#if commaSupported}
+			<input
+				type="text"
+				class="{'input ' + _class} {classesTextField($errors)}"
+				data-testid="form-input-{field.replaceAll('_', '-')}"
+				name={field}
+				aria-invalid={$errors ? 'true' : undefined}
+				placeholder=""
+				bind:value={stringifiedValue}
+				onbeforeinput={(e) => {
+					if (e.inputType === 'deleteContentBackward') return;
+
+					const targetElem = e.target as HTMLInputElement;
+					const selectionStart = targetElem.selectionStart;
+					const selectionEnd = targetElem.selectionEnd;
+
+					const currentText = e.target.value;
+					// const newText = currentText + e.data;
+
+					const newText =
+						currentText.slice(0, selectionStart) + e.data + currentText.slice(selectionEnd);
+					console.log('===>', newText);
+
+					const newNumber = Number(newText);
+
+					if (newNumber !== newNumber || newNumber > max) {
+						e.preventDefault();
+					}
+					if (newText && !stringifiedValueRegex.test(newText)) {
+						e.preventDefault();
+					}
+				}}
+				{...$constraints}
+				{...rest}
+				{disabled}
+				{required}
+			/>
+		{:else}
+			<!-- { step }-->
+			<input
+				type="number"
+				class="{'input ' + _class} {classesTextField($errors)}"
+				data-testid="form-input-{field.replaceAll('_', '-')}"
+				name={field}
+				aria-invalid={$errors ? 'true' : undefined}
+				placeholder=""
+				bind:value={$value}
+				{...$constraints}
+				{...rest}
+				{disabled}
+				{required}
+			/>
+		{/if}
 	</div>
 	{#if helpText}
 		<p class="text-sm text-gray-500">{helpText}</p>

--- a/frontend/src/lib/components/Forms/NumberField.svelte
+++ b/frontend/src/lib/components/Forms/NumberField.svelte
@@ -130,14 +130,15 @@
 					const currentText = targetElem.value;
 					const newText =
 						currentText.slice(0, selectionStart) + e.data + currentText.slice(selectionEnd);
-					console.log('===>', newText);
+
+					if (!newText || (allowNegative && newText === '-')) return;
 
 					const newNumber = Number(newText);
 
 					if (newNumber !== newNumber || newNumber > max) {
 						e.preventDefault();
 					}
-					if (newText && !stringifiedValueRegex.test(newText)) {
+					if (!stringifiedValueRegex.test(newText)) {
 						e.preventDefault();
 					}
 				}}

--- a/frontend/src/lib/utils/schemas.ts
+++ b/frontend/src/lib/utils/schemas.ts
@@ -691,14 +691,14 @@ export const quantitativeRiskStudySchema = z.object({
 				.object({
 					point1: z
 						.object({
-							probability: z.number().min(0.01).max(0.99).optional(),
+							probability: z.number().min(0.01).max(0.99).step(0.01).optional(),
 							acceptable_loss: z.number().min(1).optional()
 						})
 						.default({ probability: 0.99 })
 						.optional(),
 					point2: z
 						.object({
-							probability: z.number().min(0.01).max(0.99).optional(),
+							probability: z.number().min(0.01).max(0.99).step(0.01).optional(),
 							acceptable_loss: z.number().min(1).optional()
 						})
 						.optional()


### PR DESCRIPTION
This PR originates  from the SUP-441 ticket on Jira.
The `commaSupported` prop added to the `NumberField` component shall be removed before merging this PR as it serves as a temporary parameter to activate this new feature.
At the end the `NumberField` component shall act as if the `commaSupported` value was always true giving support for commas all across the app.

Maybe we should adapt the float display based on the locale (e.g. French/Dutch with comma, English with dot), or we could have a user parameter to make this choice (kind of like what we have with the currency global parameter).

This PR has been set as draft for now as i want the idea to be approved before changing the behavior of every single `NumberField` used throughout the codebase.



