### PR TITLE
feat: Add TaskTemplate last_occurence and next_occurence filters

### DIFF
--- a/frontend/src/lib/utils/table.ts
+++ b/frontend/src/lib/utils/table.ts
@@ -746,17 +746,6 @@ const ASSET_TYPE_FILTER: ListViewFilterConfig = {
 	}
 };
 
-const ASSET_CLASS_FILTER: ListViewFilterConfig = {
-	//still broken
-	component: AutocompleteSelect,
-	props: {
-		label: 'assetClass',
-		optionsEndpoint: 'asset-class',
-		optionsLabelField: 'full_path',
-		optionsValueField: 'id',
-		multiple: false
-	}
-};
 const REFERENCE_CONTROL_CATEGORY_FILTER: ListViewFilterConfig = {
 	component: AutocompleteSelect,
 	props: {
@@ -768,6 +757,7 @@ const REFERENCE_CONTROL_CATEGORY_FILTER: ListViewFilterConfig = {
 		optionsValueField: 'value'
 	}
 };
+
 const FINDINGS_ASSESSMENTS_CATEGORY_FILTER: ListViewFilterConfig = {
 	component: AutocompleteSelect,
 	props: {
@@ -779,6 +769,7 @@ const FINDINGS_ASSESSMENTS_CATEGORY_FILTER: ListViewFilterConfig = {
 		optionsValueField: 'value'
 	}
 };
+
 const STAKEHOLDER_CATEGORY_FILTER: ListViewFilterConfig = {
 	component: AutocompleteSelect,
 	props: {
@@ -813,6 +804,7 @@ const OWNER_FILTER: ListViewFilterConfig = {
 		multiple: true
 	}
 };
+
 const FINDINGS_OWNER_FILTER: ListViewFilterConfig = {
 	component: AutocompleteSelect,
 	props: {
@@ -820,6 +812,30 @@ const FINDINGS_OWNER_FILTER: ListViewFilterConfig = {
 		optionsLabelField: 'email',
 		optionsValueField: 'id',
 		optionsEndpoint: 'findings/owner',
+		multiple: true
+	}
+};
+
+const LAST_OCCURENCE_STATUS_FILTER: ListViewFilterConfig = {
+	component: AutocompleteSelect,
+	props: {
+		label: 'last_occurrence_status',
+		optionsEndpoint: 'task-templates/status',
+		optionsLabelField: 'label',
+		optionsValueField: 'value',
+		browserCache: 'force-cache',
+		multiple: true
+	}
+};
+
+const NEXT_OCCURENCE_STATUS_FILTER: ListViewFilterConfig = {
+	component: AutocompleteSelect,
+	props: {
+		label: 'next_occurrence_status',
+		optionsEndpoint: 'task-templates/status',
+		optionsLabelField: 'label',
+		optionsValueField: 'value',
+		browserCache: 'force-cache',
 		multiple: true
 	}
 };
@@ -1663,7 +1679,9 @@ export const listViewFields = {
 		],
 		filters: {
 			folder: DOMAIN_FILTER,
-			is_recurrent: IS_RECURRENT_FILTER
+			is_recurrent: IS_RECURRENT_FILTER,
+			last_occurrence_status: LAST_OCCURENCE_STATUS_FILTER,
+			next_occurrence_status: NEXT_OCCURENCE_STATUS_FILTER
 		}
 	},
 	'task-nodes': {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added filters to task templates for last occurrence status and next occurrence status, enabling more precise list views.
  - Added a findings owner filter to streamline searching by owner.

- Improvements
  - Task template list view now includes the new status filters in the UI.

- Chores
  - Removed a broken asset-class filter from the table configuration to reduce clutter and avoid confusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->