### PR TITLE
fix: Add owner to RiskScenario create modal and display it into the detail view

### DIFF
--- a/frontend/src/lib/components/Forms/ModelForm/RiskScenarioForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/RiskScenarioForm.svelte
@@ -79,6 +79,17 @@
 <AutocompleteSelect
 	{form}
 	multiple
+	optionsEndpoint="users?is_third_party=false"
+	optionsLabelField="email"
+	field="owner"
+	cacheLock={cacheLocks['owner']}
+	bind:cachedValue={formDataCache['owner']}
+	label={m.owner()}
+/>
+
+<AutocompleteSelect
+	{form}
+	multiple
 	optionsEndpoint="assets"
 	optionsExtraFields={[['folder', 'str']]}
 	optionsDetailedUrlParameters={[

--- a/frontend/src/lib/utils/schemas.ts
+++ b/frontend/src/lib/utils/schemas.ts
@@ -149,9 +149,9 @@ export const RiskScenarioSchema = z.object({
 	threats: z.string().uuid().optional().array().optional(),
 	assets: z.string().uuid().optional().array().optional(),
 	vulnerabilities: z.string().uuid().optional().array().optional(),
-	owner: z.string().uuid().optional().array().optional(),
 	security_exceptions: z.string().uuid().optional().array().optional(),
-	ref_id: z.string().max(100).optional()
+	ref_id: z.string().max(100).optional(),
+	owner: z.string().uuid().optional().array().optional()
 });
 
 export const AppliedControlSchema = z.object({

--- a/frontend/src/routes/(app)/(internal)/risk-scenarios/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/risk-scenarios/[id=uuid]/+page.svelte
@@ -160,6 +160,12 @@
 					<p class="text-sm font-semibold text-gray-400">{m.name()}</p>
 					<p class="font-semibold">{data.scenario.name}</p>
 				</div>
+				<div>
+					<p class="text-sm font-semibold text-gray-400">{m.owner()}</p>
+					{#each data.scenario.owner as owner}
+						<p class="text-sm"><a href="/users/{owner.id}" class="anchor">{owner.str}</a></p>
+					{/each}
+				</div>
 			</span>
 			<div>
 				<p class="text-sm font-semibold text-gray-400">{m.description()}</p>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Assign multiple owners to a Risk Scenario via a new multi-select, autocomplete Owners field in the form.
  - Owners are now displayed on the Risk Scenario detail page, each shown as a clickable link to the corresponding user profile.
  - Improved clarity with an explicit Owners section in the scenario header alongside existing details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->