### PR TITLE
fix: library overview column

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2199,5 +2199,6 @@
 	"isSelectedHelpText": "Decide if it should be passed to the study",
 	"quantRiskPriorityHelpText": "Useful for analyst to force an order on the exec summary",
 	"lossThreshold": "Loss threshold",
-	"lossThresholdHelpText": "Maximum acceptable loss that will serve as a baseline for the tolerance"
+	"lossThresholdHelpText": "Maximum acceptable loss that will serve as a baseline for the tolerance",
+	"libraryOverview": "{objectType}: {count}"
 }

--- a/frontend/src/lib/components/ModelTable/LibraryOverview.svelte
+++ b/frontend/src/lib/components/ModelTable/LibraryOverview.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import { safeTranslate } from '$lib/utils/i18n';
+	import { m } from '$paraglide/messages';
+
+	interface Props {
+		cell: Array<any>;
+		[key: string]: any;
+	}
+
+	type ReferentialObject =
+		| 'reference_controls'
+		| 'threats'
+		| 'framework'
+		| 'risk_matrix'
+		| 'requirement_mapping_set';
+
+	let { cell, ...rest }: Props = $props();
+	let display = $derived(Object.entries(cell));
+
+	function getLocalizedOverview(objectType: ReferentialObject, count: number) {
+		return m.libraryOverview({ objectType: safeTranslate(objectType), count });
+	}
+</script>
+
+<ul class="list-disc" {...rest}>
+	{#each display as obj}
+		<li>{getLocalizedOverview(obj[0] as ReferentialObject, obj[1])}</li>
+	{/each}
+</ul>

--- a/frontend/src/lib/utils/crud.ts
+++ b/frontend/src/lib/utils/crud.ts
@@ -6,6 +6,7 @@ import LibraryActions from '$lib/components/ModelTable/LibraryActions.svelte';
 import UserGroupNameDisplay from '$lib/components/ModelTable/UserGroupNameDisplay.svelte';
 import LecChartPreview from '$lib/components/ModelTable/LecChartPreview.svelte';
 import { type urlModel } from './types';
+import LibraryOverview from '$lib/components/ModelTable/LibraryOverview.svelte';
 
 type GetOptionsParams = {
 	objects: any[];
@@ -1581,10 +1582,12 @@ export const FIELD_COMPONENT_MAP = {
 	},
 	'stored-libraries': {
 		locales: LanguageDisplay,
+		objects_meta: LibraryOverview,
 		[CUSTOM_ACTIONS_COMPONENT]: LibraryActions
 	},
 	'loaded-libraries': {
 		locales: LanguageDisplay,
+		objects_meta: LibraryOverview,
 		[CUSTOM_ACTIONS_COMPONENT]: LibraryActions
 	},
 	'user-groups': {

--- a/frontend/src/lib/utils/table.ts
+++ b/frontend/src/lib/utils/table.ts
@@ -1219,11 +1219,19 @@ export const listViewFields = {
 	},
 	libraries: {
 		head: ['provider', 'name', 'description', 'language', 'overview'],
-		body: ['provider', 'name', 'description', 'locales', 'overview']
+		body: ['provider', 'name', 'description', 'locales', 'objects_meta']
 	},
 	'stored-libraries': {
 		head: ['provider', 'ref_id', 'name', 'description', 'language', 'overview', 'publication_date'],
-		body: ['provider', 'ref_id', 'name', 'description', 'locales', 'overview', 'publication_date'],
+		body: [
+			'provider',
+			'ref_id',
+			'name',
+			'description',
+			'locales',
+			'objects_meta',
+			'publication_date'
+		],
 		filters: {
 			locale: LANGUAGE_FILTER,
 			provider: PROVIDER_FILTER,
@@ -1233,7 +1241,15 @@ export const listViewFields = {
 	},
 	'loaded-libraries': {
 		head: ['provider', 'ref_id', 'name', 'description', 'language', 'overview', 'publication_date'],
-		body: ['provider', 'ref_id', 'name', 'description', 'locales', 'overview', 'publication_date'],
+		body: [
+			'provider',
+			'ref_id',
+			'name',
+			'description',
+			'locales',
+			'objects_meta',
+			'publication_date'
+		],
 		filters: {
 			locale: LANGUAGE_FILTER,
 			provider: PROVIDER_FILTER,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Library list views now display a localized “objects overview” showing counts of items (e.g., controls, threats, frameworks) per library.
  - The overview appears in Libraries, Stored Libraries, and Loaded Libraries tables for quicker at-a-glance insights.

- Localization
  - Added a new translation string for the library objects overview with placeholders for object type and count, enabling full i18n support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->