### PR TITLE
fix: update findings metrics inside follow-up on finding create or delete

### DIFF
--- a/frontend/src/routes/(app)/(internal)/findings-assessments/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/findings-assessments/[id=uuid]/+page.svelte
@@ -15,7 +15,6 @@
 
 	let { data, form }: Props = $props();
 	let exportPopupOpen = $state(false);
-
 </script>
 
 {#if data.data?.is_locked}


### PR DESCRIPTION
This PR solves a reactivity issue in the follow-up detail view. When creating or deleting a finding inside a follow-up, the metrics (severity, number of findings etc.) would not be updated on create, it required to reload the page to see the up-to-date metrics.
This PR makes it so that the metrics are updated reactively on finding create/delete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Widgets on Findings Assessments now re-render immediately when assessment forms change or are submitted.
  - Ensures the latest form state is reflected without manual reloads.
  - Improves consistency of on-page updates during editing or submission.
  - Reduces occurrences of stale data appearing in widgets; no visual or workflow changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->