### PR TITLE
fix: flaky ebios rm test

### DIFF
--- a/frontend/tests/functional/detailed/ebios-rm.test.ts
+++ b/frontend/tests/functional/detailed/ebios-rm.test.ts
@@ -47,6 +47,7 @@ test('ebios rm study', async ({
 	ebiosRmStudyPage,
 	complianceAssessmentsPage,
 	appliedControlsPage,
+	riskAssessmentsPage,
 	page
 }) => {
 	test.setTimeout(900_000);
@@ -587,10 +588,10 @@ test('ebios rm study', async ({
 
 	await test.step('workshop 5', async () => {
 		await page.getByRole('button', { name: ' Step 1 Generate the risk' }).click();
-		await page.getByTestId('form-input-name').click();
-		await page.getByTestId('form-input-name').fill('generated risk assessment 1');
-		await page.getByTestId('form-input-perimeter').getByRole('textbox').click();
-		await page.getByRole('option', { name: `${vars.folderName}/${vars.perimeterName}` }).click();
+		await riskAssessmentsPage.form.fill({
+			name: 'test-risk-assessment-ebios-rm',
+			perimeter: `${vars.folderName}/${vars.perimeterName}`
+		});
 		await page.getByTestId('save-button').click();
 		await expect(page.getByTestId('modal-title')).not.toBeVisible();
 		await page


### PR DESCRIPTION
This PR addresses flakiness on the EBIOS RM test module. This flakiness was due to an eager filling of the risk assessment create form in workshop 5. This was addressed by using the `riskAssessmentsPage.form.fill` method to create the risk assessment in workshop 5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Streamlined automated tests for the EBIOS RM risk assessment workflow by using a higher-level form-fill action.
  - Improved test reliability and reduced flakiness in the risk creation steps.
  - Maintained checks for saving and modal visibility to ensure consistent behavior.
  - Expect faster, more stable CI runs with clearer test intent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->