### PR TITLE
Moving the aggregate risk setting from interface to risk section

### DIFF
--- a/frontend/src/lib/components/Forms/ModelForm/GeneralSettingForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/GeneralSettingForm.svelte
@@ -30,7 +30,7 @@
 	let horizontalAxisPos = $derived(flipVertically ? 'top-8' : 'bottom-8');
 	let horizontalLabelPos = $derived(flipVertically ? 'top-2' : 'bottom-2');
 
-	let openAccordionItems = $state(['notifications','financial']);
+	let openAccordionItems = $state(['notifications', 'financial']);
 </script>
 
 <Accordion


### PR DESCRIPTION
- Moving the aggrate risk setting under risk matrix settings
<img width="984" height="487" alt="image" src="https://github.com/user-attachments/assets/30cfb9fb-3412-420e-9ad3-5ea5cf1e7725" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Risk Matrix settings now include a checkbox to enable the aggregated scenario matrix; the existing "Swap Axes" option remains available.

* **Refactor**
  * Interface-related controls were removed from their own section and consolidated into the Risk Matrix panel; the aggregated-scenario checkbox is placed before the "Swap Axes" option to streamline related settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->