### PR TITLE
fix: xrays regression with the evidence model change

### DIFF
--- a/frontend/src/routes/(app)/(internal)/x-rays/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/x-rays/+page.svelte
@@ -15,9 +15,16 @@
 		const types = ['errors', 'warnings', 'info'];
 		const result = {};
 
+		if (!item?.objects || typeof item.objects !== 'object') {
+			types.forEach((type) => {
+				result[type] = [];
+			});
+			return result;
+		}
+
 		types.forEach((type) => {
 			result[type] = Object.entries(item.objects).reduce((acc, [key, value]) => {
-				if (key !== 'object') {
+				if (key !== 'object' && value?.quality_check?.[type]) {
 					// if key === 'quality_check'
 					acc = [...acc, ...value.quality_check[type]];
 				}
@@ -31,17 +38,21 @@
 	let tabStates = $state({});
 
 	const processPerimetersData = (rawData: any) => {
+		if (!rawData || typeof rawData !== 'object') {
+			return [];
+		}
 		return Object.entries(rawData).map(([key, value]) => {
+			const valueObj = value as Record<string, any>;
 			return {
 				id: key,
-				...(value as Record<string, any>),
+				...valueObj,
 				compliance_assessments: {
-					...value.compliance_assessments,
-					...aggregateQualityChecks(value.compliance_assessments)
+					...valueObj.compliance_assessments,
+					...aggregateQualityChecks(valueObj.compliance_assessments)
 				},
 				risk_assessments: {
-					...value.risk_assessments,
-					...aggregateQualityChecks(value.risk_assessments)
+					...valueObj.risk_assessments,
+					...aggregateQualityChecks(valueObj.risk_assessments)
 				}
 			};
 		});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Quality/Integrity reports now issue clearer, per-evidence warnings when no file or link is uploaded, with links pointing directly to the specific evidence.
  - Improved stability on the X-Rays page: handles missing or malformed data gracefully, preventing errors and displaying empty states where appropriate.
- **Refactor**
  - Internal restructuring of evidence checks to process items individually for more precise reporting, without changing public behavior or APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->