### PR TITLE
Adding  the number of linked objects to the exception view

### DIFF
--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -1772,6 +1772,17 @@ class SecurityExceptionReadSerializer(BaseModelSerializer):
     owners = FieldsRelatedField(many=True)
     approver = FieldsRelatedField()
     severity = serializers.CharField(source="get_severity_display")
+    associated_objects_count = serializers.SerializerMethodField()
+
+    def get_associated_objects_count(self, obj):
+        """Calculate objects count dynamically"""
+        return (
+            obj.assets.count()
+            + obj.applied_controls.count()
+            + obj.vulnerabilities.count()
+            + obj.risk_scenarios.count()
+            + obj.requirement_assessments.count()
+        )
 
     class Meta:
         model = SecurityException

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -6281,6 +6281,15 @@ class SecurityExceptionViewSet(BaseModelViewSet):
     def status(self, request):
         return Response(dict(SecurityException.Status.choices))
 
+    def get_queryset(self):
+        return SecurityException.objects.prefetch_related(
+            "assets",
+            "applied_controls",
+            "vulnerabilities",
+            "risk_scenarios",
+            "requirement_assessments",
+        )
+
 
 class FindingsAssessmentViewSet(BaseModelViewSet):
     model = FindingsAssessment

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -6282,12 +6282,16 @@ class SecurityExceptionViewSet(BaseModelViewSet):
         return Response(dict(SecurityException.Status.choices))
 
     def get_queryset(self):
-        return SecurityException.objects.prefetch_related(
-            "assets",
-            "applied_controls",
-            "vulnerabilities",
-            "risk_scenarios",
-            "requirement_assessments",
+        return (
+            super()
+            .get_queryset()
+            .prefetch_related(
+                "assets",
+                "applied_controls",
+                "vulnerabilities",
+                "risk_scenarios",
+                "requirement_assessments",
+            )
         )
 
 

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -54,6 +54,7 @@
 	"associatedRepresentatives": "Associated representatives",
 	"associatedSolutions": "Associated solutions",
 	"associatedTaskTemplates": "Associated tasks",
+	"associatedEntitiesCount": "Associated objects",
 	"home": "Home",
 	"edit": "Edit",
 	"view": "View",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -54,7 +54,7 @@
 	"associatedRepresentatives": "Associated representatives",
 	"associatedSolutions": "Associated solutions",
 	"associatedTaskTemplates": "Associated tasks",
-	"associatedEntitiesCount": "Associated objects",
+	"associatedObjectsCount": "Associated objects",
 	"home": "Home",
 	"edit": "Edit",
 	"view": "View",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -54,7 +54,7 @@
 	"associatedRepresentatives": "Représentants associés",
 	"associatedSolutions": "Solutions associées",
 	"associatedTaskTemplates": "Tâches associées",
-	"associatedEntitiesCount": "Objets associés",
+	"associatedObjectsCount": "Objets associés",
 	"home": "Accueil",
 	"edit": "Modifier",
 	"view": "Voir",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -54,6 +54,7 @@
 	"associatedRepresentatives": "Représentants associés",
 	"associatedSolutions": "Solutions associées",
 	"associatedTaskTemplates": "Tâches associées",
+	"associatedEntitiesCount": "Objets associées",
 	"home": "Accueil",
 	"edit": "Modifier",
 	"view": "Voir",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -54,7 +54,7 @@
 	"associatedRepresentatives": "Représentants associés",
 	"associatedSolutions": "Solutions associées",
 	"associatedTaskTemplates": "Tâches associées",
-	"associatedEntitiesCount": "Objets associées",
+	"associatedEntitiesCount": "Objets associés",
 	"home": "Accueil",
 	"edit": "Modifier",
 	"view": "Voir",

--- a/frontend/src/lib/utils/table.ts
+++ b/frontend/src/lib/utils/table.ts
@@ -1536,7 +1536,7 @@ export const listViewFields = {
 			'status',
 			'expiration_date',
 			'domain',
-			'associatedEntitiesCount'
+			'associatedObjectsCount'
 		],
 		body: [
 			'ref_id',

--- a/frontend/src/lib/utils/table.ts
+++ b/frontend/src/lib/utils/table.ts
@@ -1529,8 +1529,24 @@ export const listViewFields = {
 		body: ['elementary_action', 'attack_stage', 'antecedents', 'logic_operator']
 	},
 	'security-exceptions': {
-		head: ['ref_id', 'name', 'severity', 'status', 'expiration_date', 'domain'],
-		body: ['ref_id', 'name', 'severity', 'status', 'expiration_date', 'folder'],
+		head: [
+			'ref_id',
+			'name',
+			'severity',
+			'status',
+			'expiration_date',
+			'domain',
+			'associatedEntitiesCount'
+		],
+		body: [
+			'ref_id',
+			'name',
+			'severity',
+			'status',
+			'expiration_date',
+			'folder',
+			'associated_objects_count'
+		],
 		filters: {
 			folder: DOMAIN_FILTER,
 			severity: EXCEPTION_SEVERITY_FILTER,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Security Exceptions list now shows an "Associated objects" column displaying the total number of related items per exception.
  * English and French labels added for the new column.

* Refactor
  * Security Exceptions querying optimized to prefetch related items and reduce extra database calls, improving list performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->