### PR TITLE
fix: properly display path in autocomplete select components

### DIFF
--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -1129,7 +1129,7 @@ class FolderWriteSerializer(BaseModelSerializer):
 
 
 class FolderReadSerializer(BaseModelSerializer):
-    path = PathField(source="get_folder_full_path", read_only=True)
+    path = serializers.SerializerMethodField()
     parent_folder = FieldsRelatedField()
 
     content_type = serializers.CharField(source="get_content_type_display")

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -395,16 +395,14 @@ class BaseModelViewSet(viewsets.ModelViewSet):
             while queue:
                 folder_id = queue.popleft()
                 folder = folders[folder_id]
-                path.append(
-                    {
-                        "str": str(folder),
-                        "id": folder.id,
-                        "parent_id": folder.parent_folder.id
-                        if folder.parent_folder
-                        else None,
-                    }
-                )
                 if folder.parent_folder:
+                    path.append(
+                        {
+                            "str": str(folder),
+                            "id": folder.id,
+                            "parent_id": folder.parent_folder.id,
+                        }
+                    )
                     queue.append(folder.parent_folder.id)
             path_results[obj.id] = path[::-1]  # Reverse to get root to leaf order
 

--- a/frontend/src/lib/components/Forms/AutocompleteSelect.svelte
+++ b/frontend/src/lib/components/Forms/AutocompleteSelect.svelte
@@ -223,7 +223,6 @@
 								return obj.str;
 							})
 						: [];
-				path.pop(); // remove duplicate last part if it exists
 
 				const infoFields = optionsInfoFields.fields
 					.map((f) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Folder paths in selection lists now display the full hierarchy for clearer context.

* Bug Fixes
  * Corrected path construction to remove empty/root placeholders and avoid truncated or duplicated segments in folder paths.
  * Improved consistency of displayed parent-child relationships across views and lists.

* Refactor
  * Unified backend path generation to use shared logic for consistent results across endpoints and views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->