### PR TITLE
Fix broken healthchecks

### DIFF
--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -123,6 +123,7 @@ urlpatterns = [
     path("resilience/", include("resilience.urls")),
     path("crq/", include("crq.urls")),
     path("csrf/", get_csrf_token, name="get_csrf_token"),
+    path("health/", healthcheck, name="healthcheck"),
     path("build/", get_build, name="get_build"),
     path(
         "evidences/<uuid:pk>/upload/",

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -6139,6 +6139,12 @@ def get_disk_usage():
 
 
 @api_view(["GET"])
+@permission_classes([permissions.AllowAny])
+def healthcheck(request):
+    return Response({"status": "ok"})
+
+
+@api_view(["GET"])
 def get_build(request):
     """
     API endpoint that returns the build version of the application.

--- a/config/docker-compose-barebone.yml
+++ b/config/docker-compose-barebone.yml
@@ -12,7 +12,7 @@ services:
     volumes:
       - ./db:/code/db
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://backend:8000/api/build || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://backend:8000/api/health/ || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 10

--- a/config/docker-compose.sh
+++ b/config/docker-compose.sh
@@ -20,7 +20,7 @@ echo "Initializing the database. This can take up to 3 minutes, please wait.."
 docker compose -f ./docker-compose-custom.yml up -d
 
 echo "Waiting for CISO Assistant backend to be ready..."
-until docker compose -f ./docker-compose-custom.yml exec -T backend curl -f http://localhost:8000/api/build >/dev/null 2>&1; do
+until docker compose -f ./docker-compose-custom.yml exec -T backend curl -f http://localhost:8000/api/health/ >/dev/null 2>&1; do
   echo "Backend is not ready - waiting 10s..."
   sleep 10
 done

--- a/config/templates/docker-compose-postgresql-bunkerweb.yml.j2
+++ b/config/templates/docker-compose-postgresql-bunkerweb.yml.j2
@@ -51,7 +51,7 @@ services:
     volumes:
       - ./db:/code/db
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://backend:8000/api/build || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://backend:8000/api/health/ || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 20

--- a/config/templates/docker-compose-postgresql-caddy.yml.j2
+++ b/config/templates/docker-compose-postgresql-caddy.yml.j2
@@ -49,7 +49,7 @@ services:
     volumes:
       - ./db:/code/db
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://backend:8000/api/build || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://backend:8000/api/health/ || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 20

--- a/config/templates/docker-compose-postgresql-traefik.yml.j2
+++ b/config/templates/docker-compose-postgresql-traefik.yml.j2
@@ -49,7 +49,7 @@ services:
     volumes:
       - ./db:/code/db
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://backend:8000/api/build || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://backend:8000/api/health/ || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 20

--- a/config/templates/docker-compose-sqlite-bunkerweb.yml.j2
+++ b/config/templates/docker-compose-sqlite-bunkerweb.yml.j2
@@ -21,7 +21,7 @@ services:
     volumes:
       - ./db:/code/db
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://backend:8000/api/build || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://backend:8000/api/health/ || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 20

--- a/config/templates/docker-compose-sqlite-caddy.yml.j2
+++ b/config/templates/docker-compose-sqlite-caddy.yml.j2
@@ -20,7 +20,7 @@ services:
     volumes:
       - ./db:/code/db
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://backend:8000/api/build || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://backend:8000/api/health/ || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 20

--- a/config/templates/docker-compose-sqlite-traefik.yml.j2
+++ b/config/templates/docker-compose-sqlite-traefik.yml.j2
@@ -20,7 +20,7 @@ services:
     volumes:
       - ./db:/code/db
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://backend:8000/api/build || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://backend:8000/api/health/ || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 20

--- a/docker-compose.ps1
+++ b/docker-compose.ps1
@@ -17,7 +17,7 @@ Write-Output "Waiting for CISO Assistant backend to be ready..."
 do {
     $backendReady = $false
     try {
-        $result = docker compose exec -T backend curl -f http://localhost:8000/api/build 2>$null
+        $result = docker compose exec -T backend curl -f http://localhost:8000/api/health/ 2>$null
         if ($LASTEXITCODE -eq 0) {
             $backendReady = $true
         }

--- a/docker-compose.sh
+++ b/docker-compose.sh
@@ -13,7 +13,7 @@ echo "Initializing the database. This can take up to 2 minutes, please wait.."
 docker compose up -d
 
 echo "Waiting for CISO Assistant backend to be ready..."
-until docker compose exec -T backend curl -f http://localhost:8000/api/build >/dev/null 2>&1; do
+until docker compose exec -T backend curl -f http://localhost:8000/api/health/ >/dev/null 2>&1; do
   echo "Backend is not ready - waiting 10s..."
   sleep 10
 done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - ./db:/code/db
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://backend:8000/api/build || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://backend:8000/api/health/ || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 20

--- a/enterprise/config/docker-compose.sh
+++ b/enterprise/config/docker-compose.sh
@@ -17,7 +17,7 @@ echo "Initializing the database. This can take up to 2 minutes, please wait.."
 docker compose -f ./docker-compose.yml up -d
 
 echo "Waiting for CISO Assistant backend to be ready..."
-until docker compose -f ./docker-compose.yml exec -T backend curl -f http://localhost:8000/api/build >/dev/null 2>&1; do
+until docker compose -f ./docker-compose.yml exec -T backend curl -f http://localhost:8000/api/health/ >/dev/null 2>&1; do
   echo "Backend is not ready - waiting 10s..."
   sleep 10
 done

--- a/enterprise/config/templates/docker-compose-postgresql-caddy.yml.j2
+++ b/enterprise/config/templates/docker-compose-postgresql-caddy.yml.j2
@@ -51,7 +51,7 @@ services:
     volumes:
       - ./db:/code/db
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://backend:8000/api/build || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://backend:8000/api/health/ || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 10

--- a/enterprise/config/templates/docker-compose-postgresql-traefik.yml.j2
+++ b/enterprise/config/templates/docker-compose-postgresql-traefik.yml.j2
@@ -51,7 +51,7 @@ services:
     volumes:
       - ./db:/code/db
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://backend:8000/api/build || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://backend:8000/api/health/ || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 10

--- a/enterprise/config/templates/docker-compose-sqlite-caddy.yml.j2
+++ b/enterprise/config/templates/docker-compose-sqlite-caddy.yml.j2
@@ -22,7 +22,7 @@ services:
     volumes:
       - ./db:/code/db
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://backend:8000/api/build || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://backend:8000/api/health/ || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 10

--- a/enterprise/config/templates/docker-compose-sqlite-traefik.yml.j2
+++ b/enterprise/config/templates/docker-compose-sqlite-traefik.yml.j2
@@ -22,7 +22,7 @@ services:
     volumes:
       - ./db:/code/db
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://backend:8000/api/build || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://backend:8000/api/health/ || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 10


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public health check endpoint (/api/health) that returns a simple status response.

* **Chores**
  * Updated health checks in container configs and startup scripts to use the new health endpoint instead of the previous one.
  * Retained existing intervals, timeouts, and retries for health checks.
  * Introduced a start_period (100s) in one container template to delay initial health evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->