### PR TITLE
feat: use CSF functions colors for the nightingdale chart

### DIFF
--- a/frontend/src/lib/components/Chart/NightingaleChart.svelte
+++ b/frontend/src/lib/components/Chart/NightingaleChart.svelte
@@ -27,6 +27,26 @@
 		const echarts = await import('echarts');
 		let chart = echarts.init(document.getElementById(chart_id), null, { renderer: 'svg' });
 
+		// Color mapping for CSF functions
+		const colorMap: Record<string, string> = {
+			'(undefined)': '#505372',
+			'Govern': '#FAE482',
+			'Identify': '#85C4EA',
+			'Protect': '#B29BBA',
+			'Detect': '#FAB647',
+			'Respond': '#E47677',
+			'Recover': '#8ACB93'
+		};
+
+		// Map data with specific colors
+		const dataWithColors = values.map(item => ({
+			...item,
+			itemStyle: {
+				color: colorMap[item.name] || '#505372',
+				borderRadius: 5
+			}
+		}));
+
 		// specify chart configuration item and data
 		var option = {
 			tooltip: {
@@ -39,10 +59,7 @@
 					type: 'pie',
 					radius: [20, 100],
 					roseType: 'area',
-					itemStyle: {
-						borderRadius: 5
-					},
-					data: values
+					data: dataWithColors
 				}
 			]
 		}; // console.debug(option);

--- a/frontend/src/lib/components/Chart/NightingaleChart.svelte
+++ b/frontend/src/lib/components/Chart/NightingaleChart.svelte
@@ -30,16 +30,16 @@
 		// Color mapping for CSF functions
 		const colorMap: Record<string, string> = {
 			'(undefined)': '#505372',
-			'Govern': '#FAE482',
-			'Identify': '#85C4EA',
-			'Protect': '#B29BBA',
-			'Detect': '#FAB647',
-			'Respond': '#E47677',
-			'Recover': '#8ACB93'
+			Govern: '#FAE482',
+			Identify: '#85C4EA',
+			Protect: '#B29BBA',
+			Detect: '#FAB647',
+			Respond: '#E47677',
+			Recover: '#8ACB93'
 		};
 
 		// Map data with specific colors
-		const dataWithColors = values.map(item => ({
+		const dataWithColors = values.map((item) => ({
 			...item,
 			itemStyle: {
 				color: colorMap[item.name] || '#505372',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Nightingale chart now maps each CSF function to a consistent, meaningful color for improved readability and faster visual scanning.
  * Chart segments include subtle rounding for a more polished, modern appearance.
  * Colors are embedded in the data so legends and tooltips reliably match segment colors; no changes to interactions or displayed values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->