### PR TITLE
fix: Broken security objective RadioGroup

### DIFF
--- a/frontend/src/lib/components/Forms/ModelForm/AssetForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/AssetForm.svelte
@@ -169,11 +169,6 @@
 	>
 		<div class="flex flex-col space-y-4">
 			{#each securityObjectives as objective}
-				{@const objectiveFormData =
-					data.security_objectives?.objectives &&
-					Object.hasOwn(data.security_objectives?.objectives, objective)
-						? data.security_objectives.objectives[objective]
-						: {}}
 				<span class="flex flex-row items-end space-x-4">
 					<Checkbox
 						{form}
@@ -192,7 +187,7 @@
 						key="value"
 						field={objective}
 						valuePath="security_objectives.objectives.{objective}.value"
-						disabled={objectiveFormData && objectiveFormData.is_enabled === false}
+						disabled={!data.security_objectives?.objectives[objective].is_enabled}
 					/>
 				</span>
 			{/each}

--- a/frontend/src/lib/components/Forms/ModelForm/AssetForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/AssetForm.svelte
@@ -187,7 +187,7 @@
 						key="value"
 						field={objective}
 						valuePath="security_objectives.objectives.{objective}.value"
-						disabled={!data.security_objectives?.objectives[objective].is_enabled}
+						disabled={data.security_objectives?.objectives?.[objective]?.is_enabled === false}
 					/>
 				</span>
 			{/each}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal logic that determines whether security objectives are enabled in the Asset form.
  * Removed intermediate checks and guards, streamlining how objective enablement is evaluated.
  * Adjusted control disabled behavior to rely directly on objective enablement.
  * No expected changes to user-facing behavior; improves maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->