### PR TITLE
feat(ui): Hide selected implementation groups field if empty

### DIFF
--- a/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/+page.svelte
@@ -384,8 +384,8 @@
 			{#each Object.entries(data.compliance_assessment).filter(([key, value]) => {
 				const fieldsToShow = ['ref_id', 'name', 'description', 'perimeter', 'framework', 'authors', 'reviewers', 'status', 'selected_implementation_groups', 'assets', 'evidences', 'campaign'];
 				if (!fieldsToShow.includes(key)) return false;
-				// Hide selected_implementation_groups if it's empty
-				if (key === 'selected_implementation_groups' && (!value || (Array.isArray(value) && value.length === 0))) return false;
+				// Hide selected_implementation_groups if framework doesn't support implementation groups
+				if (key === 'selected_implementation_groups' && (!data.compliance_assessment.framework.implementation_groups_definition || !Array.isArray(data.compliance_assessment.framework.implementation_groups_definition) || data.compliance_assessment.framework.implementation_groups_definition.length === 0)) return false;
 				return true;
 			}) as [key, value]}
 				<div class="flex flex-col">

--- a/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/+page.svelte
@@ -381,7 +381,13 @@
 	{/if}
 	<div class="card px-6 py-4 bg-white flex flex-row justify-between shadow-lg w-full">
 		<div class="flex flex-col space-y-2 whitespace-pre-line w-1/5 pr-1">
-			{#each Object.entries(data.compliance_assessment).filter( ([key, _]) => ['ref_id', 'name', 'description', 'perimeter', 'framework', 'authors', 'reviewers', 'status', 'selected_implementation_groups', 'assets', 'evidences', 'campaign'].includes(key) ) as [key, value]}
+			{#each Object.entries(data.compliance_assessment).filter(([key, value]) => {
+				const fieldsToShow = ['ref_id', 'name', 'description', 'perimeter', 'framework', 'authors', 'reviewers', 'status', 'selected_implementation_groups', 'assets', 'evidences', 'campaign'];
+				if (!fieldsToShow.includes(key)) return false;
+				// Hide selected_implementation_groups if it's empty
+				if (key === 'selected_implementation_groups' && (!value || (Array.isArray(value) && value.length === 0))) return false;
+				return true;
+			}) as [key, value]}
 				<div class="flex flex-col">
 					<div
 						class="text-sm font-medium text-gray-800 capitalize-first"


### PR DESCRIPTION
<img width="1743" height="729" alt="image" src="https://github.com/user-attachments/assets/75bd4222-7234-4770-b9a3-e448540ff68e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Dynamic filtering in compliance assessment details now constructs allowed fields at runtime and displays only permitted text, array, link, and markdown fields while preserving existing rendering.
- Bug Fixes
  - Hides “Selected implementation groups” when its definition or value is missing or empty to reduce visual clutter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->