### PR TITLE
feat: copy ref_id when creating applied control with a reference control

### DIFF
--- a/frontend/src/lib/components/Forms/ModelForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm.svelte
@@ -276,6 +276,7 @@
 									updated_fields.add('reference_control');
 									return {
 										...currentData,
+										name: r.name,
 										category: r.category,
 										csf_function: r.csf_function,
 										ref_id: r.ref_id

--- a/frontend/src/lib/components/Forms/ModelForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm.svelte
@@ -274,7 +274,12 @@
 										return currentData; // Keep the current values in the edit form.
 									}
 									updated_fields.add('reference_control');
-									return { ...currentData, category: r.category, csf_function: r.csf_function };
+									return {
+										...currentData,
+										category: r.category,
+										csf_function: r.csf_function,
+										ref_id: r.ref_id
+									};
 								});
 							});
 					}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When selecting a reference control in the form, the related reference ID is now captured and stored alongside existing fields, improving completeness of the populated data.
  * The form reflects this additional context to ensure more accurate editing and downstream actions (e.g., validation, export, or review).
* **Bug Fixes**
  * Ensures consistent propagation of reference details when updating form data after selecting a reference control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->