### PR TITLE
fix: Mapping perf issue

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -4662,7 +4662,7 @@ class ComplianceAssessment(Assessment):
                         "is_scored",
                         "observation",
                     ],
-                    batch_size=1000
+                    batch_size=1000,
                 )
 
             # Handle M2M relationships
@@ -5251,7 +5251,7 @@ class ComplianceAssessment(Assessment):
                 "is_scored",
                 "observation",
             ],
-            batch_size=1000
+            batch_size=1000,
         )
         return requirement_assessments
 

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -5238,9 +5238,19 @@ class ComplianceAssessment(Assessment):
                     },
                     # "mappings": [mapping.id for mapping in mappings],
                 }
-                requirement_assessment.save()
                 requirement_assessments.append(requirement_assessment)
 
+        RequirementAssessment.objects.bulk_update(
+            requirement_assessments,
+            [
+                "mapping_inference",
+                "result",
+                "status",
+                "score",
+                "is_scored",
+                "observation",
+            ],
+        )
         return requirement_assessments
 
     def get_progress(self) -> int:

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -4662,6 +4662,7 @@ class ComplianceAssessment(Assessment):
                         "is_scored",
                         "observation",
                     ],
+                    batch_size=1000
                 )
 
             # Handle M2M relationships
@@ -5250,6 +5251,7 @@ class ComplianceAssessment(Assessment):
                 "is_scored",
                 "observation",
             ],
+            batch_size=1000
         )
         return requirement_assessments
 


### PR DESCRIPTION
When applying a mapping for the CJIS framework (which has almost 2000 requirement nodes), the time for the mapping to be applied is around 200 seconds.
During this time the instance is "blocked" (The ASGI can't reply to the new received requests until the apply mapping operation finishes).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized updating of assessment results to reduce processing time and database round-trips.
  * Users may experience faster completion of assessment scoring and status updates, especially under heavy workloads.
  * Reduces risk of partial updates during large operations, improving reliability.
  * No changes to user workflows or visible data outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->