### PR TITLE
feat: add owner on evidences table

### DIFF
--- a/frontend/src/lib/utils/table.ts
+++ b/frontend/src/lib/utils/table.ts
@@ -1327,8 +1327,8 @@ export const listViewFields = {
 		}
 	},
 	evidences: {
-		head: ['name', 'file', 'size', 'folder', 'status', 'updatedAt', 'labels'],
-		body: ['name', 'attachment', 'size', 'folder', 'status', 'updated_at', 'filtering_labels'],
+		head: ['name', 'file', 'folder', 'owner', 'status', 'updatedAt', 'labels'],
+		body: ['name', 'attachment', 'folder', 'owner', 'status', 'updated_at', 'filtering_labels'],
 		filters: {
 			folder: DOMAIN_FILTER,
 			filtering_labels: LABELS_FILTER,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Evidences list now includes an Owner column in both the header and rows, making it easier to identify who owns each item.
  * The Size column has been removed to streamline the table layout and focus on relevant metadata.
  * Existing fields (name, file/attachment, folder, status, labels) remain unchanged.
  * Filters and other table behaviors are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->