### PR TITLE
fix: Can't pick twice the same result in audit flash-mode

### DIFF
--- a/frontend/src/lib/components/Forms/RadioGroup.svelte
+++ b/frontend/src/lib/components/Forms/RadioGroup.svelte
@@ -86,10 +86,12 @@
 				onclick={(event) => {
 					event.preventDefault();
 					if (disabled) return;
-					// event.stopPropagation();
-					if (internalValue === option[key] && nullable) {
-						internalValue = null;
-						onChange(internalValue);
+					if (internalValue === option[key]) {
+						if (nullable) {
+							internalValue = null;
+							onChange(internalValue);
+							return;
+						}
 						return;
 					}
 					value?.set(option[key]);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Radio groups that allow null selection can now be cleared by clicking the currently selected option.
  - Options are now rendered as interactive buttons for clearer, more direct selection.

- Style
  - Improved visual styling and cursor feedback for disabled and active radio options.

- Refactor
  - Simplified selection handling and event flow for more consistent behavior across options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->