### PR TITLE
fix: Stakeholder filters

### DIFF
--- a/backend/ebios_rm/views.py
+++ b/backend/ebios_rm/views.py
@@ -461,7 +461,13 @@ class StakeholderFilter(df.FilterSet):
 
     class Meta:
         model = Stakeholder
-        fields = ["ebios_rm_study", "is_selected", "applied_controls", "category"]
+        fields = [
+            "ebios_rm_study",
+            "is_selected",
+            "applied_controls",
+            "category",
+            "entity",
+        ]
 
     def filter_current_criticality(self, queryset, name, values):
         ids = [obj.id for obj in queryset if obj.current_criticality in values]

--- a/frontend/src/lib/utils/table.ts
+++ b/frontend/src/lib/utils/table.ts
@@ -746,7 +746,7 @@ const CURRENT_CRITICALITY_FILTER: ListViewFilterConfig = {
 			{ label: '1', value: 1 },
 			{ label: '2', value: 2 },
 			{ label: '3', value: 3 },
-			{ label: '3', value: 4 }
+			{ label: '4', value: 4 }
 		],
 		multiple: true,
 		translateOptions: false
@@ -832,12 +832,11 @@ const FINDINGS_ASSESSMENTS_CATEGORY_FILTER: ListViewFilterConfig = {
 const STAKEHOLDER_CATEGORY_FILTER: ListViewFilterConfig = {
 	component: AutocompleteSelect,
 	props: {
+		optionsEndpoint: 'terminologies?field_path=entity.relationship',
+		optionsLabelField: 'name',
 		label: 'category',
-		optionsEndpoint: 'stakeholders/category',
-		multiple: true,
-		optionsLabelField: 'label',
 		browserCache: 'force-cache',
-		optionsValueField: 'value'
+		multiple: true
 	}
 };
 
@@ -1671,9 +1670,7 @@ export const listViewFields = {
 		filters: {
 			is_selected: IS_SELECTED_FILTER,
 			entity: ENTITY_FILTER,
-			category: STAKEHOLDER_CATEGORY_FILTER,
-			current_criticality: CURRENT_CRITICALITY_FILTER,
-			residual_criticality: RESIDUAL_CRITICALITY_FILTER
+			category: STAKEHOLDER_CATEGORY_FILTER
 		}
 	},
 	'strategic-scenarios': {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added endpoints to retrieve stakeholder category choices and ecosystem radar chart data.
  - Enabled multi-select filtering for stakeholder current and residual criticality.

- Enhancements
  - Criticality filter options now show explicit labels with values and translation disabled for consistent display.
  - Stakeholder category filter now sources terminology choices (uses name labels) and is the primary list-view filter for stakeholders; per-item criticality filters were removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->