### PR TITLE
Revert "feat(ux): Allow unselecting an answer to a question"

### DIFF
--- a/frontend/src/lib/components/Forms/Question.svelte
+++ b/frontend/src/lib/components/Forms/Question.svelte
@@ -106,7 +106,6 @@
 						possibleOptions={question.choices}
 						{form}
 						initialValue={internalAnswers[urn]}
-						nullable={true}
 						key="urn"
 						labelKey="value"
 						field="answers"

--- a/frontend/src/lib/components/Forms/RadioGroup.svelte
+++ b/frontend/src/lib/components/Forms/RadioGroup.svelte
@@ -11,7 +11,6 @@
 		form?: SuperForm<Record<string, any>>;
 		disabled?: boolean;
 		initialValue?: any;
-		nullable?: boolean;
 		onChange?: (value: string) => void;
 		cacheLock?: CacheLock;
 		cachedValue?: any;
@@ -29,7 +28,6 @@
 		form,
 		disabled = false,
 		initialValue,
-		nullable = false,
 		onChange = () => {},
 		cacheLock = {
 			promise: new Promise((res) => res(null)),
@@ -56,6 +54,8 @@
 		if (value) {
 			$value = internalValue;
 		}
+		const input = radioInputs[internalValue];
+		if (input) input.checked = true;
 	});
 
 	$effect(() => {
@@ -89,16 +89,6 @@
 							class="invisible"
 							id={option.id}
 							bind:this={radioInputs[option[key]]}
-							onclick={(event) => {
-								if (!nullable) return;
-								if (internalValue === option[key]) {
-									internalValue = null;
-									onChange(internalValue);
-								} else {
-									// This makes it possible to reselect an unselected radio input in svelte.
-									event.target?.dispatchEvent(new Event('change', { bubbles: true }));
-								}
-							}}
 							onchange={(e) => {
 								internalValue = option[key];
 								onChange(internalValue);


### PR DESCRIPTION
Reverts intuitem/ciso-assistant-community#2648

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Single-choice (radio) questions no longer support clearing a selection; an option must remain selected.

- **Bug Fixes**
  - Radio selections now stay correctly in sync with the current value.
  - Improved change handling to prevent unintended clears and duplicate events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->