### PR TITLE
fix: better explain the counters difference

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -911,7 +911,7 @@
 	"mtdHelpText": "Maximum Tolerable Downtime",
 	"disasterRecoveryObjectives": "Disaster Recovery objectives",
 	"noExpirationDateSet": "No expiration date set",
-	"sumpageTotal": "total",
+	"sumpageTotal": "total (all categories)",
 	"sumpageActive": "active",
 	"sumpageDeprecated": "deprecated",
 	"sumpageToDo": "to do",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -885,7 +885,7 @@
 	"mtdHelpText": "Temps d'arrêt maximal tolérable",
 	"disasterRecoveryObjectives": "Objectifs de reprise d'activité",
 	"noExpirationDateSet": "Aucune date d'expiration définie",
-	"sumpageTotal": "Total",
+	"sumpageTotal": "Total (toutes catégories)",
 	"sumpageActive": "Actif",
 	"sumpageDeprecated": "Obsolète",
 	"sumpageToDo": "A faire",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated UI copy for the “Total” label to clarify it represents the sum across all categories on the summary page.
  * English: “total (all categories)”; French: “Total (toutes catégories)”.
  * Improves clarity for users reviewing aggregated totals in both languages.
  * No functional or behavioral changes; display text only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->