### PR TITLE
feat: add domain to perimeter in campaign form

### DIFF
--- a/frontend/src/lib/components/Forms/ModelForm/CampaignForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/CampaignForm.svelte
@@ -75,6 +75,7 @@
 	/>
 {/if}
 <AutocompleteSelect
+	multiple
 	{form}
 	optionsEndpoint="perimeters"
 	optionsExtraFields={[['folder', 'str']]}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Campaign form now uses a single-select Perimeter field instead of multi-select.
  * Perimeter options include additional folder/context info for clearer selection.
  * The selector caches and reuses the last chosen perimeter for faster, more consistent entry.
  * Field label updated to “Perimeter,” and field visibility now respects provided initial data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->