### PR TITLE
fix: permissions list in role edition

### DIFF
--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -1147,11 +1147,15 @@ class PermissionReadSerializer(BaseModelSerializer):
 
     def get_normalized_model(self, obj):
         model_class = obj.content_type.model_class()
-        return model_class.__name__ if model_class else obj.content_type.model.capitalize()
+        return (
+            model_class.__name__ if model_class else obj.content_type.model.capitalize()
+        )
 
     def get_normalized_codename(self, obj):
         model_class = obj.content_type.model_class()
-        model_name = model_class.__name__ if model_class else obj.content_type.model.capitalize()
+        model_name = (
+            model_class.__name__ if model_class else obj.content_type.model.capitalize()
+        )
         return f"{obj.codename.split('_')[0]}{model_name}"
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where permission names and codenames could be incorrect or error when a related content type lacked an associated model. Permission labels and codenames now reliably fall back to an available model identifier, ensuring consistent, stable display in the UI and API responses for edge cases and custom content types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->