### PR TITLE
fix: pass the ref_id from reference control to applied controls during suggestion

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -5964,9 +5964,7 @@ class RequirementAssessment(AbstractBaseModel, FolderMixin, ETADueDateMixin):
                     defaults={
                         "name": reference_control.get_name_translated
                         or reference_control.ref_id,
-                        "ref_id": reference_control.ref_id
-                        if not reference_control.get_name_translated
-                        else None,
+                        "ref_id": reference_control.ref_id,
                     },
                 )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where reference identifiers were not consistently preserved when creating items from suggestions. Previously, identifiers could be lost when certain translation conditions were present. This behavior has been corrected. Reference identifiers are now reliably and consistently maintained in all cases to ensure complete and accurate data records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->