### PR TITLE
fix: Word-break styling break words in Markdown rendering

### DIFF
--- a/frontend/src/lib/components/MarkdownRenderer.svelte
+++ b/frontend/src/lib/components/MarkdownRenderer.svelte
@@ -74,7 +74,7 @@
 </script>
 
 {#if renderedContent}
-	<div class="prose prose-sm max-w-none break-all whitespace-pre-line {className}">
+	<div class="prose prose-sm max-w-none wrap-break-word whitespace-pre-line {className}">
 		{@html renderedContent}
 	</div>
 {:else}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated text wrapping behavior in markdown content display to improve readability and prevent inappropriate word breaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->