### PR TITLE
feat: Make save and continue button go to the next requirement instead

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -4,7 +4,7 @@ import re
 import hashlib
 from datetime import date, datetime
 from pathlib import Path
-from typing import Self, Union, List
+from typing import Self, Union, List, Optional
 import statistics
 
 from django.utils import timezone
@@ -5910,6 +5910,23 @@ class RequirementAssessment(AbstractBaseModel, FolderMixin, ETADueDateMixin):
             },
             "description",
         )
+
+    @property
+    def get_next_requirement_id(self) -> Optional[str]:
+        order_id = self.requirement.order_id
+        if order_id is None:
+            return
+
+        next_requirement_assessment: RequirementAssessment = (
+            self.compliance_assessment.requirement_assessments.filter(
+                requirement__order_id=order_id + 1
+            ).first()
+        )
+
+        if next_requirement_assessment is None:
+            return
+
+        return str(next_requirement_assessment.id)
 
     @property
     def is_locked(self) -> bool:

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -1768,6 +1768,7 @@ class RequirementAssessmentReadSerializer(BaseModelSerializer):
     requirement = FilteredNodeSerializer()
     security_exceptions = FieldsRelatedField(many=True)
     is_locked = serializers.BooleanField()
+    next_requirement = serializers.CharField(source="get_next_requirement_id")
 
     class Meta:
         model = RequirementAssessment
@@ -1776,6 +1777,9 @@ class RequirementAssessmentReadSerializer(BaseModelSerializer):
 
 class RequirementAssessmentWriteSerializer(BaseModelSerializer):
     requirement = serializers.PrimaryKeyRelatedField(read_only=True)
+    next_requirement = serializers.CharField(
+        source="get_next_requirement_id", read_only=True
+    )
 
     def validate(self, attrs):
         compliance_assessment = self.get_compliance_assessment()

--- a/frontend/src/lib/utils/schemas.ts
+++ b/frontend/src/lib/utils/schemas.ts
@@ -322,7 +322,7 @@ export const RequirementAssessmentSchema = z.object({
 	applied_controls: z.array(z.string().uuid().optional()).optional(),
 	observation: z.string().optional().nullable(),
 	security_exceptions: z.string().uuid().optional().array().optional(),
-	noRedirect: z.boolean().default(false)
+	gotoNextRequirement: z.boolean().default(false)
 });
 
 export const UserEditSchema = z.object({

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.server.ts
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.server.ts
@@ -205,12 +205,15 @@ export const actions: Actions = {
 		const object = await response.json();
 		const model: string = urlParamModelVerboseName(URLModel);
 		setFlash({ type: 'success', message: m.successfullySavedObject({ object: model }) }, event);
-		if (formData.noRedirect) return;
-		redirect(
-			302,
-			getSecureRedirect(event.url.searchParams.get('next')) ||
-				`/compliance-assessments/${object.compliance_assessment}/`
-		);
+		if (formData.gotoNextRequirement) {
+			redirect(302, `/requirement-assessments/${object.next_requirement}/edit`);
+		} else {
+			redirect(
+				302,
+				getSecureRedirect(event.url.searchParams.get('next')) ||
+					`/compliance-assessments/${object.compliance_assessment}/`
+			);
+		}
 	},
 	createAppliedControl: async (event) => {
 		const URLModel = 'applied-controls';

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.svelte
@@ -687,15 +687,17 @@
 							type="button"
 							onclick={cancel}>{m.cancel()}</button
 						>
-						<button
-							class="btn preset-filled-secondary-500 font-semibold w-full"
-							data-testid="save-no-continue-button"
-							type="submit"
-							onclick={() =>
-								form.form.update((data) => {
-									return { ...data, noRedirect: true };
-								})}>{m.saveAndContinue()}</button
-						>
+						{#if page.data.requirementAssessment.next_requirement !== null}
+							<button
+								class="btn preset-filled-secondary-500 font-semibold w-full"
+								data-testid="save-no-continue-button"
+								type="submit"
+								onclick={() =>
+									form.form.update((data) => {
+										return { ...data, gotoNextRequirement: true };
+									})}>{m.saveAndContinue()}</button
+							>
+						{/if}
 						<button
 							class="btn preset-filled-primary-500 font-semibold w-full"
 							data-testid="save-button"


### PR DESCRIPTION
Note that the "save and continue" naming for the button hasn't been changed.
Should we change the name of this button ?
To discuss.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Save and Continue" button that navigates to the next requirement when completing an assessment, streamlining workflows for multi-requirement assessments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->