### PR TITLE
feat: custom ca certificate script

### DIFF
--- a/config/init-custom-ca-certificates.sh
+++ b/config/init-custom-ca-certificates.sh
@@ -1,0 +1,14 @@
+set -e
+
+CERT_PATH="${CUSTOM_CA_CERT_PATH:-}"
+
+echo "[init-cert] Starting container initialization..."
+
+if [ -n "$CERT_PATH" ] && [ -f "$CERT_PATH" ]; then
+  echo "[init-cert] Found certificate at: $CERT_PATH"
+  update-ca-certificates
+else
+  echo "[init-cert] No custom CA certificate found or CUSTOM_CA_CERT_PATH not set."
+fi
+
+exec "$@"

--- a/enterprise/config/init-custom-ca-certificates.sh
+++ b/enterprise/config/init-custom-ca-certificates.sh
@@ -1,0 +1,14 @@
+set -e
+
+CERT_PATH="${CUSTOM_CA_CERT_PATH:-}"
+
+echo "[init-cert] Starting container initialization..."
+
+if [ -n "$CERT_PATH" ] && [ -f "$CERT_PATH" ]; then
+  echo "[init-cert] Found certificate at: $CERT_PATH"
+  update-ca-certificates
+else
+  echo "[init-cert] No custom CA certificate found or CUSTOM_CA_CERT_PATH not set."
+fi
+
+exec "$@"


### PR DESCRIPTION
Added a custom ca certificate script in config/init-custom-ca-certificates.sh and enterprise/config/init-custom-ca-certificates.sh to explain the user how the mailer can work while having a local ca-certificate.

git book extract that is currently in review by @Mohamed-Hacene :

Add automatically your local CA-certificate
An issue you may encounter when setting up your mailer is that your local CA certificates might not be included inside your Docker container. This could cause problems when sending emails.
To address this, we provide a script located at config/init-custom-ca-certificates.sh and enterprise/config/init-custom-ca-certificates.sh.
You need to use this script with your Docker Compose setup by adding the following lines to the huey service:
This environment variable : 
- CUSTOM_CA_CERT_PATH=/usr/local/share/ca-certificates/root_CA.crt
This volumes (replace /your/ca-certificate/path/example_CA.crt by the pass and the name of your ca-certificate) :
- /your/ca-certificate/path/example_CA.crt:/usr/local/share/ca-certificates/root_CA.crt:ro
- ./config/init-custom-ca-certificates.sh:/docker-entrypoint-init.d/init-custom-ca-certificates.sh:ro
This entrypoint : 
entrypoint:
  - /bin/sh
  - -c
  - |
    /docker-entrypoint-init.d/init-custom-ca-certificates.sh && \
    poetry run python manage.py run_huey -w 2 --scheduler-interval 60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added custom CA certificate support for container deployments. The system now automatically detects and installs custom CA certificates during startup when configured, enabling secure communication in environments requiring certificate authority validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->