### PR TITLE
fix(UI): remove empty integrations tab in global settings

### DIFF
--- a/frontend/src/routes/(app)/(internal)/settings/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/settings/+page.svelte
@@ -22,9 +22,6 @@
 		<Tabs.Control value="featureFlags"
 			><i class="fa-solid fa-flag"></i> {m.featureFlags()}</Tabs.Control
 		>
-		<Tabs.Control value="integrations"
-			><i class="fa-solid fa-plug"></i> {m.integrations()}</Tabs.Control
-		>
 	{/snippet}
 	{#snippet content()}
 		<Tabs.Panel value="general">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the integrations tab from the settings page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->