### PR TITLE
fix: remove the "back to the audit" button in TPRM table mode

### DIFF
--- a/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/table-mode/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/table-mode/+page.svelte
@@ -407,7 +407,7 @@
 					>
 						<div
 							class="absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-transparent bg-linear-to-r from-transparent via-gray-500 to-transparent opacity-75"
-						></div>	
+						></div>
 						<span class="relative z-10 bg-white px-6 text-orange-600 font-semibold text-xl">
 							{getTitle(requirementAssessment)}
 						</span>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * The back navigation link in the compliance assessments table header now appears only for non–third-party users; third‑party users will no longer see the link.
* **Style**
  * Minor markup formatting adjustment in the header region with no observable change to behavior or appearance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->