### PR TITLE
fix: replace x by trash icon in legal identifiers

### DIFF
--- a/frontend/src/lib/components/Forms/LegalIdentifierField.svelte
+++ b/frontend/src/lib/components/Forms/LegalIdentifierField.svelte
@@ -167,7 +167,7 @@
 						onclick={() => removeIdentifier(type)}
 						title={m.removeIdentifier()}
 					>
-						✕
+						<i class="fa-solid fa-trash"></i>
 					</button>
 				</div>
 			</div>


### PR DESCRIPTION
Quick UX fix to make the "Remove Identifier" button more consistent and avoid misleading X icon, which looked a bit like it was an indicator to tell if the ID was valid or not.

Before: 
<img width="991" height="94" alt="image" src="https://github.com/user-attachments/assets/723b0eb6-bf71-45e3-91ed-6d69c6a9dca2" />

Now :
<img width="980" height="77" alt="image" src="https://github.com/user-attachments/assets/16b0786f-6cbf-4a8a-90b3-e9205f35beee" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the delete button icon in the legal identifier form field to a trash icon for better visual clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->