### PR TITLE
feat: ref_id  editable for attack path

### DIFF
--- a/backend/ebios_rm/models.py
+++ b/backend/ebios_rm/models.py
@@ -782,6 +782,15 @@ class AttackPath(NameDescriptionMixin, FolderMixin):
         )
         return result
 
+    @classmethod
+    def get_default_ref_id(cls, strategic_scenario):
+        attack_paths_ref_ids = list(
+            strategic_scenario.attack_paths.values_list("ref_id", flat=True)
+        )
+        nb_attack_paths = len(attack_paths_ref_ids) + 1
+        candidates = [f"AP.{i:02d}" for i in range(1, nb_attack_paths + 1)]
+        return next(x for x in candidates if x not in attack_paths_ref_ids)
+
     @property
     def form_display_name(self):
         """Returns attack path name with strategic scenario for form dropdown display"""

--- a/backend/ebios_rm/views.py
+++ b/backend/ebios_rm/views.py
@@ -660,6 +660,15 @@ class AttackPathViewSet(BaseModelViewSet):
 
     filterset_class = AttackPathFilter
 
+    def perform_create(self, serializer):
+        if not serializer.validated_data.get(
+            "ref_id"
+        ) and serializer.validated_data.get("strategic_scenario"):
+            strategic_scenario = serializer.validated_data["strategic_scenario"]
+            ref_id = AttackPath.get_default_ref_id(strategic_scenario)
+            serializer.validated_data["ref_id"] = ref_id
+        serializer.save()
+
 
 class OperationalScenarioViewSet(BaseModelViewSet):
     model = OperationalScenario

--- a/frontend/src/lib/components/Forms/ModelForm/AttackPathForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/AttackPathForm.svelte
@@ -5,6 +5,7 @@
 	import type { SuperForm } from 'sveltekit-superforms';
 	import Checkbox from '../Checkbox.svelte';
 	import TextArea from '../TextArea.svelte';
+	import TextField from '$lib/components/Forms/TextField.svelte';
 
 	interface Props {
 		form: SuperForm<any>;
@@ -44,6 +45,13 @@
 	bind:cachedValue={formDataCache['folder']}
 	label={m.folder()}
 	hidden
+/>
+<TextField
+	{form}
+	field="ref_id"
+	label={m.refId()}
+	cacheLock={cacheLocks['ref_id']}
+	bind:cachedValue={formDataCache['ref_id']}
 />
 <AutocompleteSelect
 	{form}

--- a/frontend/src/lib/utils/schemas.ts
+++ b/frontend/src/lib/utils/schemas.ts
@@ -1036,6 +1036,7 @@ export const StrategicScenarioSchema = z.object({
 
 export const AttackPathSchema = z.object({
 	...NameDescriptionMixin,
+	ref_id: z.string().optional(),
 	ebios_rm_study: z.string(),
 	strategic_scenario: z.string().uuid(),
 	stakeholders: z.string().uuid().optional().array().optional(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Attack paths now automatically generate sequential reference IDs (AP.01, AP.02, etc.) when created if not manually specified
  * Added a reference ID input field to the attack path creation form for manual entry or review

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->