### PR TITLE
feat: add CHF to supported currencies

### DIFF
--- a/frontend/src/lib/components/Forms/ModelForm/GeneralSettingForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/GeneralSettingForm.svelte
@@ -240,7 +240,8 @@
 						{ label: 'Japanese Yen (¥)', value: '¥' },
 						{ label: 'Canadian Dollar (C$)', value: 'C$' },
 						{ label: 'Australian Dollar (A$)', value: 'A$' },
-						{ label: 'New Zealand Dollar (NZ$)', value: 'NZ$' }
+						{ label: 'New Zealand Dollar (NZ$)', value: 'NZ$' },
+						{ label: 'Swiss Franc (CHF)', value: 'CHF' }
 					]}
 					label={m.currency()}
 					helpText={m.currencyHelpText()}

--- a/frontend/src/lib/utils/schemas.ts
+++ b/frontend/src/lib/utils/schemas.ts
@@ -177,7 +177,7 @@ export const AppliedControlSchema = z.object({
 	control_impact: z.number().optional().nullable(),
 	cost: z
 		.object({
-			currency: z.enum(['€', '$', '£', '¥', 'C$', 'A$', 'NZ$']).default('€'),
+			currency: z.enum(['€', '$', '£', '¥', 'C$', 'A$', 'NZ$', 'CHF']).default('€'),
 			amortization_period: z.number().min(1).max(50).default(1),
 			build: z
 				.object({
@@ -500,7 +500,7 @@ export const GeneralSettingsSchema = z.object({
 	risk_matrix_swap_axes: z.boolean().default(false).optional(),
 	risk_matrix_flip_vertical: z.boolean().default(false).optional(),
 	risk_matrix_labels: z.enum(['ISO', 'EBIOS']).default('ISO').optional(),
-	currency: z.enum(['€', '$', '£', '¥', 'C$', 'A$', 'NZ$']).default('€'),
+	currency: z.enum(['€', '$', '£', '¥', 'C$', 'A$', 'NZ$', 'CHF']).default('€'),
 	daily_rate: z.number().default(500).optional(),
 	mapping_max_depth: z.coerce.number().int().min(2).max(5).default(3).optional(),
 	allow_self_validation: z.boolean().default(false).optional()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Swiss Franc (CHF) now available as a currency option in Financial settings
  * Switching currencies triggers a conversion rate entry prompt
  * Invalid or cancelled conversion rates automatically restore the original currency and reset to default values

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->