### PR TITLE
fix: avoid clearing field when switching to preview for some markdown fields

### DIFF
--- a/frontend/src/lib/components/Forms/TableMarkdownField.svelte
+++ b/frontend/src/lib/components/Forms/TableMarkdownField.svelte
@@ -22,7 +22,6 @@
 	}
 
 	function saveChanges() {
-		value = editValue;
 		onSave(editValue);
 		isEditing = false;
 	}
@@ -87,10 +86,20 @@
 			{/if}
 		</div>
 		<div class="flex justify-end items-center">
-			<button type="button" class="btn btn-sm variant-soft" onclick={startEdit}>
-				<i class="fas fa-edit mr-1"></i>
-				Edit
-			</button>
+			<div class="flex space-x-2">
+				<button type="button" class="btn btn-sm variant-soft" onclick={startEdit}>
+					<i class="fas fa-edit mr-1"></i>
+					Edit
+				</button>
+				<button class="btn btn-sm variant-filled-success" onclick={saveChanges} type="button">
+					<i class="fa-solid fa-check mr-1"></i>
+					Save
+				</button>
+				<button class="btn btn-sm variant-filled-error" onclick={cancelEdit} type="button">
+					<i class="fa-solid fa-xmark mr-1"></i>
+					Cancel
+				</button>
+			</div>
 		</div>
 	{/if}
 </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixes Preview behavior so edits are applied before exiting edit mode, preventing lost changes.

* **UI**
  * Rearranges controls to a right-aligned group and adds a dedicated Preview button alongside Save and Cancel for a clearer, consistent editing workflow.
  * Adds Save/Cancel availability from the non-edit (preview) state so changes can be persisted without re-entering edit mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->