### PR TITLE
feat: allow changing domain for evidences and tasks while updating the children domains

### DIFF
--- a/frontend/src/lib/components/Forms/ModelForm/EvidenceForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/EvidenceForm.svelte
@@ -71,22 +71,15 @@
 		allowedExtensions={'*'}
 	/>
 {/if}
-{#if !(initialData.applied_controls || initialData.requirement_assessments)}
-	<AutocompleteSelect
-		{form}
-		optionsEndpoint="folders"
-		field="folder"
-		pathField="path"
-		cacheLock={cacheLocks['folder']}
-		bind:cachedValue={formDataCache['folder']}
-		label={m.domain()}
-		hidden={initialData.applied_controls ||
-			initialData.requirement_assessments ||
-			initialData.folder}
-	/>
-{:else}
-	<HiddenInput {form} field="folder" />
-{/if}
+<AutocompleteSelect
+	{form}
+	optionsEndpoint="folders"
+	field="folder"
+	pathField="path"
+	cacheLock={cacheLocks['folder']}
+	bind:cachedValue={formDataCache['folder']}
+	label={m.domain()}
+/>
 {#if context !== 'edit'}
 	<TextField
 		{form}

--- a/frontend/src/lib/components/Forms/ModelForm/TaskTemplateForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/TaskTemplateForm.svelte
@@ -56,7 +56,6 @@
 	cacheLock={cacheLocks['folder']}
 	bind:cachedValue={formDataCache['folder']}
 	label={m.domain()}
-	hidden={initialData.folder}
 />
 {#if !$is_recurrent}
 	<TextField


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Folder field is now consistently visible in evidence and task template forms, regardless of record type.
  * Folder changes are now automatically synchronized across all related records, ensuring data consistency throughout your workspace.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->