### PR TITLE
fix: prevent deleting an audit unrelated to the entity assessment enclave

### DIFF
--- a/backend/tprm/views.py
+++ b/backend/tprm/views.py
@@ -715,7 +715,7 @@ class EntityAssessmentViewSet(BaseModelViewSet):
             else:
                 logger.warning(
                     "Compliance assessment folder is not an Enclave, skipping deletion",
-                    folder,
+                    folder=folder,
                 )
 
         return super().destroy(request, *args, **kwargs)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where compliance assessments were being incorrectly deleted when removing entity assessment entries.

* **General**
  * Enhanced logging messages for non-Enclave compliance assessment folders with more explicit details for better visibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->