### PR TITLE
fix: use safe_display for audits comparison to have a fallback

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -8358,12 +8358,15 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
             score_different = base_ra.score != compare_ra.score
 
             if result_different or score_different:
+                # Use safe_display_str for smart fallback: name → ref_id → description → URN
+                req_name = base_ra.requirement.safe_display_str
+
                 differences.append(
                     {
                         "requirement": {
                             "id": str(base_ra.requirement.id),
                             "ref_id": base_ra.requirement.ref_id,
-                            "name": base_ra.requirement.name,
+                            "name": req_name,
                             "description": base_ra.requirement.description,
                         },
                         "base": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced requirement name display in assessment comparison outputs with a safe, multi-level fallback mechanism. Requirement names and identifiers now display more reliably in diff operations, with automatic fallback options ensuring consistent and meaningful display across all scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->