### PR TITLE
fix: regression on tableMarkdown persistence

### DIFF
--- a/frontend/src/lib/components/Forms/TableMarkdownField.svelte
+++ b/frontend/src/lib/components/Forms/TableMarkdownField.svelte
@@ -14,7 +14,7 @@
 	}: Props = $props();
 
 	let isEditing = $state(false);
-	let editValue = $state('');
+	let editValue = $state(value ?? '');
 
 	function startEdit() {
 		editValue = value;
@@ -28,11 +28,11 @@
 	}
 
 	function cancelEdit() {
+		editValue = value;
 		isEditing = false;
 	}
 
 	function preview() {
-		value = editValue;
 		isEditing = false;
 	}
 </script>
@@ -79,8 +79,8 @@
 				}
 			}}
 		>
-			{#if value}
-				<MarkdownRenderer content={value} />
+			{#if editValue}
+				<MarkdownRenderer content={editValue} />
 			{:else}
 				<p class="text-gray-500 italic">{placeholder}</p>
 			{/if}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved edit-mode behavior for markdown form fields: draft text now initializes to an empty placeholder when absent, editing opens after the draft is prepared, saving updates the main value before triggering save, and preview/edit toggle reliably shows the draft (or placeholder) without prematurely mutating the saved value.
  
<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->