### PR TITLE
fix: error on requirement assessment when the audit is locked

### DIFF
--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/+page.svelte
@@ -93,7 +93,7 @@
 		>
 			{safeTranslate(data.requirementAssessment.result)}
 		</span>
-		{#if data.requirement.implementation_groups.length > 0}
+		{#if data.requirement.implementation_groups?.length > 0}
 			<div class="ml-3">
 				<b class="mr-2">Implemetation Groups :</b>
 				{#each data.requirement.implementation_groups as ig}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the requirement assessments page could encounter an error when implementation groups were unavailable, improving overall stability and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->