### PR TITLE
fix: incidents md export issue when threats are attached

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -10456,12 +10456,10 @@ class IncidentViewSet(ExportMixin, BaseModelViewSet):
         # Related Threats
         if incident.threats.exists():
             md_content += "## Related Threats\n\n"
-            md_content += "| Name | Type |\n"
+            md_content += "| Name | Reference ID |\n"
             md_content += "|------|------|\n"
             for threat in incident.threats.all():
-                md_content += (
-                    f"| {threat.name} | {threat.get_category_display() or 'N/A'} |\n"
-                )
+                md_content += f"| {threat.name} | {threat.ref_id or 'N/A'} |\n"
             md_content += "\n"
 
         # Timeline


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Related Threats section in incident details now displays Reference ID instead of threat type, with 'N/A' shown when unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->