### PR TITLE
fix: align pro/community settings

### DIFF
--- a/backend/ciso_assistant/settings.py
+++ b/backend/ciso_assistant/settings.py
@@ -62,11 +62,6 @@ LOGGING = {
     },
     "loggers": {
         "": {"handlers": ["console"], "level": LOG_LEVEL},
-        "django.server": {
-            "handlers": [],
-            "level": "WARNING",
-            "propagate": False,
-        },
     },
 }
 

--- a/enterprise/backend/enterprise_core/settings.py
+++ b/enterprise/backend/enterprise_core/settings.py
@@ -31,6 +31,7 @@ LOG_FORMAT = os.environ.get("LOG_FORMAT", "plain")
 LOG_OUTFILE = os.environ.get("LOG_OUTFILE", "")
 
 CISO_ASSISTANT_URL = os.environ.get("CISO_ASSISTANT_URL", "http://localhost:5173")
+FORCE_CREATE_ADMIN = os.environ.get("FORCE_CREATE_ADMIN", "False").lower() == "true"
 
 
 def set_ciso_assistant_url(_, __, event_dict):
@@ -70,7 +71,6 @@ if LOG_OUTFILE:
         "formatter": "json",
     }
     LOGGING["loggers"][""]["handlers"].append("file")
-
 
 structlog.configure(
     processors=[
@@ -238,7 +238,10 @@ AUTH_TOKEN_AUTO_REFRESH_MAX_TTL = (
 )  # absolute timeout for auto-refresh, defaults to 10 hours. token expires after this time even if the user is active.
 
 CISO_ASSISTANT_SUPERUSER_EMAIL = os.environ.get("CISO_ASSISTANT_SUPERUSER_EMAIL")
+logger.info("CISO_ASSISTANT_SUPERUSER_EMAIL: %s", CISO_ASSISTANT_SUPERUSER_EMAIL)
+logger.info("FORCE_CREATE_ADMIN: %s", FORCE_CREATE_ADMIN)
 DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL")
+logger.info("DEFAULT_FROM_EMAIL: %s", DEFAULT_FROM_EMAIL)
 
 EMAIL_HOST = os.environ.get("EMAIL_HOST")
 EMAIL_PORT = os.environ.get("EMAIL_PORT")
@@ -510,10 +513,12 @@ HUEY_FILE_PATH = os.environ.get("HUEY_FILE_PATH", BASE_DIR / "db" / "huey.db")
 HUEY = {
     "huey_class": "huey.SqliteHuey",
     "name": "ciso_assistant",
+    "utc": True,
     "filename": HUEY_FILE_PATH,
     "results": True,  # would be interesting for debug
     "immediate": False,  # set to False to run in "live" mode regardless of DEBUG, otherwise it will follow
 }
+
 AUDITLOG_RETENTION_DAYS = int(os.environ.get("AUDITLOG_RETENTION_DAYS", 90))
 AUDITLOG_MAX_RECORDS = int(os.environ.get("AUDITLOG_MAX_RECORDS", 50000))
 


### PR DESCRIPTION
- align pro settings on community settings, to enable FORCE_CREATE_ADMIN
- fix log config for community (but keep level WARNING)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated logging configuration and removed deprecated logger entries.
  * Added configurable audit log retention settings (retention days and maximum records).
  * Introduced new admin creation configuration flag for deployment scenarios.
  * Enabled UTC-based timestamp support for scheduled task processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->