### PR TITLE
fix: asset security capability not disabled in security objectives comparison

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -3064,6 +3064,8 @@ class Asset(
                 continue
 
             c = sc_obj.get(key) or {}
+            if not c.get("is_enabled", False):
+                continue
             real_value = c.get("value", None) if isinstance(c, dict) else None
 
             verdict = None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed security objectives comparison to properly exclude disabled objectives from evaluation and verdicts. Disabled security objectives are now correctly ignored during comparison operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->