### PR TITLE
fix: cascade deletion of attachment with evidence

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -3762,6 +3762,13 @@ class Evidence(
         super().save(*args, **kwargs)
         self.revisions.update(is_published=self.is_published)
 
+    def delete(self, using=None, keep_parents=False):
+        for rev in self.revisions.all():
+            if rev.attachment:
+                rev.attachment.delete(save=False)
+
+        return super().delete(using=using, keep_parents=keep_parents)
+
     @property
     def last_revision(self):
         return self.revisions.order_by("-version").first() or None
@@ -3849,6 +3856,12 @@ class EvidenceRevision(AbstractBaseModel, FolderMixin):
         self.is_published = self.evidence.is_published
 
         super().save(*args, **kwargs)
+
+    def delete(self, using=None, keep_parents=False):
+        if self.attachment:
+            self.attachment.delete(save=False)
+
+        return super().delete(using=using, keep_parents=keep_parents)
 
     def filename(self):
         return os.path.basename(self.attachment.name)


### PR DESCRIPTION
**Ciso Assistant have this following issue:**

If we create an evidence, create a revision containing an attachment. We have normally 3 cases:

- Erasing the entire evidence deleting all evidenceRevisions and their attachments
- Erasing the entire Revision and the attachment linked to it
- Only Erasing the attachment in the detail view revision.

With this 3 cases, only one works now which is the last one. The other ones have an issue: not deleting the attachment when deleting the evidence / evidenceRevision object.

The last one is working because it uses backend function delete_attachment and the others are only erasing their object. (Django does NOT delete FileField files when a model instance is deleted)

 Fixed by changing the delete function by first deleting all attachments contained by the models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of attachments when evidence items are deleted. Associated attachments are now properly removed from the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->