### PR TITLE
fix: modeltable tabs not flex in generic collections

### DIFF
--- a/frontend/src/routes/(app)/(internal)/generic-collections/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/generic-collections/[id=uuid]/+page.svelte
@@ -125,7 +125,7 @@
 			onValueChange={(e) => {
 				group = e.value;
 			}}
-			listJustify="justify-center"
+			listJustify="justify-center flex flex-wrap gap-2"
 		>
 			{#snippet list()}
 				{#each Object.entries(data.relatedModels).sort( ([a], [b]) => a.localeCompare(b) ) as [urlmodel, model]}


### PR DESCRIPTION
Fix a little UI problem about not flex modeltable tabs list 
<img width="2360" height="306" alt="image" src="https://github.com/user-attachments/assets/386530e5-5de5-4dbc-a5ca-b67f2afee775" />

into this 

<img width="2244" height="328" alt="image" src="https://github.com/user-attachments/assets/2d881262-3cc9-4957-b4c8-7fc0c59214ab" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved tab layout in the related models section with better spacing and wrapping of tab controls for enhanced readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->