### PR TITLE
fix: typo in fr translation

### DIFF
--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -2239,7 +2239,7 @@
 	"displayAle": "Perte annuelle attendue",
 	"errorCreatingPersonalAccessToken": "Une erreur s'est produite lors de la création du jeton d'accès personnel.",
 	"errorMaxPatAmountExceeded": "Nombre maximum de jetons autorisés dépassé pour cet utilisateur.",
-	"evidencesHelpText": "Ce tableau montre toutes les preuves associées à cette évaluation de conformité, soit directement par les évaluations d'exigences, soit indirectement par les mesures appliqués.",
+	"evidencesHelpText": "Ce tableau montre toutes les preuves associées à cette évaluation de conformité, soit directement par les évaluations d'exigences, soit indirectement par les mesures appliquées.",
 	"featureFlagSettingsUpdated": "Paramètres des indicateurs de fonctionnalités mis à jour. Veuillez actualiser la page pour appliquer les modifications.",
 	"featureFlags": "Gestion des fonctionnalités",
 	"fileAcceptExcelOnly": "Fichiers Excel uniquement (.xls, .xlsx)",


### PR DESCRIPTION
appliqués -> appliquées

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected French grammar in help text for applied measures, ensuring proper grammatical agreement in the translation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->