### PR TITLE
fix: change processing.foreignKeys.owner.urlModel from users to entities

### DIFF
--- a/frontend/src/lib/utils/crud.ts
+++ b/frontend/src/lib/utils/crud.ts
@@ -1101,7 +1101,7 @@ export const URL_MODEL_MAP: ModelMap = {
 		selectFields: [{ field: 'status' }, { field: 'nature' }],
 		foreignKeyFields: [
 			{ field: 'folder', urlModel: 'folders', urlParams: 'content_type=DO&content_type=GL' },
-			{ field: 'owner', urlModel: 'users' },
+			{ field: 'owner', urlModel: 'entities' },
 			{ field: 'purposes', urlModel: 'purposes' },
 			{ field: 'assigned_to', urlModel: 'users', urlParams: 'is_third_party=false' },
 			{ field: 'filtering_labels', urlModel: 'filtering-labels' }


### PR DESCRIPTION
In `privacy.models`, `Processing.owner` is a foreign key to an `Entity`,
not a user.
This fixes a bug where the link to the owner points to /users/<id>
instead of /entities/<id>.
NOTE: We do not display the processing's owner in the UI at the time,
this fix just avoids the footgun.
