### PR TITLE
fix: teams page in enterprise sidebar

### DIFF
--- a/enterprise/frontend/src/lib/components/SideBar/navData.ts
+++ b/enterprise/frontend/src/lib/components/SideBar/navData.ts
@@ -113,6 +113,11 @@ export const navData = {
 					href: '/users'
 				},
 				{
+					name: 'teams',
+					fa_icon: 'fa-solid fa-people-group',
+					href: '/teams'
+				},
+				{
 					name: 'userGroups',
 					fa_icon: 'fa-solid fa-users',
 					href: '/user-groups'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Teams navigation item to the sidebar menu, providing quick access to team management features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->