### PR TITLE
fix(lib): CIS Controls v8 "reference_control_base_urn" Field

### DIFF
--- a/tools/excel/cis/prep_cis.py
+++ b/tools/excel/cis/prep_cis.py
@@ -99,7 +99,7 @@ ws.append(["framework_urn", f"urn:{packager.lower()}:risk:framework:cis-controls
 ws.append(["framework_ref_id", "CIS-Controls-v8"])
 ws.append(["framework_name", "CIS Controls v8"])
 ws.append(["framework_description", "CIS Controls v8"])
-ws.append(["reference_control_base_urn", "urn:intuitem:risk:function:cis-controls-v8", "1"])
+ws.append(["reference_control_base_urn", f"urn:{packager.lower()}:risk:function:cis-controls-v8", "1"])
 ws.append(["tab", "controls", "requirements"])
 ws.append(["tab", "imp_grp", "implementation_groups"])
 ws.append(["tab", "ref_ctrl", "reference_controls"])


### PR DESCRIPTION
# Changes

Replaced the packager name `intuitem` with the actual name of the framework packager in the `reference_control_base_urn` field to ensure consistency with the rest of the framework.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Control base URN generation now adapts to the configured packager instead of using a fixed reference.
  * Source and target node base URNs are derived dynamically from available framework data rather than constructed statically.

* **Bug Fix**
  * Added validation to ensure frameworks contain requirement nodes; a clear error is raised when nodes are missing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->