### PR TITLE
fix(tool): Compute Correct Source & Target Requirement Node Base URNs

### DIFF
--- a/tools/prepare_mapping_v2.py
+++ b/tools/prepare_mapping_v2.py
@@ -49,7 +49,7 @@ def load_and_validate_yaml(path, label):
 
 
 
-def common_urn_base(req_nodes: List[Dict], *, name: str) -> str:
+def compute_base_urn(req_nodes: List[Dict], *, name: str) -> str:
     
     # Ensure the requirement nodes list exists and is not empty
     if not req_nodes:
@@ -128,8 +128,8 @@ def generate_mapping_excel(source_yaml, target_yaml):
     target_req_nodes = target_framework.get("requirement_nodes")
 
     # Compute the base URN (common prefix) for each framework
-    source_node_base_urn = common_urn_base(source_req_nodes, name="Source framework")
-    target_node_base_urn = common_urn_base(target_req_nodes, name="Target framework")
+    source_node_base_urn = compute_base_urn(source_req_nodes, name="Source framework")
+    target_node_base_urn = compute_base_urn(target_req_nodes, name="Target framework")
     
 
     # --- Create a new workbook and remove default sheet ---


### PR DESCRIPTION
# Changes
Fixed an issue in `prepare_mapping_v2.py` that computed an incorrect `node_base_urn` source and/or target when the packager name wasn't equal to `intuitem`. 

The script was inserting the full URN of a node into the Excel table instead of removing the base URN from the URN.

# Update

The base URN computing system has been modified to take all required node URNs into account for the calculation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Mapping export now derives base URNs dynamically from framework data instead of using static constructions, updating how mapping IDs and sheet entries are generated.
* **Bug Fix**
  * Added validation and explicit warnings for missing or inconsistent framework URNs to surface issues without halting export.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->