### PR TITLE
fix: filter out unrelated representatives in entity assessment create form

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -5558,6 +5558,7 @@ class UserFilter(GenericFilterSet):
             "expiry_date",
             "user_groups",
             "exclude_current",
+            "representative__entity",
         ]
 
 

--- a/frontend/src/lib/components/Forms/ModelForm/EntityAssessmentForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/EntityAssessmentForm.svelte
@@ -124,17 +124,25 @@
 	cacheLock={cacheLocks['due_date']}
 	bind:cachedValue={formDataCache['due_date']}
 />
-<AutocompleteSelect
-	{form}
-	multiple
-	optionsEndpoint="users?is_third_party=true"
-	optionsLabelField="email"
-	field="representatives"
-	helpText={m.entityAssessmentRepresentativesHelpText()}
-	cacheLock={cacheLocks['representatives']}
-	bind:cachedValue={formDataCache['representatives']}
-	label={m.representatives()}
-/>
+{#if $formStore?.entity}
+	{#key $formStore?.entity}
+		<AutocompleteSelect
+			{form}
+			multiple
+			optionsEndpoint="users"
+			optionsDetailedUrlParameters={[
+				['is_third_party', 'true'],
+				['representative__entity', $formStore?.entity || '']
+			]}
+			optionsLabelField="email"
+			field="representatives"
+			helpText={m.entityAssessmentRepresentativesHelpText()}
+			cacheLock={cacheLocks['representatives']}
+			bind:cachedValue={formDataCache['representatives']}
+			label={m.representatives()}
+		/>
+	{/key}
+{/if}
 <Select
 	{form}
 	options={model.selectOptions['conclusion']}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Representatives field in forms now displays conditionally, appearing only when relevant to the current selection
  * API filtering capabilities expanded to enable more granular search options when selecting representatives, ensuring accurate results based on organizational context

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->