### PR TITLE
feat(tool): CIS Controls v8 to NIST CSF 2.0 & ISO27001:2022 Mapping Tools

### DIFF
--- a/tools/excel/cis/README.md
+++ b/tools/excel/cis/README.md
@@ -1,6 +1,81 @@
+# > `convert_cis.sh (Linux / Mac) / convert_cis.bat (Windows)`
+
 This script prepares the file to be parsed by the converter:
 
 - Copy the downloaded Excel file from the [CIS website](https://www.cisecurity.org/controls) next to this script (for instance `CIS_Controls_Version_8.xlsx`)
 - Run `pip install -r requirements.txt`
 - Run the preparation script by passing the filename as 1st argument and your name/entity as a second one for the packager (e.g. `./convert_cis.sh ./cis_v8.xlsx intuitem`). Use `convert_cis.bat` if you're on Windows, or `convert_cis.sh` if you're on Linux/Mac.
 - Use the resulting YAML in CISO Assistant
+
+# > `prep_mapping_cis_controls_csf_2.0.py`
+
+
+This script generates a structured mapping between **CIS Controls v8** and **NIST Cybersecurity Framework (CSF) 2.0**.
+
+It performs two steps:
+1. **Create an Excel mapping file** with three sheets:
+   - `library_meta`
+   - `mappings_meta`
+   - `mappings_content` (source_node_id | target_node_id | relationship)
+2. **Convert the Excel mapping into a YAML library** using the existing conversion tooling.
+
+
+## Prerequisites
+
+Before running this script, ensure that:
+
+- The official **CIS Controls v8 mapping Excel file** (downloaded from the [CIS website](https://www.cisecurity.org/)) is copied **next to this script** or that its path is correctly referenced when running the command.
+- All required Python dependencies are installed by running:
+
+  ```bash
+  pip install -r requirements.txt
+  ```
+
+## Usage
+
+```bash
+python prep_mapping_cis_controls_csf_2.0.py <input_excel_file> <packager_name>
+```
+
+- **`<input_excel_file>`**  
+  Path to the official CIS Controls v8 mapping Excel file used as input.  
+  This file contains the raw mapping data between CIS Controls and the target framework.
+
+- **`<packager_name>`**  
+  Identifier of the packager used in your **CIS Controls v8 framework YAML**.  
+  ⚠️ This value **must be strictly identical** to the one defined in the CIS v8 YAML file (around line ~20), for example:
+
+  ```yaml
+  packager: <packager_name>
+  ```
+
+   Using the same packager name guarantees URN consistency between the CIS framework and the generated mapping libraries.
+
+
+---
+
+# > `prep_mapping_cis_controls_iso_27.py`
+
+This script generates a mapping between **CIS Controls v8** and **ISO/IEC 27001:2022**.
+
+The **overall behavior is strictly identical** to the CSF version.
+
+## Usage
+
+```bash
+python prep_mapping_cis_controls_iso_27.py <input_excel_file> <packager_name>
+```
+
+- **`<input_excel_file>`**  
+  Path to the official CIS Controls v8 mapping Excel file used as input.  
+  This file contains the raw mapping data between CIS Controls and the target framework.
+
+- **`<packager_name>`**  
+  Identifier of the packager used in your **CIS Controls v8 framework YAML**.  
+  ⚠️ This value **must be strictly identical** to the one defined in the CIS v8 YAML file (around line ~20), for example:
+
+  ```yaml
+  packager: <packager_name>
+  ```
+
+  Using the same packager name guarantees URN consistency between the CIS framework and the generated mapping libraries.

--- a/tools/excel/cis/README.md
+++ b/tools/excel/cis/README.md
@@ -31,6 +31,7 @@ Before running this script, ensure that:
   pip install -r requirements.txt
   ```
 
+
 ## Usage
 
 ```bash
@@ -58,7 +59,20 @@ python prep_mapping_cis_controls_csf_2.0.py <input_excel_file> <packager_name>
 
 This script generates a mapping between **CIS Controls v8** and **ISO/IEC 27001:2022**.
 
-The **overall behavior is strictly identical** to the CSF version.
+The **overall behavior is strictly identical** to the CSF version..
+
+
+## Prerequisites
+
+Before running this script, ensure that:
+
+- The official **CIS Controls v8 mapping Excel file** (downloaded from the [CIS website](https://www.cisecurity.org/)) is copied **next to this script** or that its path is correctly referenced when running the command.
+- All required Python dependencies are installed by running:
+
+  ```bash
+  pip install -r requirements.txt
+  ```
+
 
 ## Usage
 

--- a/tools/excel/cis/README.md
+++ b/tools/excel/cis/README.md
@@ -53,6 +53,13 @@ python prep_mapping_cis_controls_csf_2.0.py <input_excel_file> <packager_name>
    Using the same packager name guarantees URN consistency between the CIS framework and the generated mapping libraries.
 
 
+## Example
+
+```bash
+python prep_mapping_cis_controls_csf_2.0.py CIS_Controls_v8_Mapping_to_CSF_2.0.xlsx intuitem
+```
+
+
 ---
 
 # > `prep_mapping_cis_controls_iso_27.py`
@@ -93,3 +100,10 @@ python prep_mapping_cis_controls_iso_27.py <input_excel_file> <packager_name>
   ```
 
   Using the same packager name guarantees URN consistency between the CIS framework and the generated mapping libraries.
+
+
+## Example
+
+```bash
+python prep_mapping_cis_controls_iso_27.py CIS_Controls_v8_NEW_MAPPING_to_ISO.IEC_27001.2022_2_2023.xlsx intuitem
+```

--- a/tools/excel/cis/prep_mapping_cis_controls_csf_2.0.py
+++ b/tools/excel/cis/prep_mapping_cis_controls_csf_2.0.py
@@ -5,6 +5,8 @@ Creates an output Excel with:
 1) library_meta
 2) mappings_meta
 3) mappings_content (source_node_id|target_node_id|relationship)
+
+Then converts the Excel mapping into YAML (Step 2).
 """
 
 import sys
@@ -80,9 +82,9 @@ def extract_mappings_content(input_file: str) -> pd.DataFrame:
 
     mapping_data = []
     for _, row in df.iterrows():
-        source_node_id = row.iloc[2]   # Column C (index 2)
-        target_node_id = row.iloc[11]  # Column L (index 11)
-        relationship = row.iloc[10]    # Column K (index 10)
+        source_node_id = row.iloc[2]    # Column C (index 2)
+        target_node_id = row.iloc[11]   # Column L (index 11)
+        relationship = row.iloc[10]     # Column K (index 10)
 
         if pd.isna(source_node_id) or pd.isna(target_node_id) or pd.isna(relationship):
             continue
@@ -115,7 +117,7 @@ def process_mapping(input_file: str, packager_name: str, output_file: str = None
     if output_file is None:
         output_file = DEFAULT_OUTPUT_FILENAME_EXCEL
 
-    # Write sheets in the required order:
+    # Sheet order:
     # 1) library_meta
     # 2) mappings_meta
     # 3) mappings_content
@@ -141,10 +143,10 @@ def main():
     )
 
     args = parser.parse_args()
-    
+
     output_excel_file = DEFAULT_OUTPUT_FILENAME_EXCEL
-    
-    # Determine output file path (add .yaml if missing)
+
+    # Output YAML: same stem as Excel + .yaml
     output_path = Path(Path(DEFAULT_OUTPUT_FILENAME_EXCEL).stem + ".yaml")
 
 
@@ -154,7 +156,7 @@ def main():
         print("###########################################\n")
 
         process_mapping(args.input_excel_file, args.packager_name_CIS, output_excel_file)
-        
+
         print("\n##########################################")
         print("##### [STEP 2] Creating YAML Mapping #####")
         print("##########################################\n")

--- a/tools/excel/cis/prep_mapping_cis_controls_csf_2.0.py
+++ b/tools/excel/cis/prep_mapping_cis_controls_csf_2.0.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""
+Script to extract CIS Controls to CSF 2.0 mapping from Excel file.
+Reads the mapping data and creates a simplified output with source_node_id, target_node_id, and relationship.
+"""
+
+import sys
+import re
+import pandas as pd
+from pathlib import Path
+
+
+def format_target_node_id(node_id: str) -> str:
+    """
+    Format target node ID to put them in lowercase
+    """
+
+    return node_id.lower()
+
+
+def process_mapping(input_file: str, output_file: str = None):
+    """
+    Process CIS Controls to CSF 2.0 mapping Excel file.
+
+    Args:
+        input_file: Path to input Excel file
+        output_file: Path to output Excel file (optional, defaults to input_file with _mapping suffix)
+    """
+    # Read the Excel file - using the 5th sheet (index 4) which is "All CIS Controls & Safeguards"
+    df = pd.read_excel(input_file, sheet_name=3)
+
+    # Extract relevant columns
+    # Column C = CIS Safeguard (source_node_id)
+    # Column L = Control # (target_node_id)
+    # Column K = Relationship
+    mapping_data = []
+
+    for _, row in df.iterrows():
+        source_node_id = row.iloc[2]  # Column C (index 2)
+        target_node_id = row.iloc[11]  # Column L (index 11)
+        relationship = row.iloc[10]  # Column K (index 10)
+
+        # Skip rows with missing data
+        if pd.isna(source_node_id) or pd.isna(target_node_id) or pd.isna(relationship):
+            continue
+
+        # Convert to string and lowercase
+        source_node_id = str(source_node_id).strip().lower()
+        target_node_id = str(target_node_id).strip().lower()
+        relationship = str(relationship).strip().lower()
+
+        # Format target_node_id to put it  in lowercase
+        target_node_id = format_target_node_id(target_node_id)
+
+        # Replace "equivalent" with "equal"
+        if relationship == "equivalent":
+            relationship = "equal"
+
+        mapping_data.append(
+            {
+                "source_node_id": source_node_id,
+                "target_node_id": target_node_id,
+                "relationship": relationship,
+            }
+        )
+
+    # Create output DataFrame
+    output_df = pd.DataFrame(mapping_data)
+
+    # Determine output file name
+    if output_file is None:
+        input_path = Path(input_file)
+        output_file = input_path.parent / f"{input_path.stem}_mapping.xlsx"
+
+    # Write to Excel
+    output_df.to_excel(output_file, index=False, sheet_name="Mapping")
+
+    print(f"Processed {len(output_df)} mappings")
+    print(f"Output written to: {output_file}")
+
+    return output_df
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(
+            f"Usage: python {sys.argv[0]} <input_excel_file> [output_excel_file]"
+        )
+        print("\nExample:")
+        print(
+            f"  python {sys.argv[0]} CIS_Controls_v8_Mapping_to_CSF_2.0.xlsx"
+        )
+        sys.exit(1)
+
+    input_file = sys.argv[1]
+    output_file = sys.argv[2] if len(sys.argv) > 2 else None
+
+    try:
+        process_mapping(input_file, output_file)
+    except Exception as e:
+        print(f"Error processing file: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/excel/cis/prep_mapping_cis_controls_csf_2.0.py
+++ b/tools/excel/cis/prep_mapping_cis_controls_csf_2.0.py
@@ -26,7 +26,7 @@ def process_mapping(input_file: str, output_file: str = None):
         input_file: Path to input Excel file
         output_file: Path to output Excel file (optional, defaults to input_file with _mapping suffix)
     """
-    # Read the Excel file - using the 5th sheet (index 4) which is "All CIS Controls & Safeguards"
+    # Read the Excel file - using the 4th sheet (index 3) which is "All CIS Controls & Safeguards"
     df = pd.read_excel(input_file, sheet_name=3)
 
     # Extract relevant columns

--- a/tools/excel/cis/prep_mapping_cis_controls_csf_2.0.py
+++ b/tools/excel/cis/prep_mapping_cis_controls_csf_2.0.py
@@ -1,58 +1,98 @@
-#!/usr/bin/env python3
 """
 Script to extract CIS Controls to CSF 2.0 mapping from Excel file.
-Reads the mapping data and creates a simplified output with source_node_id, target_node_id, and relationship.
+
+Creates an output Excel with:
+1) library_meta
+2) mappings_meta
+3) mappings_content (source_node_id|target_node_id|relationship)
 """
 
 import sys
-import re
+import argparse
 import pandas as pd
 from pathlib import Path
 
 
-def format_target_node_id(node_id: str) -> str:
-    """
-    Format target node ID to put them in lowercase
-    """
+# Import helper to create base Excel file from YAML (Step 2)
+parent_dir = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(parent_dir))
 
+# Import Excel to YAML Converter (Step 3)
+from convert_library_v2 import create_library as convert_excel_to_yaml
+
+
+DEFAULT_OUTPUT_FILENAME_EXCEL = "mapping-cis-controls-v8-and-nist-csf-2.0.xlsx"
+
+
+def format_target_node_id(node_id: str) -> str:
+    """Format target node ID to lowercase."""
     return node_id.lower()
 
 
-def process_mapping(input_file: str, output_file: str = None):
-    """
-    Process CIS Controls to CSF 2.0 mapping Excel file.
+def build_library_meta(packager_name: str) -> pd.DataFrame:
+    rows = [
+        ("type", "library"),
+        ("urn", f"urn:{packager_name}:risk:library:mapping-cis-controls-v8-and-nist-csf-2.0"),
+        ("version", "1"),
+        ("locale", "en"),
+        ("ref_id", "mapping-cis-controls-v8-and-nist-csf-2.0"),
+        ("name", "CIS-Controls-v8 <-> NIST-CSF-2.0"),
+        ("description", "Mapping between CIS Controls v8 and NIST CSF v2.0"),
+        (
+            "copyright",
+            "This work is licensed under a Creative Commons Attribution-NonCommercial-No Derivatives 4.0 International Public License "
+            "(the link can be found at https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode). To further clarify the Creative Commons "
+            "license related to the CIS Controls® content, you are authorized to copy and redistribute the content as a framework for use by you, "
+            "within your organization and outside of your organization for non-commercial purposes only, provided that (i) appropriate credit is given "
+            "to CIS, and (ii) a link to the license is provided. Additionally, if you remix, transform or build upon the CIS Controls, you may not distribute "
+            "the modified materials. Users of the CIS Controls framework are also required to refer to (http://www.cisecurity.org/controls/) when referring "
+            "to the CIS Controls in order to ensure that users are employing the most up-to-date guidance. Commercial use of the CIS Controls is subject to "
+            "the prior approval of CIS® (Center for Internet Security, Inc.).",
+        ),
+        ("provider", "CIS"),
+        ("packager", packager_name),
+        (
+            "dependencies",
+            f"urn:{packager_name}:risk:library:cis-controls-v8, urn:intuitem:risk:library:nist-csf-2.0",
+        ),
+    ]
+    return pd.DataFrame(rows)
 
-    Args:
-        input_file: Path to input Excel file
-        output_file: Path to output Excel file (optional, defaults to input_file with _mapping suffix)
-    """
+
+def build_mappings_meta(packager_name: str) -> pd.DataFrame:
+    rows = [
+        ("type", "requirement_mapping_set"),
+        ("urn", f"urn:{packager_name}:risk:req_mapping_set:mapping-cis-controls-v8-and-nist-csf-2.0"),
+        ("ref_id", "mapping-cis-controls-v8-and-nist-csf-2.0"),
+        ("name", "CIS-Controls-v8 <-> NIST-CSF-2.0"),
+        ("description", "Mapping between CIS Controls v8 and NIST CSF v2.0"),
+        ("source_framework_urn", f"urn:{packager_name}:risk:framework:cis-controls-v8"),
+        ("target_framework_urn", "urn:intuitem:risk:framework:nist-csf-2.0"),
+        ("source_node_base_urn", f"urn:{packager_name}:risk:req_node:cis-controls-v8"),
+        ("target_node_base_urn", "urn:intuitem:risk:req_node:nist-csf-2.0"),
+    ]
+    return pd.DataFrame(rows)
+
+
+def extract_mappings_content(input_file: str) -> pd.DataFrame:
     # Read the Excel file - using the 4th sheet (index 3) which is "All CIS Controls & Safeguards"
     df = pd.read_excel(input_file, sheet_name=3)
 
-    # Extract relevant columns
-    # Column C = CIS Safeguard (source_node_id)
-    # Column L = Control # (target_node_id)
-    # Column K = Relationship
     mapping_data = []
-
     for _, row in df.iterrows():
-        source_node_id = row.iloc[2]  # Column C (index 2)
+        source_node_id = row.iloc[2]   # Column C (index 2)
         target_node_id = row.iloc[11]  # Column L (index 11)
-        relationship = row.iloc[10]  # Column K (index 10)
+        relationship = row.iloc[10]    # Column K (index 10)
 
-        # Skip rows with missing data
         if pd.isna(source_node_id) or pd.isna(target_node_id) or pd.isna(relationship):
             continue
 
-        # Convert to string and lowercase
         source_node_id = str(source_node_id).strip().lower()
         target_node_id = str(target_node_id).strip().lower()
         relationship = str(relationship).strip().lower()
 
-        # Format target_node_id to put it  in lowercase
         target_node_id = format_target_node_id(target_node_id)
 
-        # Replace "equivalent" with "equal"
         if relationship == "equivalent":
             relationship = "equal"
 
@@ -64,41 +104,65 @@ def process_mapping(input_file: str, output_file: str = None):
             }
         )
 
-    # Create output DataFrame
-    output_df = pd.DataFrame(mapping_data)
+    return pd.DataFrame(mapping_data)
 
-    # Determine output file name
+
+def process_mapping(input_file: str, packager_name: str, output_file: str = None) -> pd.DataFrame:
+    mapping_df = extract_mappings_content(input_file)
+    library_meta_df = build_library_meta(packager_name)
+    mappings_meta_df = build_mappings_meta(packager_name)
+
     if output_file is None:
-        input_path = Path(input_file)
-        output_file = input_path.parent / f"{input_path.stem}_mapping.xlsx"
+        output_file = DEFAULT_OUTPUT_FILENAME_EXCEL
 
-    # Write to Excel
-    output_df.to_excel(output_file, index=False, sheet_name="Mapping")
+    # Write sheets in the required order:
+    # 1) library_meta
+    # 2) mappings_meta
+    # 3) mappings_content
+    with pd.ExcelWriter(output_file, engine="openpyxl") as writer:
+        library_meta_df.to_excel(writer, index=False, header=False, sheet_name="library_meta")
+        mappings_meta_df.to_excel(writer, index=False, header=False, sheet_name="mappings_meta")
+        mapping_df.to_excel(writer, index=False, sheet_name="mappings_content")
 
-    print(f"Processed {len(output_df)} mappings")
+    print(f"Processed {len(mapping_df)} mappings")
     print(f"Output written to: {output_file}")
 
-    return output_df
+    return mapping_df
 
 
 def main():
-    if len(sys.argv) < 2:
-        print(
-            f"Usage: python {sys.argv[0]} <input_excel_file> [output_excel_file]"
-        )
-        print("\nExample:")
-        print(
-            f"  python {sys.argv[0]} CIS_Controls_v8_Mapping_to_CSF_2.0.xlsx"
-        )
-        sys.exit(1)
+    parser = argparse.ArgumentParser(
+        description="Extract CIS Controls v8 to NIST CSF 2.0 mapping and generate a formatted Excel output."
+    )
+    parser.add_argument("input_excel_file", help="Path to input Excel mapping file")
+    parser.add_argument(
+        "packager_name_CIS",
+        help="Packager name used in your CIS v8 Framework",
+    )
 
-    input_file = sys.argv[1]
-    output_file = sys.argv[2] if len(sys.argv) > 2 else None
+    args = parser.parse_args()
+    
+    output_excel_file = DEFAULT_OUTPUT_FILENAME_EXCEL
+    
+    # Determine output file path (add .yaml if missing)
+    output_path = Path(Path(DEFAULT_OUTPUT_FILENAME_EXCEL).stem + ".yaml")
+
 
     try:
-        process_mapping(input_file, output_file)
+        print("\n###########################################")
+        print("##### [STEP 1] Creating Excel Mapping #####")
+        print("###########################################\n")
+
+        process_mapping(args.input_excel_file, args.packager_name_CIS, output_excel_file)
+        
+        print("\n##########################################")
+        print("##### [STEP 2] Creating YAML Mapping #####")
+        print("##########################################\n")
+
+        convert_excel_to_yaml(output_excel_file, output_path)
+
     except Exception as e:
-        print(f"Error processing file: {e}")
+        print(f"Error processing file: {e}", file=sys.stderr)
         sys.exit(1)
 
 

--- a/tools/excel/cis/prep_mapping_cis_controls_iso_27.py
+++ b/tools/excel/cis/prep_mapping_cis_controls_iso_27.py
@@ -1,13 +1,29 @@
-#!/usr/bin/env python3
 """
-Script to extract CIS Controls to ISO 27001 mapping from Excel file.
-Reads the mapping data and creates a simplified output with source_node_id, target_node_id, and relationship.
+Script to extract CIS Controls to ISO/IEC 27001:2022 mapping from Excel file.
+
+Creates an output Excel with:
+1) library_meta
+2) mappings_meta
+3) mappings_content (source_node_id|target_node_id|relationship)
+
+Then converts the Excel mapping into YAML (Step 2).
 """
 
 import sys
 import re
+import argparse
 import pandas as pd
 from pathlib import Path
+
+# Import helper to create base Excel file from YAML (Step 2)
+parent_dir = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(parent_dir))
+
+# Import Excel to YAML Converter (Step 3)
+from convert_library_v2 import create_library as convert_excel_to_yaml
+
+
+DEFAULT_OUTPUT_FILENAME_EXCEL = "mapping-cis-controls-v8-and-iso27001-2022.xlsx"
 
 
 def format_target_node_id(node_id: str) -> str:
@@ -15,52 +31,77 @@ def format_target_node_id(node_id: str) -> str:
     Format target node ID to include dot after letter prefix.
     Example: a5.9 -> a.5.9, a8.8 -> a.8.8
     """
-    # Pattern to match letter(s) followed by digits (e.g., a5, a8)
     pattern = r"^([a-z]+)(\d)"
     match = re.match(pattern, node_id)
-
     if match:
-        # Insert dot between letter prefix and first digit
-        return f"{match.group(1)}.{node_id[len(match.group(1)) :]}"
-
+        return f"{match.group(1)}.{node_id[len(match.group(1)):]}"
     return node_id
 
 
-def process_mapping(input_file: str, output_file: str = None):
-    """
-    Process CIS Controls to ISO 27001 mapping Excel file.
+def build_library_meta(packager_name: str) -> pd.DataFrame:
+    rows = [
+        ("type", "library"),
+        ("urn", f"urn:{packager_name}:risk:library:mapping-cis-controls-v8-and-iso27001-2022"),
+        ("version", "1"),
+        ("locale", "en"),
+        ("ref_id", "mapping-cis-controls-v8-and-iso27001-2022"),
+        ("name", "CIS-Controls-v8 <-> ISO/IEC 27001:2022"),
+        ("description", "Mapping between CIS Controls v8 and International standard ISO/IEC 27001:2022"),
+        (
+            "copyright",
+            "This work is licensed under a Creative Commons Attribution-NonCommercial-No Derivatives 4.0 International Public License "
+            "(the link can be found at https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode). To further clarify the Creative Commons "
+            "license related to the CIS Controls® content, you are authorized to copy and redistribute the content as a framework for use by you, "
+            "within your organization and outside of your organization for non-commercial purposes only, provided that (i) appropriate credit is given "
+            "to CIS, and (ii) a link to the license is provided. Additionally, if you remix, transform or build upon the CIS Controls, you may not distribute "
+            "the modified materials. Users of the CIS Controls framework are also required to refer to (http://www.cisecurity.org/controls/) when referring "
+            "to the CIS Controls in order to ensure that users are employing the most up-to-date guidance. Commercial use of the CIS Controls is subject to "
+            "the prior approval of CIS® (Center for Internet Security, Inc.).",
+        ),
+        ("provider", "CIS"),
+        ("packager", packager_name),
+        (
+            "dependencies",
+            f"urn:{packager_name}:risk:library:cis-controls-v8, urn:intuitem:risk:library:iso27001-2022",
+        ),
+    ]
+    return pd.DataFrame(rows)
 
-    Args:
-        input_file: Path to input Excel file
-        output_file: Path to output Excel file (optional, defaults to input_file with _mapping suffix)
-    """
-    # Read the Excel file - using the 5th sheet (index 4) which is "All CIS Controls & Safeguards"
+
+def build_mappings_meta(packager_name: str) -> pd.DataFrame:
+    rows = [
+        ("type", "requirement_mapping_set"),
+        ("urn", f"urn:{packager_name}:risk:req_mapping_set:mapping-cis-controls-v8-and-iso27001-2022"),
+        ("ref_id", "mapping-cis-controls-v8-and-iso27001-2022"),
+        ("name", "CIS-Controls-v8 <-> ISO/IEC 27001:2022"),
+        ("description", "Mapping between CIS Controls v8 and International standard ISO/IEC 27001:2022"),
+        ("source_framework_urn", f"urn:{packager_name}:risk:framework:cis-controls-v8"),
+        ("target_framework_urn", "urn:intuitem:risk:framework:iso27001-2022"),
+        ("source_node_base_urn", f"urn:{packager_name}:risk:req_node:cis-controls-v8"),
+        ("target_node_base_urn", "urn:intuitem:risk:req_node:iso27001-2022"),
+    ]
+    return pd.DataFrame(rows)
+
+
+def extract_mappings_content(input_file: str) -> pd.DataFrame:
+    # ISO mapping file: 5th sheet (index 4) = "All CIS Controls & Safeguards"
     df = pd.read_excel(input_file, sheet_name=4)
 
-    # Extract relevant columns
-    # Column C = CIS Safeguard (source_node_id)
-    # Column L = Control # (target_node_id)
-    # Column K = Relationship
     mapping_data = []
-
     for _, row in df.iterrows():
-        source_node_id = row.iloc[2]  # Column C (index 2)
-        target_node_id = row.iloc[11]  # Column L (index 11)
-        relationship = row.iloc[10]  # Column K (index 10)
+        source_node_id = row.iloc[2]    # Column C (index 2)
+        target_node_id = row.iloc[11]   # Column L (index 11)
+        relationship = row.iloc[10]     # Column K (index 10)
 
-        # Skip rows with missing data
         if pd.isna(source_node_id) or pd.isna(target_node_id) or pd.isna(relationship):
             continue
 
-        # Convert to string and lowercase
         source_node_id = str(source_node_id).strip().lower()
         target_node_id = str(target_node_id).strip().lower()
         relationship = str(relationship).strip().lower()
 
-        # Format target_node_id to include dot after letter prefix (e.g., a5.9 -> a.5.9)
         target_node_id = format_target_node_id(target_node_id)
 
-        # Replace "equivalent" with "equal"
         if relationship == "equivalent":
             relationship = "equal"
 
@@ -72,41 +113,65 @@ def process_mapping(input_file: str, output_file: str = None):
             }
         )
 
-    # Create output DataFrame
-    output_df = pd.DataFrame(mapping_data)
+    return pd.DataFrame(mapping_data)
 
-    # Determine output file name
+
+def process_mapping(input_file: str, packager_name: str, output_file: str = None) -> pd.DataFrame:
+    mapping_df = extract_mappings_content(input_file)
+    library_meta_df = build_library_meta(packager_name)
+    mappings_meta_df = build_mappings_meta(packager_name)
+
     if output_file is None:
-        input_path = Path(input_file)
-        output_file = input_path.parent / f"{input_path.stem}_mapping.xlsx"
+        output_file = DEFAULT_OUTPUT_FILENAME_EXCEL
 
-    # Write to Excel
-    output_df.to_excel(output_file, index=False, sheet_name="Mapping")
+    # Sheet order:
+    # 1) library_meta
+    # 2) mappings_meta
+    # 3) mappings_content
+    with pd.ExcelWriter(output_file, engine="openpyxl") as writer:
+        library_meta_df.to_excel(writer, index=False, header=False, sheet_name="library_meta")
+        mappings_meta_df.to_excel(writer, index=False, header=False, sheet_name="mappings_meta")
+        mapping_df.to_excel(writer, index=False, sheet_name="mappings_content")
 
-    print(f"Processed {len(output_df)} mappings")
+    print(f"Processed {len(mapping_df)} mappings")
     print(f"Output written to: {output_file}")
 
-    return output_df
+    return mapping_df
 
 
 def main():
-    if len(sys.argv) < 2:
-        print(
-            "Usage: python prep_mapping_cis_controls_iso_27.py <input_excel_file> [output_excel_file]"
-        )
-        print("\nExample:")
-        print(
-            "  python prep_mapping_cis_controls_iso_27.py CIS_Controls_v8_NEW_MAPPING_to_ISO.IEC_27001.2022_2_2023.xlsx"
-        )
-        sys.exit(1)
+    parser = argparse.ArgumentParser(
+        description="Extract CIS Controls v8 to ISO/IEC 27001:2022 mapping and generate a formatted Excel output, then YAML."
+    )
+    parser.add_argument("input_excel_file", help="Path to input Excel mapping file")
+    parser.add_argument(
+        "packager_name_CIS",
+        help="Packager name used in your CIS v8 Framework",
+    )
 
-    input_file = sys.argv[1]
-    output_file = sys.argv[2] if len(sys.argv) > 2 else None
+    args = parser.parse_args()
+
+    output_excel_file = DEFAULT_OUTPUT_FILENAME_EXCEL
+
+    # Output YAML: same stem as Excel + .yaml
+    output_path = Path(Path(DEFAULT_OUTPUT_FILENAME_EXCEL).stem + ".yaml")
+
 
     try:
-        process_mapping(input_file, output_file)
+        print("\n###########################################")
+        print("##### [STEP 1] Creating Excel Mapping #####")
+        print("###########################################\n")
+
+        process_mapping(args.input_excel_file, args.packager_name_CIS, output_excel_file)
+
+        print("\n##########################################")
+        print("##### [STEP 2] Creating YAML Mapping #####")
+        print("##########################################\n")
+
+        convert_excel_to_yaml(output_excel_file, output_path)
+
     except Exception as e:
-        print(f"Error processing file: {e}")
+        print(f"Error processing file: {e}", file=sys.stderr)
         sys.exit(1)
 
 


### PR DESCRIPTION
# Script `prep_mapping_cis_controls_csf_2.0.py`

The `prep_mapping_cis_controls_csf_2.0.py` script creates the mapping spreadsheet between CIS Controls v8 and NIST CSF 2.0, using the official CIS Controls v8 mapping. ~The generated sheet must be transferred to an Excel file mapping CIS Controls v8 to NIST CSF 2.0, created by `prepare_mapping_v2.py`.~ The complete mapping file will be generated in both Excel and YAML formats.

# Script `prep_mapping_cis_controls_iso_27.py`
It does the same thing as `prep_mapping_cis_controls_csf_2.0.py`, except that it uses the official CIS Controls v8 mapping to ISO27001:2022.

# Documentation

The documentation has been added for both scripts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tools to generate normalized 3-sheet Excel mappings (library_meta, mappings_meta, mappings_content) and companion YAML for CIS→NIST CSF 2.0 and CIS→ISO mappings.
  * Command‑line interface to process input spreadsheets, show step progress, report processed counts and output paths, and use sensible default output names.

* **Refactor**
  * Standardized identifier formatting, row validation (skips incomplete rows), consolidated Excel→YAML pipeline, and improved error handling.

* **Documentation**
  * Added usage, prerequisites, and examples for the mapping tools.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->