### PR TITLE
fix: make leader field required on team creation

### DIFF
--- a/frontend/src/lib/utils/schemas.ts
+++ b/frontend/src/lib/utils/schemas.ts
@@ -1412,7 +1412,7 @@ export const teamSchema = z.object({
 	team_email: z.string().email().optional(),
 	folder: z.string(),
 	members: z.array(z.string().uuid().optional()).optional(),
-	leader: z.string(),
+	leader: z.string().uuid(),
 	deputies: z.array(z.string().uuid().optional()).optional()
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Team records now require a leader to be specified; creating or updating a team without assigning a leader will be rejected.
  * Validation tightened to disallow empty or omitted leader values, so forms and APIs must provide a valid leader identifier.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->