### PR TITLE
fix(frontend): stabilize pnpm check & VSCode Svelte IntelliSense with preserveSymlinks

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -8,7 +8,8 @@
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
 		"sourceMap": true,
-		"strict": true
+		"strict": true,
+		"preserveSymlinks": true
 	}
 	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
 	//


### PR DESCRIPTION
# What

- Enable `compilerOptions.preserveSymlinks = true` in `frontend/tsconfig.json`.

# Why

- In our pnpm setup, dependencies are resolved through symlinks (`node_modules -> .pnpm/...`).
- Without preserving symlinks, the TypeScript / Svelte tooling may resolve packages via their real paths, leading to a **Node heap OOM** (e.g. `pnpm check` stops due to an OOM error. See console output below).
<details>
  <summary><strong>pnpm check — OOM error output (before preserveSymlinks)</strong></summary>

```text
some_user@PC:~/Desktop/intuitem/ciso-assistant-community/frontend$ pnpm check

> frontend@0.0.1 check /home/some_user/Desktop/intuitem/ciso-assistant-community/frontend
> svelte-kit sync && svelte-check --tsconfig ./tsconfig.json


====================================
Loading svelte-check in workspace: /home/some_user/Desktop/intuitem/ciso-assistant-community/frontend
Getting Svelte diagnostics...


<--- Last few GCs --->

[5214:0x3c4ae000]   182541 ms: Mark-Compact 4038.5 (4131.1) -> 4023.2 (4131.6) MB, pooled: 0 MB, 1500.14 / 0.00 ms  (average mu = 0.076, current mu = 0.008) allocation failure; scavenge might not succeed
[5214:0x3c4ae000]   184108 ms: Mark-Compact 4039.0 (4131.6) -> 4023.8 (4132.4) MB, pooled: 0 MB, 1556.09 / 0.00 ms  (average mu = 0.042, current mu = 0.007) allocation failure; scavenge might not succeed


<--- JS stacktrace --->

FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
----- Native stack trace -----

 1: 0xe38a0e node::OOMErrorHandler(char const*, v8::OOMDetails const&) [node]
 2: 0x120a5a0 v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [node]
 3: 0x120a877 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [node]
 4: 0x1438155  [node]
 5: 0x1438183  [node]
 6: 0x145125a  [node]
 7: 0x1454428  [node]
 8: 0x1cba291  [node]
fatal error: all goroutines are asleep - deadlock!
Aborted (core dumped)

goroutine 1 [chan receive]:
github.com/evanw/esbuild/internal/helpers.(*ThreadSafeWaitGroup).Wait(...)
        github.com/evanw/esbuild/internal/helpers/waitgroup.go:36
main.runService.func2()
        github.com/evanw/esbuild/cmd/esbuild/service.go:114 +0x51
main.runService(0x1)
        github.com/evanw/esbuild/cmd/esbuild/service.go:160 +0x50c
main.main()
         ELIFECYCLE  Command failed with exit code 134.
github.com/evanw/esbuild/cmd/esbuild/main.go:252 +0xb8b

goroutine 35 [chan receive]:
main.runService.func1()
        github.com/evanw/esbuild/cmd/esbuild/service.go:98 +0x45
created by main.runService in goroutine 1
        github.com/evanw/esbuild/cmd/esbuild/service.go:97 +0x1db

goroutine 36 [chan receive]:
main.(*serviceType).sendRequest(0xc00018c360, {0x9973a0, 0xc0002c5da0})
        github.com/evanw/esbuild/cmd/esbuild/service.go:192 +0x12b
main.runService.func3()
        github.com/evanw/esbuild/cmd/esbuild/service.go:125 +0x3e
created by main.runService in goroutine 1
        github.com/evanw/esbuild/cmd/esbuild/service.go:122 +0x30e

goroutine 37 [semacquire]:
sync.runtime_Semacquire(0xc000114630?)
        runtime/sema.go:71 +0x25
sync.(*WaitGroup).Wait(0xc00012c2a0?)
        sync/waitgroup.go:118 +0x48
github.com/evanw/esbuild/internal/bundler.ScanBundle(_, {_, _, _, _, _, _}, {_, _}, 0xc00012c2a0, ...)
        github.com/evanw/esbuild/internal/bundler/bundler.go:1475 +0x9be
github.com/evanw/esbuild/pkg/api.rebuildImpl({0xc00012c2a0, {0x0, 0x0, 0x0}, {0x0, 0x0, 0x0}, {0x0, 0x1, 0x2, ...}, ...}, ...)
        github.com/evanw/esbuild/pkg/api/api_impl.go:1493 +0x2e5
github.com/evanw/esbuild/pkg/api.(*internalContext).rebuild(_)
        github.com/evanw/esbuild/pkg/api/api_impl.go:1007 +0x29c
github.com/evanw/esbuild/pkg/api.(*internalContext).Rebuild(...)
        github.com/evanw/esbuild/pkg/api/api_impl.go:1068
github.com/evanw/esbuild/pkg/api.Build({0x2, 0x4, 0x0, 0xc00018c5d0, 0x0, 0x1, {0x0, 0x0}, 0x0, 0x0, ...})
        github.com/evanw/esbuild/pkg/api/api.go:396 +0x9b
main.(*serviceType).handleBuildRequest(0xc00018c360, 0x0, 0xc00018c3f0)
        github.com/evanw/esbuild/cmd/esbuild/service.go:782 +0xe3f
main.(*serviceType).handleIncomingPacket.func2()
        github.com/evanw/esbuild/cmd/esbuild/service.go:235 +0x57
created by main.(*serviceType).handleIncomingPacket in goroutine 1
        github.com/evanw/esbuild/cmd/esbuild/service.go:233 +0x1ad

goroutine 38 [chan receive]:
main.(*serviceType).sendRequest(0xc00018c360, {0x9973a0, 0xc0000c8000})
        github.com/evanw/esbuild/cmd/esbuild/service.go:192 +0x12b
main.(*serviceType).convertPlugins.func2.2()
        github.com/evanw/esbuild/cmd/esbuild/service.go:963 +0x117
github.com/evanw/esbuild/pkg/api.(*pluginImpl).onStart-fm.(*pluginImpl).onStart.func1()
        github.com/evanw/esbuild/pkg/api/api_impl.go:1865 +0x35
github.com/evanw/esbuild/internal/bundler.ScanBundle.func1({{0xa20a8d, 0x12}, {0xc000114558, 0x1, 0x1}, {0xc00018ca50, 0x1, 0x1}, {0xc00018cab0, 0x1, ...}}, ...)
        github.com/evanw/esbuild/internal/bundler/bundler.go:1381 +0x5e
created by github.com/evanw/esbuild/internal/bundler.ScanBundle in goroutine 37
        github.com/evanw/esbuild/internal/bundler/bundler.go:1380 +0x10d9

goroutine 39 [chan send]:
github.com/evanw/esbuild/internal/bundler.ScanBundle.func2()
        github.com/evanw/esbuild/internal/bundler/bundler.go:1415 +0x2c5
created by github.com/evanw/esbuild/internal/bundler.ScanBundle in goroutine 37
        github.com/evanw/esbuild/internal/bundler/bundler.go:1413 +0x97d
```

</details>

- It also breaks the IntelliSense feature in VSCode, making it unable to find definitions. This seems to be a [common issue with dependencies installed with pnpm](https://github.com/pnpm/pnpm/issues/3671#issuecomment-898956023). This also appears to be due to an OOM error after a few tests, according to the `OUTPUT` tab in VSCode.
- These issues occurs on both **WSL (Windows)** and **a native Linux installation**.


- This change fixes:
  - VSCode Svelte / TypeScript IntelliSense (Go to Definition, references, etc.)
  - `pnpm check` (`svelte-kit sync && svelte-check --tsconfig ./tsconfig.json`), which previously crashed
    with **JavaScript heap out of memory** and now correctly reports diagnostics.

# How to test

- Run:
  ```bash
  cd frontend && pnpm check
  ```
- Open a `.svelte` file in VSCode and verify that `Ctrl+Click` (Go to Definition) works as expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript compiler configuration to adjust module resolution behavior during the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->