### PR TITLE
fix(ui): different color for update quick filter and align quick filter icons with those in the sidebar

### DIFF
--- a/frontend/src/routes/(app)/(internal)/libraries/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/libraries/+page.svelte
@@ -10,7 +10,7 @@
 	} from '$lib/components/Modals/stores';
 
 	import { safeTranslate } from '$lib/utils/i18n';
-	import { navData } from '$lib/components/SideBar/navData.js';
+	import { navData } from '$lib/components/SideBar/navData';
 
 	let { data } = $props();
 


### PR DESCRIPTION
# Changes

- The color of the `Update available` button is now `lime` (light green) instead of `pink` like the `Mappings` button.
- Quick filter button icons are now aligned with those used in the sidebar. Icons defined in the `navData.ts` file are used to avoid any future manual updates to icon names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unified library filter icons with the sidebar navigation so icons are consistent across the app.

* **Style**
  * Updated hover and selected colors for filter items (now lime-toned) for clearer visual feedback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->