### PR TITLE
fix: remove trailing line-break on markdown rendering

### DIFF
--- a/frontend/src/lib/components/MarkdownRenderer.svelte
+++ b/frontend/src/lib/components/MarkdownRenderer.svelte
@@ -67,7 +67,7 @@
 			.replace(/<\/p>\s*<ol>/g, '</p><ol>') // Remove space between paragraphs and ordered lists
 			.replace(/<\/ol>\s*<p>/g, '</ol><p>'); // Remove space between ordered lists and paragraphs
 
-		return html;
+		return html.trim();
 	}
 
 	let renderedContent = $derived(processContent(content));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved markdown rendering by removing unnecessary leading and trailing whitespace from rendered content, ensuring cleaner output formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->