### PR TITLE
fix: get_accessible_folder_ids lacking check for folders object

### DIFF
--- a/backend/iam/models.py
+++ b/backend/iam/models.py
@@ -1194,8 +1194,10 @@ class RoleAssignment(NameDescriptionMixin, FolderMixin):
                     result_delete.add(obj_id)
 
         # Published inheritance: published parents for local-view folders
-        # PERF: collect all ancestor folder_ids first, then do ONE query.
-        if hasattr(object_type, "is_published") and hasattr(object_type, "folder"):
+        # PERF: collect all ancestor folder_ids first, then do ONE query.""
+        if hasattr(object_type, "is_published") and (
+            hasattr(object_type, "folder") or object_type is Folder
+        ):
             ancestor_ids: set[uuid.UUID] = set()
 
             for folder_id, perms in folder_perm_codes.items():
@@ -1212,11 +1214,18 @@ class RoleAssignment(NameDescriptionMixin, FolderMixin):
                     parent_id = state.parent_map.get(parent_id)
 
             if ancestor_ids:
-                result_view.update(
-                    object_type.objects.filter(
-                        folder_id__in=ancestor_ids, is_published=True
-                    ).values_list("id", flat=True)
-                )
+                if object_type is Folder:
+                    result_view.update(
+                        object_type.objects.filter(
+                            id__in=ancestor_ids, is_published=True
+                        ).values_list("id", flat=True)
+                    )
+                else:
+                    result_view.update(
+                        object_type.objects.filter(
+                            folder_id__in=ancestor_ids, is_published=True
+                        ).values_list("id", flat=True)
+                    )
 
         return (list(result_view), list(result_change), list(result_delete))
 


### PR DESCRIPTION
#### Problem
- When entering in focus mode the Global domain wasn't retrieve which wasn't normal
<img width="1137" height="685" alt="image" src="https://github.com/user-attachments/assets/5ecc8e5e-547c-42bb-bfa4-efcdecfc4ffb" />

#### Solution
- Add the lacking checks when dealing with an object of type folder in get_accessible_folder_ids
<img width="1121" height="725" alt="image" src="https://github.com/user-attachments/assets/1bd04c30-ea12-4ce7-b1ff-060c7548da61" />
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed permission inheritance calculation for items within folder hierarchies to ensure accurate access visibility across nested folder structures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->