### PR TITLE
fix: recovery objectives alignment for unset objective

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -3310,7 +3310,12 @@ class Asset(
             real_value = capabilities.get(key)
 
             verdict = None
-            if isinstance(exp_value, int) and isinstance(real_value, int) and exp_value > 0 and real_value > 0:
+            if (
+                isinstance(exp_value, int)
+                and isinstance(real_value, int)
+                and exp_value > 0
+                and real_value > 0
+            ):
                 verdict = real_value <= exp_value
 
             result.append(


### PR DESCRIPTION
When the recovery objective of a primary asset is 0 (meaning it's unset) and the capability of its support asset is greater than 0 the UI display this as an unalignment.
If there's no recovery objective there can't be any unalignment.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed verdict calculation to properly handle non-positive values by excluding them from verdict generation, improving data accuracy in edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->