### PR TITLE
feat(UX): Add tab title

### DIFF
--- a/frontend/src/routes/(app)/+layout.svelte
+++ b/frontend/src/routes/(app)/+layout.svelte
@@ -155,6 +155,10 @@
 	// $inspect(data);
 </script>
 
+<svelte:head>
+	<title>CISO Assistant | {safeTranslate(displayTitle)}</title>
+</svelte:head>
+
 <!-- App Shell -->
 <div class="overflow-x-hidden">
 	<SideBar bind:open={sidebarOpen} {sideBarVisibleItems} />


### PR DESCRIPTION
It would be convenient for users working with multiple tabs to have meaningful tab titles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Browser page titles now dynamically display the current page name alongside "CISO Assistant," improving tab navigation and clarity when managing multiple pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->