### PR TITLE
fix: properly unpack actor emails for audit word export

### DIFF
--- a/backend/core/generators.py
+++ b/backend/core/generators.py
@@ -427,8 +427,12 @@ def gen_audit_context(id, doc, tree, lang):
 
     context = dict()
 
-    authors = ", ".join([a.email for a in audit.authors.all()])
-    reviewers = ", ".join([a.email for a in audit.reviewers.all()])
+    authors = ", ".join(
+        dict.fromkeys(email for a in audit.authors.all() for email in a.get_emails())
+    )
+    reviewers = ", ".join(
+        dict.fromkeys(email for r in audit.reviewers.all() for email in r.get_emails())
+    )
 
     spider_data = list()
     result_counts = count_category_results(tree)


### PR DESCRIPTION
This fixes a 400 error on audit word export, which is a regression induced by the migration from `User` to `Actor` in the `ComplianceAssessment.authors` and `ComplianceAssessment.reviewers` relationships. The bug happened because we attempted to get `Actor.email`, which does not exist. This PR replaces it with `Actor.get_emails()`, which is the only correct way to get actor emails at the time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved author and reviewer email handling with enhanced deduplication and multi-email support for more accurate attribution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->