### PR TITLE
fix: purposes and personal data creation without global permissions

### DIFF
--- a/backend/iam/models.py
+++ b/backend/iam/models.py
@@ -257,6 +257,7 @@ class Folder(NameDescriptionMixin):
             ["risk_assessment", "perimeter", "folder"],
             ["risk_scenario", "risk_assessment", "perimeter", "folder"],
             ["compliance_assessment", "perimeter", "folder"],
+            ["processing", "folder"],
         ]
 
         # Attempt to traverse each path until a valid folder is found or all paths are exhausted.


### PR DESCRIPTION
This PR fixes privacy objects creation without global permissions. 
As the folder is inherited from the processing inside the save methods, the field remains empty inside the serializer. It leads to an error if you're not Administrator because it takes Global folder by default.

Fix: Add processing path to find the folder inside the `get_folder()` method, which is called inside the `BaseModelSerializer`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved folder resolution to handle additional folder structures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->