### PR TITLE
fix: bwrap optional

### DIFF
--- a/backend/ciso_assistant/settings.py
+++ b/backend/ciso_assistant/settings.py
@@ -121,15 +121,10 @@ MAIL_DEBUG = os.environ.get("MAIL_DEBUG", "False").lower() in ("true", "1", "yes
 
 # SECURITY WARNING: Sensitive operations, such as excel file processing, can run in a sandbox.
 # The sandbox is disabled by default; set ENABLE_SANDBOX=true to enable bubblewrap isolation.
-ENABLE_SANDBOX = (
-    os.environ.get(
-        "ENABLE_SANDBOX",
-        "False",
-    )
-    .strip()
-    .lower()
-    in ("true", "1", "yes")
-)
+ENABLE_SANDBOX = os.environ.get(
+    "ENABLE_SANDBOX",
+    "False",
+).strip().lower() in ("true", "1", "yes")
 
 LIBRARY_COMPATIBILITY_MODES = [0, 1, 2, 3]
 

--- a/enterprise/backend/enterprise_core/settings.py
+++ b/enterprise/backend/enterprise_core/settings.py
@@ -120,9 +120,10 @@ MAIL_DEBUG = os.environ.get("MAIL_DEBUG", "False").lower() in ("true", "1", "yes
 
 # SECURITY WARNING: Sensitive operations, such as excel file processing, can run in a sandbox.
 # The sandbox is disabled by default; set ENABLE_SANDBOX=true to enable bubblewrap isolation.
-ENABLE_SANDBOX = (
-    os.environ.get("ENABLE_SANDBOX", "False").strip().lower()
-    in ("true", "1", "yes")
+ENABLE_SANDBOX = os.environ.get("ENABLE_SANDBOX", "False").strip().lower() in (
+    "true",
+    "1",
+    "yes",
 )
 
 LIBRARY_COMPATIBILITY_MODES = [0, 1, 2, 3]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified sandbox configuration to be disabled by default. The sandbox feature can now only be enabled by explicitly setting the `ENABLE_SANDBOX` environment variable to a truthy value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->