### PR TITLE
feat: Unify card styles unconsistency on modeltable and different pages

### DIFF
--- a/frontend/src/lib/components/ModelTable/ModelTable.svelte
+++ b/frontend/src/lib/components/ModelTable/ModelTable.svelte
@@ -564,7 +564,7 @@
 	let openState = $state(false);
 </script>
 
-<div class="table-wrap {classesBase}">
+<div class="card table-wrap {classesBase}">
 	<header class="flex justify-between items-center space-x-8 p-2">
 		{#if !hideFilters}
 			<Popover

--- a/frontend/src/routes/(app)/(internal)/experimental/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/experimental/+page.svelte
@@ -6,7 +6,7 @@
 	$pageTitle = 'Experimental';
 </script>
 
-<div class="bg-white grid grid-cols-2 p-4 gap-4">
+<div class="bg-white grid grid-cols-2 p-4 gap-4 card">
 	<Article
 		title={m.requirementsExplorer()}
 		desc={m.visualizeRequirements()}

--- a/frontend/src/routes/(app)/(internal)/recap/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/recap/+page.svelte
@@ -34,7 +34,7 @@
 		});
 </script>
 
-<div class="p-4 space-y-6 bg-gray-50 min-h-screen">
+<div class="p-4 space-y-6 bg-gray-50 min-h-screen card">
 	<h2 class="text-2xl font-extrabold text-gray-800 mb-4">{m.overallCompliance()}</h2>
 
 	<div class="space-y-6">

--- a/frontend/src/routes/(app)/(internal)/reports/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/reports/+page.svelte
@@ -45,11 +45,11 @@
 	}
 </script>
 
-<div class="px-4 py-6 space-y-6">
+<div class="space-y-6">
 	<!-- Header -->
 
 	<!-- Reports Grid with White Background -->
-	<div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+	<div class="bg-white card border border-gray-200 p-6">
 		<div class="grid grid-cols-1 md:grid-cols-2 gap-6">
 			{#each reportTiles as tile}
 				<ReportTile
@@ -66,7 +66,7 @@
 	</div>
 
 	<!-- Info Section -->
-	<div class="bg-gradient-to-br from-gray-50 to-gray-100 rounded-xl border border-gray-200 p-6">
+	<div class="bg-gradient-to-br from-gray-50 to-gray-100 card border border-gray-200 p-6">
 		<div class="flex items-start gap-4">
 			<div class="flex-shrink-0">
 				<i class="fas fa-info-circle text-2xl text-blue-600"></i>


### PR DESCRIPTION
Over ciso assistant , some pages have this :

<img width="450" height="380" alt="image" src="https://github.com/user-attachments/assets/5c0c04b2-1f93-49c6-bb51-cf7e7c725f10" />


or this:

<img width="522" height="394" alt="image" src="https://github.com/user-attachments/assets/a62e7413-1b8e-43af-a44a-16b0119dc8f0" />


or this:

<img width="882" height="676" alt="image" src="https://github.com/user-attachments/assets/4ece7b72-cb15-4e6f-a0df-df1cd755e835" />

This pull request is here to unify the pages with the card style: 

<img width="2304" height="776" alt="image" src="https://github.com/user-attachments/assets/d30cc97e-a5bb-4e6c-9ab8-002e66568b6b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Applied consistent "card" design styling across multiple application pages (ModelTable, experimental, and recap sections) for improved visual coherence.
  * Refined card styling on report pages with updated visual presentation and adjusted spacing.
  * Enhanced overall design consistency throughout the application interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->