### PR TITLE
fix: create audit/evidence buttons have wrong color 

### DIFF
--- a/frontend/src/routes/(app)/(third-party)/[model=thirdparty_urlmodels]/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/[model=thirdparty_urlmodels]/+page.svelte
@@ -48,7 +48,7 @@
 						<span class="inline-flex overflow-hidden rounded-md border bg-white shadow-xs">
 							{#if !['risk-matrices', 'frameworks', 'requirement-mapping-sets', 'user-groups', 'role-assignments'].includes(URLModel)}
 								<button
-									class="inline-block border-e p-3 text-gray-50 bg-pink-500 hover:bg-pink-400 w-12 focus:relative"
+									class="inline-block border-e p-3 text-gray-50 bg-primary-500 hover:bg-primary-400 w-12 focus:relative"
 									data-testid="add-button"
 									id="add-button"
 									title={safeTranslate('add-' + data.model.localName)}


### PR DESCRIPTION
All ciso assistant has the primary color as a button but not the audit/evidence due to the third party button configuration.

<img width="216" height="166" alt="image" src="https://github.com/user-attachments/assets/b16ce8c3-0df7-4720-8c45-b67ef30dd43e" />


Changing this so all the create buttons have the same primary color and there is no inconsistency

<img width="188" height="214" alt="image" src="https://github.com/user-attachments/assets/7f65540e-5c9b-45c5-8783-dc6959a2b629" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the add button styling in the third-party interface to use the primary design system color theme for improved visual consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->