### PR TITLE
fix: propagate domains to children objects for risk assessments and metric instances

### DIFF
--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -341,6 +341,12 @@ class RiskAssessmentWriteSerializer(BaseModelSerializer):
             if new_perimeter and new_perimeter.folder:
                 validated_data["folder"] = new_perimeter.folder
 
+        # Check if folder is being changed (either directly or via perimeter)
+        new_folder = validated_data.get("folder")
+        if new_folder and new_folder != instance.folder:
+            # Cascade folder change to all child RiskScenarios
+            instance.risk_scenarios.update(folder=new_folder)
+
         return super().update(instance, validated_data)
 
     class Meta:

--- a/backend/metrology/serializers.py
+++ b/backend/metrology/serializers.py
@@ -42,6 +42,15 @@ class MetricInstanceWriteSerializer(BaseModelSerializer):
         required=False,
     )
 
+    def update(self, instance, validated_data):
+        # Check if folder is being changed
+        new_folder = validated_data.get("folder")
+        if new_folder and new_folder != instance.folder:
+            # Cascade folder change to all child CustomMetricSamples
+            instance.samples.update(folder=new_folder)
+
+        return super().update(instance, validated_data)
+
     class Meta:
         model = MetricInstance
         fields = "__all__"
@@ -97,9 +106,11 @@ class MetricInstanceReadSerializer(BaseModelSerializer):
 
 # CustomMetricSample serializers
 class CustomMetricSampleWriteSerializer(BaseModelSerializer):
-    class Meta:
-        model = CustomMetricSample
-        fields = "__all__"
+    def create(self, validated_data):
+        # Set folder from metric_instance before the permission check in parent class
+        if "metric_instance" in validated_data and validated_data["metric_instance"]:
+            validated_data["folder"] = validated_data["metric_instance"].folder
+        return super().create(validated_data)
 
     def validate_timestamp(self, value):
         """Prevent creating samples with future timestamps"""
@@ -110,6 +121,10 @@ class CustomMetricSampleWriteSerializer(BaseModelSerializer):
                 "Cannot create metric samples with future timestamps."
             )
         return value
+
+    class Meta:
+        model = CustomMetricSample
+        exclude = ["folder"]
 
 
 class CustomMetricSampleReadSerializer(BaseModelSerializer):

--- a/frontend/src/lib/components/Forms/ModelForm/CustomMetricSampleForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/CustomMetricSampleForm.svelte
@@ -105,15 +105,6 @@
 
 <AutocompleteSelect
 	{form}
-	optionsEndpoint="folders?content_type=DO&content_type=GL"
-	field="folder"
-	pathField="path"
-	cacheLock={cacheLocks['folder']}
-	bind:cachedValue={formDataCache['folder']}
-	label={m.domain()}
-/>
-<AutocompleteSelect
-	{form}
 	optionsEndpoint="metric-instances"
 	optionsExtraFields={[
 		['folder', 'str'],

--- a/frontend/src/lib/utils/schemas.ts
+++ b/frontend/src/lib/utils/schemas.ts
@@ -1389,7 +1389,6 @@ export const MetricInstanceSchema = z.object({
 });
 
 export const CustomMetricSampleSchema = z.object({
-	folder: z.string(),
 	metric_instance: z.string().uuid(),
 	timestamp: z.string().datetime(),
 	value: jsonSchema


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Folder changes now automatically cascade to related risk scenarios and custom metric samples.
  * Custom metric samples now inherit their folder from the parent metric instance.

* **UI Changes**
  * Removed manual folder selection from the custom metric sample form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->