### PR TITLE
fix: missing recovery objectives in BIA report

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -3251,7 +3251,7 @@ class Asset(
 
         # Build ordered list of objective keys: defaults first (if present), then any extras
         default_order = list(getattr(self, "DEFAULT_SECURITY_OBJECTIVES", []))
-        extra_keys = sorted([k for k in so_obj.keys() if k not in default_order])
+        extra_keys = sorted(k for k in so_obj.keys() if k not in default_order)
         ordered_keys = default_order + extra_keys
 
         result = []
@@ -3321,7 +3321,7 @@ class Asset(
         capabilities = _normalize_seconds(rc_src)
 
         default_order = list(getattr(self, "DEFAULT_DISASTER_RECOVERY_OBJECTIVES", []))
-        extras = sorted([k for k in objectives.keys() if k not in default_order])
+        extras = sorted(k for k in objectives.keys() if k not in default_order)
         ordered_keys = default_order + extras
 
         result: list[dict] = []


### PR DESCRIPTION
This PR fixes the following bugs:

- When a primary asset isn't linked to a support asset its recovery/security objectives are not displayed.
- When a support asset isn't linked to a primary asset its recovery/security capabilities are not displayed.
- A disabled security capability (capability["is_enabled"] == False) in the support asset isn't ignored by the primary asset linked to this support asset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure security objectives and disaster recovery items are processed with defaults first, then extras, for consistent ordering.
  * Make comparison verdicts more reliable: a verdict is produced only when both objective and capacity are present as integer values, reducing spurious results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->