### PR TITLE
fix: missing translation handling for risk level

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -2256,11 +2256,13 @@ class RiskMatrixViewSet(BaseModelViewSet):
         for matrix in RiskMatrix.objects.filter(id__in=viewable_matrices):
             _choices = {}
             for i, risk in enumerate(matrix.json_definition["risk"]):
+                translations = risk.get("translations")
+                if not isinstance(translations, dict):
+                    translations = {}
+                translated = translations.get(current_language, {})
+
                 # Use the translated name if available, otherwise fall back to the default name
-                if current_language in risk.get("translations", {}):
-                    name = risk["translations"][current_language]["name"]
-                else:
-                    name = risk["name"]
+                name = translated.get("name") or risk.get("name", "")
                 _choices[risk.get("id", i)] = name
             options = options | _choices
 


### PR DESCRIPTION
Resolves issue #3392 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Risk display now supports localized risk names: the UI shows translated risk labels based on the current language and falls back to default names when translations are unavailable.

* **Style**
  * Minor internal formatting cleanups with no behavioral changes or API impacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->