### PR TITLE
fix: missing translations handling in requirements

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -2196,6 +2196,18 @@ class RequirementNode(ReferentialObjectMixin, I18nObjectMixin):
         fallback_ref = ":".join(self.urn.split(":")[5:])
         return self.display_short if self.display_short else fallback_ref
 
+    @property
+    def get_typical_evidence_translated(self) -> str:
+        translations = self.translations if self.translations else {}
+        locale_translations = translations.get(get_language(), {})
+        return locale_translations.get("typical_evidence", self.typical_evidence)
+
+    @property
+    def get_questions_translated(self) -> str:
+        translations = self.translations if self.translations else {}
+        locale_translations = translations.get(get_language(), {})
+        return locale_translations.get("questions", self.questions)
+
     class Meta:
         verbose_name = _("RequirementNode")
         verbose_name_plural = _("RequirementNodes")

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -1573,6 +1573,10 @@ class RequirementNodeReadSerializer(ReferentialSerializer):
     threats = FieldsRelatedField(many=True)
     display_short = serializers.CharField()
     display_long = serializers.CharField()
+    questions = serializers.JSONField(source="get_questions_translated")
+    typical_evidence = serializers.CharField(
+        source="get_typical_evidence_translated", allow_blank=True, allow_null=True
+    )
 
     class Meta:
         model = RequirementNode


### PR DESCRIPTION
Fix for https://github.com/intuitem/ciso-assistant-community/issues/3410

Handles yaml translations in requirement nodes for typical_evidence and questions fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved international accessibility through language-aware content. Questions and typical evidence fields now automatically retrieve and display translated versions based on the user's current language preference, with intelligent fallback mechanisms ensuring content is always accessible regardless of translation availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->