### PR TITLE
fix: Better default filters for tasks

### DIFF
--- a/frontend/src/lib/utils/crud.ts
+++ b/frontend/src/lib/utils/crud.ts
@@ -1845,7 +1845,7 @@ export const URL_MODEL_MAP: ModelMap = {
 				disableDelete: true,
 				disableEdit: true,
 				defaultFilters: {
-					past: [{ value: 'false' }]
+					status: [{ value: 'pending' }, { value: 'in_progress' }]
 				}
 			}
 		]


### PR DESCRIPTION
Only hide cancelled and completed tasks by default (as "cancelled" and "completed" mean they've been definitely dealt with).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default filtering in the task templates table. The view now displays only tasks with pending or in-progress status, providing a more focused initial view of active work items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->