### PR TITLE
fix: remove "save" and "cancel" buttons when markdown in preview mode

### DIFF
--- a/frontend/src/lib/components/Forms/TableMarkdownField.svelte
+++ b/frontend/src/lib/components/Forms/TableMarkdownField.svelte
@@ -33,6 +33,7 @@
 	}
 
 	function preview() {
+		saveChanges();
 		isEditing = false;
 	}
 </script>


### PR DESCRIPTION
…and not in editor mode"

"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Removed Save and Cancel buttons from the markdown field editor interface; only Edit and Preview buttons remain visible.
  * The Preview button now also saves changes before exiting edit mode so edits are persisted when switching to preview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->