### PR TITLE
fix: preserve MarkdownField value on form submit in preview mode

### DIFF
--- a/frontend/src/lib/components/Forms/MarkdownField.svelte
+++ b/frontend/src/lib/components/Forms/MarkdownField.svelte
@@ -113,6 +113,7 @@
 	{/if}
 	<div class="control">
 		{#if showPreview}
+			<input type="hidden" name={field} value={$value} />
 			<div
 				class="p-3 border border-surface-300 rounded-md min-h-[120px] overflow-auto max-h-[75dvh] bg-surface-50"
 				ondblclick={() => !disabled && (showPreview = false)}


### PR DESCRIPTION
When dataType is 'form' (models with attachment field like evidences),
SuperForms serializes from DOM elements. The textarea was removed from
the DOM in preview mode, causing the field value to be lost on submit.
Add a hidden input to retain the value in the DOM during preview.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where markdown field values were not being submitted when preview mode was active. The field data is now properly retained and submitted during preview interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->