### PR TITLE
fix: sanitize final filename for audit zip export

### DIFF
--- a/frontend/src/routes/(app)/(internal)/compliance-assessments/[id=uuid]/export/+server.ts
+++ b/frontend/src/routes/(app)/(internal)/compliance-assessments/[id=uuid]/export/+server.ts
@@ -6,7 +6,7 @@ import type { RequestHandler } from './$types';
 function sanitizeFileName(name: string): string {
 	return name
 		.normalize('NFKC') // Normalize Unicode
-		.replace(/[\x00-\x1F<>:”/\\|?*\u007F;’`\u2018\u2019\u201C\u201D()\[\]{}]/g, ‘-’) // Remove dangerous characters
+		.replace(/[\x00-\x1F<>:"/\\|?*\u007F;'`’‘“”()\[\]{}]/g, '-') // Remove dangerous characters
 		.replace(/\s+/g, '-') // Replace whitespace with dash
 		.replace(/\.+$/g, '') // Remove trailing dots
 		.replace(/^-+|-+$/g, '') // Trim leading/trailing dashes


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Downloaded export filenames are now ASCII-safe for the primary name while still preserving the original UTF‑8 name, improving compatibility across systems and browsers.
  * Enhanced filename sanitization and normalization to remove problematic characters, collapse repeated separators, and limit length to prevent malformed or truncated download names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->