### PR TITLE
fix: validate name length on library conversion script

### DIFF
--- a/backend/scripts/convert_library_v2.py
+++ b/backend/scripts/convert_library_v2.py
@@ -1703,13 +1703,12 @@ def create_library(
     # Step 6: Validate name lengths
     violations = validate_name_lengths(library)
     if violations:
-        print(
-            f"\n❌ [ERROR] {len(violations)} object(s) have a 'name' exceeding {NAME_MAX_LENGTH} characters:"
+        details = "; ".join(
+            f"[{obj_type}] {identifier} ({length} chars)"
+            for obj_type, identifier, length in violations
         )
-        for obj_type, identifier, length in violations:
-            print(f"   - [{obj_type}] {identifier} ({length} chars)")
         raise ValueError(
-            f"{len(violations)} object(s) have a 'name' exceeding the {NAME_MAX_LENGTH}-character limit. "
+            f"{len(violations)} object(s) have a 'name' exceeding the {NAME_MAX_LENGTH}-character limit: {details}. "
             f"Please shorten them in the source file."
         )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforces a 200-character maximum for all names within libraries. Libraries with any non-compliant names are blocked from being exported.
  * When validation fails, users receive a detailed error report identifying each offending item so issues can be corrected before export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->