### PR TITLE
fix: prevent deletion of builtin user groups via API

### DIFF
--- a/backend/app_tests/api/test_api_user_groups.py
+++ b/backend/app_tests/api/test_api_user_groups.py
@@ -1,7 +1,10 @@
 import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
 from core.models import User
 
-from iam.models import RoleAssignment
+from iam.models import RoleAssignment, UserGroup
 from test_vars import GROUPS_PERMISSIONS, TEST_USER_EMAIL
 
 
@@ -19,3 +22,32 @@ class TestUserGroups:
             assert perm in user_permissions.keys(), (
                 f"Permission {perm} not found in user permissions (group: {test.user_group})"
             )
+
+    def test_cannot_delete_builtin_user_group(self, authenticated_client):
+        """test that a builtin user group cannot be deleted via the API"""
+
+        builtin_group = UserGroup.objects.filter(builtin=True).first()
+        assert builtin_group is not None, "No builtin user group found in DB"
+
+        url = reverse("user-groups-detail", args=[builtin_group.id])
+        response = authenticated_client.delete(url)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.data.get("error") == "attemptToDeleteBuiltinUserGroup"
+        # Confirm the group still exists
+        assert UserGroup.objects.filter(id=builtin_group.id).exists()
+
+    def test_can_delete_non_builtin_user_group(self, authenticated_client):
+        """test that a non-builtin user group can be deleted via the API"""
+        from iam.models import Folder
+
+        folder = Folder.objects.get(content_type=Folder.ContentType.ROOT)
+        non_builtin_group = UserGroup.objects.create(
+            name="custom-group-to-delete", folder=folder, builtin=False
+        )
+
+        url = reverse("user-groups-detail", args=[non_builtin_group.id])
+        response = authenticated_client.delete(url)
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert not UserGroup.objects.filter(id=non_builtin_group.id).exists()

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -6047,6 +6047,15 @@ class UserGroupViewSet(BaseModelViewSet):
         filters.SearchFilter,
     ]
 
+    def destroy(self, request, *args, **kwargs):
+        user_group = self.get_object()
+        if user_group.builtin:
+            return Response(
+                {"error": "attemptToDeleteBuiltinUserGroup"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        return super().destroy(request, *args, **kwargs)
+
 
 class RoleAssignmentViewSet(BaseModelViewSet):
     """


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Built-in user groups are now protected from deletion via the API; deletion attempts return a 403 error with appropriate messaging.
  * Non-built-in user groups remain deletable through the API as expected.

* **Tests**
  * Added API tests to verify user group deletion behavior, ensuring built-in groups cannot be deleted and custom groups can be removed successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->