### PR TITLE
fix: change batch action UI size to match modeltable ui size

### DIFF
--- a/frontend/src/lib/components/ModelTable/BatchActionBar.svelte
+++ b/frontend/src/lib/components/ModelTable/BatchActionBar.svelte
@@ -107,7 +107,7 @@
 	}
 </script>
 
-<div class="flex justify-between items-center w-full">
+<div class="flex justify-between items-center w-full h-full">
 	<div class="flex items-center gap-3">
 		<span class="text-sm font-medium text-gray-700">
 			{m.itemsSelected({ count: selectedIds.size })}

--- a/frontend/src/lib/components/ModelTable/ModelTable.svelte
+++ b/frontend/src/lib/components/ModelTable/ModelTable.svelte
@@ -617,7 +617,7 @@
 </script>
 
 <div class="card table-wrap {classesBase}">
-	<header class="flex justify-between items-center space-x-8 p-2">
+	<header class="flex items-center justify-between gap-2 px-2 h-16">
 		{#if hasBatchActions && selectedIds.size > 0}
 			<BatchActionBar
 				{selectedIds}
@@ -636,7 +636,7 @@
 					onPointerDownOutside={() => (openState = false)}
 					closeOnInteractOutside={false}
 				>
-					<Popover.Trigger class="btn preset-filled-primary-500 self-end relative">
+					<Popover.Trigger class="btn preset-filled-primary-500 h-9 inline-flex items-center">
 						<i class="fa-solid fa-filter mr-2"></i>
 						{m.filters()}
 						{#if filterCount}


### PR DESCRIPTION
Unsatisfying behavior on batch action UI size that is slightly different so when u click on a select button it moves the objects by a few pixels in vertical.

To test do a few clicks on the select button to see the diff of height and this PR fix the problem 

<img width="2280" height="312" alt="image" src="https://github.com/user-attachments/assets/5ae61c91-cd28-4ca6-bc4f-b26fc6a5e32e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined UI layout and spacing in the model table interface with improved alignment and sizing of header elements and action buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->