### PR TITLE
fix: rbac bypass possibility in task template calendar 

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -12992,7 +12992,7 @@ class TaskTemplateViewSet(ExportMixin, BaseModelViewSet):
             if task_identifier in tasks_to_process_ids:
                 processed_tasks_identifiers.add(task_identifier)
 
-                task_template = TaskTemplate.objects.get(id=task_template_id)
+                task_template = self.get_queryset().get(id=task_template_id)
                 try:
                     task_node, created = TaskNode.objects.get_or_create(
                         task_template=task_template,
@@ -13044,7 +13044,7 @@ class TaskTemplateViewSet(ExportMixin, BaseModelViewSet):
                     end_date = start_date
                 # Generate the task nodes
                 self.task_calendar(
-                    task_templates=TaskTemplate.objects.filter(id=task_template.id),
+                    task_templates=self.get_queryset().filter(id=task_template.id),
                     start=start_date,
                     end=end_date,
                 )


### PR DESCRIPTION
Fixing RBAC bypass for calendar events that were visible for every users even those outside the scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Calendar and task generation now respect user permissions when selecting task templates. Users will only see and have tasks generated from templates they are authorized to access, reducing unintended visibility of restricted templates and aligning calendar behavior with access controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->