### PR TITLE
fix: correct rbac bypass on get_controls_info function 

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -13059,7 +13059,7 @@ class TaskTemplateViewSet(ExportMixin, BaseModelViewSet):
             if task_identifier in tasks_to_process_ids:
                 processed_tasks_identifiers.add(task_identifier)
 
-                task_template = TaskTemplate.objects.get(id=task_template_id)
+                task_template = self.get_queryset().get(id=task_template_id)
                 try:
                     task_node, created = TaskNode.objects.get_or_create(
                         task_template=task_template,
@@ -13111,7 +13111,7 @@ class TaskTemplateViewSet(ExportMixin, BaseModelViewSet):
                     end_date = start_date
                 # Generate the task nodes
                 self.task_calendar(
-                    task_templates=TaskTemplate.objects.filter(id=task_template.id),
+                    task_templates=self.get_queryset().filter(id=task_template.id),
                     start=start_date,
                     end=end_date,
                 )
@@ -13136,7 +13136,7 @@ class TaskTemplateViewSet(ExportMixin, BaseModelViewSet):
             end = timezone.now().date() + relativedelta.relativedelta(months=1)
         return Response(
             self.task_calendar(
-                task_templates=TaskTemplate.objects.filter(enabled=True),
+                task_templates=self.get_queryset().filter(enabled=True),
                 start=start,
                 end=end,
             )


### PR DESCRIPTION
The get_controls_info function has a RBAC bypass because of those lines :

`for ac in AppliedControl.objects.all():`
`for ra in RiskAssessment.objects.all():`
`for audit in ComplianceAssessment.objects.all():`

The code had also another problem of a really big complexity causing lots of requests with .distinct and count() that is costful


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Controls graph now respects folder and permission scope, showing only authorized items and pruning unused audit/risk nodes.
  * Audit and risk counts on controls updated to reflect only referenced/accessible data, reducing noise.

* **Refactor**
  * Data retrieval for controls tightened and optimized to limit payload size and improve performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->