### PR TITLE
feat(table mode): add annotation visibility for non assessable requirements

### DIFF
--- a/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/table-mode/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/table-mode/+page.svelte
@@ -446,6 +446,41 @@
 									<MarkdownRenderer content={requirementAssessment.requirement.description} />
 								</div>
 							{/if}
+							<!-- Show annotation for non assessable requirements -->
+							{#if requirementAssessment.requirement.annotation && !requirementAssessment.assessable}
+								<div
+									class="card p-4 preset-tonal-secondary text-sm flex flex-col justify-evenly cursor-auto w-full"
+								>
+									<h2 class="font-semibold text-base flex flex-row justify-between">
+										<div>
+											<i class="fa-solid fa-circle-info mr-2"></i>{m.additionalInformation()}
+										</div>
+										<button onclick={() => toggleSuggestion(requirementAssessment.id)}>
+											{#if !hideSuggestionHashmap[requirementAssessment.id]}
+												<i class="fa-solid fa-eye"></i>
+											{:else}
+												<i class="fa-solid fa-eye-slash"></i>
+											{/if}
+										</button>
+									</h2>
+									{#if !hideSuggestionHashmap[requirementAssessment.id]}
+										{#if requirementAssessment.requirement.annotation}
+											<div class="my-2">
+												<p class="font-medium">
+													<i class="fa-solid fa-pencil"></i>
+													{m.annotation()}
+												</p>
+												<div class="py-1">
+													<MarkdownRenderer
+														content={requirementAssessment.requirement.annotation}
+													/>
+												</div>
+											</div>
+										{/if}
+									{/if}
+								</div>
+							{/if}
+
 							{#if requirementAssessment.assessable}
 								{#if requirementAssessment.requirement.annotation || requirementAssessment.requirement.typical_evidence || requirementAssessment.mapping_inference?.result}
 									<div


### PR DESCRIPTION
# Why ?

Some frameworks such as **FINMA - Circular 2023/01** (Discussion #2204), **NIS2 - Annex to the Commission Implementing Regulation 2024/2690 with Technical**, **RBI Master Direction 2023** ~~and another framework I'm working on (#3593)~~ have additional info that doesn't really belong in the `Description` field and should be put in the `Annotation` field. The problem is that CISO doesn't show them when we are in "Table Mode", which I think is the only place where it would be relevant to show them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the compliance assessments interface with annotation display for non-assessable requirements. A new toggleable annotation block provides show/hide controls with visual state indicators, and annotation content is rendered with full formatting support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->