### PR TITLE
feat: Add CI policy check for template injection 

### DIFF
--- a/.github/workflows/ci-workflow-hardening.yml
+++ b/.github/workflows/ci-workflow-hardening.yml
@@ -22,7 +22,7 @@ jobs:
           set -euo pipefail
           cargo install zizmor --locked
 
-      - name: Run zizmor (quiet output) and fail only on template-injection
+      - name: Run zizmor - fail only on template-injection
         shell: bash
         run: |
           set -euo pipefail
@@ -54,7 +54,7 @@ jobs:
           SAFE_NAME="$(echo "$RAW_BRANCH" | sed -E 's/[^a-zA-Z0-9_-]/_/g')"
           echo "BRANCH_SANITIZED=$SAFE_NAME" >> "$GITHUB_ENV"
 
-      - name: Upload zizmor reports (always)
+      - name: Upload zizmor reports 
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
The runner will launch zizmor tool and perform the action whenever one of the workflow file is modified. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated CI hardening that runs extra checks when workflow/CI files change; failures block merges and surface clear, actionable messages for issues such as template-injection.
* **Tests**
  * Added a demonstration workflow job that prints PR metadata to help validate workflow execution and test template-injection detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->