### PR TITLE
feat: add support for SSL connections to PostgreSQL databases

### DIFF
--- a/backend/ciso_assistant/settings.py
+++ b/backend/ciso_assistant/settings.py
@@ -493,9 +493,9 @@ if "POSTGRES_NAME" in os.environ:
     }
     # Allow for SSL connections to PostgreSQL databases that require it
     if "POSTGRES_SSL_MODE" in os.environ:
-        DATABASES["default"]["OPTIONS"] = {
-            "sslmode": os.environ["POSTGRES_SSL_MODE"],
-        }
+        DATABASES["default"].setdefault("OPTIONS", {})["sslmode"] = os.environ[
+            "POSTGRES_SSL_MODE"
+        ]
 else:
     DATABASES = {
         "default": {

--- a/enterprise/backend/enterprise_core/settings.py
+++ b/enterprise/backend/enterprise_core/settings.py
@@ -481,6 +481,11 @@ if "POSTGRES_NAME" in os.environ:
             "CONN_MAX_AGE": os.environ.get("CONN_MAX_AGE", 300),
         }
     }
+    # Allow for SSL connections to PostgreSQL databases that require it
+    if "POSTGRES_SSL_MODE" in os.environ:
+        DATABASES["default"].setdefault("OPTIONS", {})["sslmode"] = os.environ[
+            "POSTGRES_SSL_MODE"
+        ]
 else:
     DATABASES = {
         "default": {


### PR DESCRIPTION
This patch enables support for SSL connections to PostgreSQL databases. Closes #3621

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added SSL/TLS connection support for PostgreSQL database connections across deployment environments, configurable via environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->