### PR TITLE
Add owner field support to Applied Controls bulk import wizard

### DIFF
--- a/backend/data_wizard/views.py
+++ b/backend/data_wizard/views.py
@@ -8,6 +8,7 @@ from rest_framework.parsers import FileUploadParser
 
 from .serializers import LoadFileSerializer
 from core.models import (
+    Actor,
     Asset,
     Evidence,
     Folder,
@@ -697,8 +698,6 @@ class AppliedControlRecordConsumer(RecordConsumer[None]):
         """
         if not value or not isinstance(value, str):
             return []
-
-        from core.models import Actor, Team
 
         entries = [entry.strip() for entry in value.split(";") if entry.strip()]
         actor_ids = []


### PR DESCRIPTION
## Summary
- Adds `owner` column support to the Applied Controls data import wizard, resolving user emails and team names to Actor IDs automatically
- Adds `owner` to `AppliedControlImportExportSerializer` for backup export completeness
- Closes #3627

## Details

The `owner` column accepts semicolon-delimited values. Each entry is resolved in order:
1. **User email** — matched case-insensitively against `User.email`
2. **Team name** — matched case-insensitively against `Team.name`

Unresolvable entries are logged as warnings and skipped (non-blocking), so a single bad entry doesn't fail the entire import.

### Example spreadsheet

| name | owner |
|------|-------|
| Control A | alice@example.com |
| Control B | Security Team |
| Control C | bob@example.com; Security Team |

## Files changed
- `backend/data_wizard/views.py` — Owner resolution logic in `AppliedControlRecordConsumer`
- `backend/core/serializers.py` — Added `owner` to export serializer fields

## Test plan
- [ ] Import an Excel file with an `owner` column containing a valid user email — verify the applied control is created with that user as owner
- [ ] Import with a valid team name — verify the team's actor is assigned as owner
- [ ] Import with multiple semicolon-separated owners — verify all are assigned
- [ ] Import with an unresolvable owner value — verify the control is still created (owner skipped, warning logged)
- [ ] Import without an `owner` column — verify existing behavior is unchanged
- [ ] Export applied controls with owners — verify the `owner` field appears in the export

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Owners can be specified during import/update by user email or team name; multiple owners accepted via semicolon-separated list. Unresolvable entries are skipped with warnings.
  * Update flow now propagates owner values to allow clearing stale owner relationships during record updates, keeping owner data in sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->