### PR TITLE
fix: Click "about" then "quick start" fails

### DIFF
--- a/frontend/src/lib/components/Modals/DisplayJSONModal.svelte
+++ b/frontend/src/lib/components/Modals/DisplayJSONModal.svelte
@@ -2,27 +2,44 @@
 	import { safeTranslate } from '$lib/utils/i18n';
 	import { getModalStore, type ModalStore } from './stores';
 
-	// Base Classes
 	const cBase = 'card bg-surface-50 p-4 w-modal shadow-xl space-y-4';
 	const cHeader = 'text-2xl font-bold';
 
 	const modalStore: ModalStore = getModalStore();
+
+	function parseBody(body: unknown) {
+		if (typeof body !== 'string') return null;
+
+		try {
+			const parsed = JSON.parse(body);
+			return parsed && typeof parsed === 'object' ? parsed : null;
+		} catch {
+			return null;
+		}
+	}
 </script>
 
 {#if $modalStore[0]}
 	{@const body = $modalStore[0].body}
+	{@const parsedBody = parseBody(body)}
+
 	<div class="modal-example-form {cBase}">
 		<header class={cHeader} data-testid="modal-title">
 			{$modalStore[0].title ?? '(title missing)'}
 		</header>
-		{#if body}
+
+		{#if parsedBody}
 			<div data-testid="key-value">
-				{#each Object.entries(JSON.parse(body)) as [key, value]}
+				{#each Object.entries(parsedBody) as [key, value]}
 					<div>
 						<div data-testid="{key}-key" class="font-bold">{safeTranslate(key)}:</div>
-						<div data-testid="{key}-value">{safeTranslate(value)}</div>
+						<div data-testid="{key}-value">{safeTranslate(String(value))}</div>
 					</div>
 				{/each}
+			</div>
+		{:else if body}
+			<div data-testid="raw-body">
+				{safeTranslate(String(body))}
 			</div>
 		{/if}
 	</div>


### PR DESCRIPTION
When the user clicked the about in the footer modal and then clicked on get started, the json modal display had a tricky issue by posting the second modal opening in plain text instead of json which caught the second modal crashing.

fixing it here 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced modal content rendering to safely handle and display structured data with fallback support for unstructured content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->