### PR TITLE
feat: enhance related models tab in detail view

### DIFF
--- a/frontend/src/lib/components/DetailView/DetailView.svelte
+++ b/frontend/src/lib/components/DetailView/DetailView.svelte
@@ -799,7 +799,7 @@
 </div>
 
 {#if relatedModels.length > 0 && displayModelTable}
-	<div class="card shadow-lg mt-8 bg-white py-6">
+	<div class="card shadow-lg mt-8 bg-white px-2 py-6">
 		<Tabs
 			value={group}
 			onValueChange={(e) => (group = e.value)}
@@ -808,19 +808,28 @@
 		>
 			<Tabs.List class="shrink-0 gap-3">
 				{#each relatedModels as [urlmodel, model]}
-					<Tabs.Trigger value={urlmodel} class="justify-start" data-testid="tabs-control">
+					<Tabs.Trigger
+						value={urlmodel}
+						class="justify-between w-full rounded-md px-3 py-2 transition-colors
+			       aria-[selected=true]:!bg-gray-200
+			       "
+						data-testid="tabs-control"
+					>
 						{safeTranslate(model.info.localNamePlural)}
 						{#if model.count !== undefined && model.count > 0}
-							<span class="badge preset-tonal-secondary">{model.count}</span>
+							<span
+								class="ml-2 rounded-full px-2 py-0.5 text-xs
+						   preset-tonal-secondary text-gray-700"
+							>
+								{model.count}
+							</span>
 						{/if}
 					</Tabs.Trigger>
 				{/each}
-				<Tabs.Indicator />
 			</Tabs.List>
 			{#each relatedModels as [urlmodel, model]}
 				<Tabs.Content value={urlmodel} class="flex-1 min-w-0">
 					{#key urlmodel}
-						<div class="py-2"></div>
 						{@const field = data.model.reverseForeignKeyFields.find(
 							(item) => item.urlModel === urlmodel
 						)}


### PR DESCRIPTION
feat: enhance related models tab in detail view: When we check on detail view related models , we can see this :

<img width="2466" height="694" alt="image" src="https://github.com/user-attachments/assets/bf8108b3-7d4a-43bf-b5e0-a4b2a82b081f" />

the black rectangle <Tabs.Indicator /> look like a scrolling element over the list and not a select element so it can trick users 

proposed correction: 

<img width="2466" height="944" alt="image" src="https://github.com/user-attachments/assets/540fcaaa-7c22-4149-95fe-33b0e5a4bd5e" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Enhanced the related models card layout with improved tab trigger styling and spacing
  * Reorganized tab content to display translations and count badges more clearly

<!-- end of auto-generated comment: release notes by coderabbit.ai -->