### PR TITLE
fix: invalid dom error in tree map chart component

### DIFF
--- a/frontend/src/lib/components/Chart/TreemapChart.svelte
+++ b/frontend/src/lib/components/Chart/TreemapChart.svelte
@@ -112,6 +112,7 @@
 	}
 
 	onMount(async () => {
+		if (tree.length === 0) return;
 		echarts = await import('echarts');
 		chart = echarts.init(document.getElementById(chart_id), null, { renderer: 'svg' });
 


### PR DESCRIPTION
if you go on http://localhost:5173/analytics/gdpr
you will have in the navigator console this error :

Uncaught (in promise) Error: Initialize failed: invalid dom. at TreemapChart.svelte:116:19 (anonymous) @ TreemapChart.svelte:116

it is because this component does not handle the case where the length of the tree is 0 when you dont have any elements 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the chart component would attempt to initialize with empty data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->