### PR TITLE
feat: enhance deleteconfirmmodal component to stick to global UI

### DIFF
--- a/frontend/src/lib/components/Modals/DeleteConfirmModal.svelte
+++ b/frontend/src/lib/components/Modals/DeleteConfirmModal.svelte
@@ -87,6 +87,17 @@
 			<header id="modal-title" class={cHeader} data-testid="modal-title">
 				{$modalStore[0].title ?? '(title missing)'}
 			</header>
+
+			<div
+				role="button"
+				tabindex="0"
+				class="flex items-center hover:text-primary-500 cursor-pointer"
+				aria-label="Close"
+				onclick={parent.onClose}
+				onkeydown={(e) => (e.key === 'Enter' || e.key === ' ') && parent.onClose()}
+			>
+				<i class="fa-solid fa-xmark"></i>
+			</div>
 		</div>
 		<article class="text-sm text-gray-700 whitespace-pre-line">
 			{$modalStore[0].body ?? '(body missing)'}

--- a/frontend/src/lib/components/Modals/DeleteConfirmModal.svelte
+++ b/frontend/src/lib/components/Modals/DeleteConfirmModal.svelte
@@ -8,9 +8,11 @@
 
 	const modalStore: ModalStore = getModalStore();
 
-	const cBase = 'card bg-white p-6 w-modal space-y-6';
-	const cHeader = 'text-xl font-medium text-gray-900';
-	const cForm = 'space-y-4';
+	// adapted to match second modal UI
+	const cBase = 'card bg-surface-50 p-4 w-fit max-w-4xl shadow-xl space-y-4';
+	const cHeaderRow = 'flex items-center justify-between';
+	const cHeader = 'text-2xl font-bold whitespace-pre-line';
+	const cForm = 'flex flex-col space-y-3';
 
 	interface Props {
 		parent: any;
@@ -81,31 +83,34 @@
 		aria-modal="true"
 		aria-labelledby="modal-title"
 	>
-		<header id="modal-title" class={cHeader} data-testid="modal-title">
-			{$modalStore[0].title ?? '(title missing)'}
-		</header>
-
-		<article>{$modalStore[0].body ?? '(body missing)'}</article>
+		<div class={cHeaderRow}>
+			<header id="modal-title" class={cHeader} data-testid="modal-title">
+				{$modalStore[0].title ?? '(title missing)'}
+			</header>
+		</div>
+		<article class="text-sm text-gray-700 whitespace-pre-line">
+			{$modalStore[0].body ?? '(body missing)'}
+		</article>
 
 		{#if loading}
 			<div class="text-sm text-gray-500">Loading...</div>
 		{:else if errorMsg}
-			<div class="p-4 bg-red-50 text-red-900 text-sm">
+			<div class="p-3 rounded-md bg-red-50 text-red-900 text-sm border border-red-200">
 				{errorMsg}
 			</div>
 		{:else if cascadeInfo}
 			{#if cascadeInfo.deleted?.count > 0}
-				<div class="p-4 bg-orange-50 border-l-2 border-orange-400">
-					<div class="text-sm font-medium text-gray-900 mb-3">
+				<div class="p-3 rounded-md bg-orange-50 border border-orange-200 space-y-2">
+					<div class="text-sm font-semibold text-gray-900">
 						{m.cascadeDeleteWarning({ count: cascadeInfo.deleted.count })}
 					</div>
 
-					<div class="max-h-64 overflow-y-auto space-y-1">
+					<div class="max-h-64 overflow-y-auto space-y-2">
 						{#each cascadeInfo.deleted.grouped_objects as group (group.model)}
-							<section class="border-t border-gray-200">
+							<section class="rounded-md border border-surface-300 bg-surface-50 overflow-hidden">
 								<button
 									type="button"
-									class="w-full flex items-center justify-between px-3 py-2 text-left hover:bg-gray-50 text-sm"
+									class="w-full flex items-center justify-between px-3 py-2 text-left hover:bg-surface-100 text-sm"
 									aria-controls={`del-${group.model}`}
 									aria-expanded={expanded.has(keyFor('deleted', group.model))}
 									onclick={() => toggle('deleted', group.model)}
@@ -117,10 +122,13 @@
 								</button>
 
 								{#if expanded.has(keyFor('deleted', group.model))}
-									<ul id={`del-${group.model}`} class="px-3 pb-2 text-sm space-y-0.5 bg-gray-50">
+									<ul
+										id={`del-${group.model}`}
+										class="px-3 pb-2 text-sm space-y-1 bg-surface-50 border-t border-surface-300"
+									>
 										{#each group.objects as o (o.id)}
-											<li class="flex items-center justify-between py-1">
-												<span class="truncate text-gray-700" title={o.name}>{o.name}</span>
+											<li class="truncate text-gray-700" title={o.name}>
+												{o.name}
 											</li>
 										{/each}
 									</ul>
@@ -132,20 +140,20 @@
 			{/if}
 
 			{#if cascadeInfo.affected?.count > 0}
-				<div class="p-4 bg-blue-50 border-l-2 border-blue-400">
-					<div class="text-sm font-medium text-gray-900 mb-1">
+				<div class="p-3 rounded-md bg-blue-50 border border-blue-200 space-y-2">
+					<div class="text-sm font-semibold text-gray-900">
 						{m.cascadeAffectedNotice({ count: cascadeInfo.affected.count })}
 					</div>
-					<p class="text-xs text-gray-600 mb-3">
+					<p class="text-xs text-gray-600">
 						{m.cascadeAffectedHint()}
 					</p>
 
-					<div class="max-h-64 overflow-y-auto space-y-1">
+					<div class="max-h-64 overflow-y-auto space-y-2">
 						{#each cascadeInfo.affected.grouped_objects as group (group.model)}
-							<section class="border-t border-gray-200">
+							<section class="rounded-md border border-surface-300 bg-surface-50 overflow-hidden">
 								<button
 									type="button"
-									class="w-full flex items-center justify-between px-3 py-2 text-left hover:bg-gray-50 text-sm"
+									class="w-full flex items-center justify-between px-3 py-2 text-left hover:bg-surface-100 text-sm"
 									aria-controls={`aff-${group.model}`}
 									aria-expanded={expanded.has(keyFor('affected', group.model))}
 									onclick={() => toggle('affected', group.model)}
@@ -157,10 +165,13 @@
 								</button>
 
 								{#if expanded.has(keyFor('affected', group.model))}
-									<ul id={`aff-${group.model}`} class="px-3 pb-2 text-sm space-y-0.5 bg-gray-50">
+									<ul
+										id={`aff-${group.model}`}
+										class="px-3 pb-2 text-sm space-y-1 bg-surface-50 border-t border-surface-300"
+									>
 										{#each group.objects as o (o.id)}
-											<li class="flex items-center justify-between py-1">
-												<span class="truncate text-gray-700" title={o.name}>{o.name}</span>
+											<li class="truncate text-gray-700" title={o.name}>
+												{o.name}
 											</li>
 										{/each}
 									</ul>
@@ -173,26 +184,28 @@
 		{/if}
 
 		<form method="POST" action={formAction} use:enhance class="modal-form {cForm}">
-			<footer class="flex gap-3 justify-end pt-4 border-t border-gray-200">
+			<input type="hidden" name="urlmodel" value={URLModel} />
+			<input type="hidden" name="id" value={id} />
+
+			<div class="flex flex-row justify-between space-x-4">
 				<button
 					type="button"
-					class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50"
+					class="btn bg-gray-400 text-white font-semibold w-full"
 					data-testid="delete-cancel-button"
 					onclick={parent.onClose}
 				>
 					{m.cancel()}
 				</button>
-				<input type="hidden" name="urlmodel" value={URLModel} />
-				<input type="hidden" name="id" value={id} />
+
 				<button
-					class="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700"
-					data-testid="delete-confirm-button"
 					type="submit"
+					class="btn bg-red-600 hover:bg-red-700 text-white font-semibold w-full"
+					data-testid="delete-confirm-button"
 					onclick={parent.onClose}
 				>
 					{m.submit()}
 				</button>
-			</footer>
+			</div>
 		</form>
 
 		{#if debug === true}

--- a/frontend/src/lib/components/Modals/PromptConfirmModal.svelte
+++ b/frontend/src/lib/components/Modals/PromptConfirmModal.svelte
@@ -99,17 +99,6 @@
 			<header class={cHeader} data-testid="modal-title">
 				{$modalStore[0].title ?? '(title missing)'}
 			</header>
-
-			<div
-				role="button"
-				tabindex="0"
-				class="flex items-center hover:text-primary-500 cursor-pointer"
-				aria-label="Close"
-				onclick={parent.onClose}
-				onkeydown={(e) => (e.key === 'Enter' || e.key === ' ') && parent.onClose()}
-			>
-				<i class="fa-solid fa-xmark"></i>
-			</div>
 		</div>
 
 		<article class="text-sm text-gray-700 whitespace-pre-line">

--- a/frontend/src/lib/components/Modals/PromptConfirmModal.svelte
+++ b/frontend/src/lib/components/Modals/PromptConfirmModal.svelte
@@ -99,6 +99,17 @@
 			<header class={cHeader} data-testid="modal-title">
 				{$modalStore[0].title ?? '(title missing)'}
 			</header>
+
+			<div
+				role="button"
+				tabindex="0"
+				class="flex items-center hover:text-primary-500 cursor-pointer"
+				aria-label="Close"
+				onclick={parent.onClose}
+				onkeydown={(e) => (e.key === 'Enter' || e.key === ' ') && parent.onClose()}
+			>
+				<i class="fa-solid fa-xmark"></i>
+			</div>
 		</div>
 
 		<article class="text-sm text-gray-700 whitespace-pre-line">


### PR DESCRIPTION
Actually, most of the software has this kind of UI class over buttons and modal, titles, forms etc...
<img width="962" height="968" alt="image" src="https://github.com/user-attachments/assets/cb256409-cebe-4927-86de-86281eeacb69" />


We have the same UI on prompt confirm modal :

<img width="1508" height="772" alt="image" src="https://github.com/user-attachments/assets/aa736f10-bd5e-4354-9266-b4e6c4c58c02" />

But we do not have the same UI on delete confirm modal which is not great as the user will tipically see the delete button UI very often it is not serious to provide such different UIs on similar components:

<img width="1166" height="734" alt="image" src="https://github.com/user-attachments/assets/5d949309-5f81-412c-b314-896ced1c7c11" />

new delete confirm modal:

<img width="1136" height="654" alt="image" src="https://github.com/user-attachments/assets/8333d5a0-d6f8-4ca7-924d-27a242762ecd" />

I also deleted the cross button on the prompt confirm modal cause we have already 'annuler' button and the click in the background which is enough 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated delete confirmation modal with card-based layout and header redesign
  * Added close button functionality to modal header
  * Enhanced visual spacing and layout structure
  * Refactored button styling to full-width variants
  * Improved overall visual consistency with the design system
<!-- end of auto-generated comment: release notes by coderabbit.ai -->