### PR TITLE
fix: prevent lazy autocompleselect deactivation for unique input

### DIFF
--- a/frontend/src/lib/components/Forms/AutocompleteSelect.svelte
+++ b/frontend/src/lib/components/Forms/AutocompleteSelect.svelte
@@ -469,7 +469,8 @@
 
 	run(() => {
 		_disabled =
-			disabled || Boolean(selected.length && options.length === 1 && $constraints?.required);
+			disabled ||
+			(Boolean(selected.length && options.length === 1 && $constraints?.required) && !lazy);
 	});
 
 	$effect(() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the autocomplete select component's disabled state behavior in lazy-loading and multiple-selection modes. The component now properly evaluates when it should be disabled in these modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->