### PR TITLE
fix: space missing between implementation groups badges in requirement assessments

### DIFF
--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/+page.svelte
@@ -97,7 +97,7 @@
 		</span>
 		{#if data.requirement.implementation_groups?.length > 0}
 			<div class="ml-3">
-				<b class="mr-2">Implemetation Groups :</b>
+				<b class="mr-2">{m.implementationGroups()} :</b>
 				{#each data.requirement.implementation_groups as ig}
 					<span class="badge bg-blue-100 mr-2">
 						{ig}


### PR DESCRIPTION
now fixed :

<img width="616" height="138" alt="image" src="https://github.com/user-attachments/assets/6408b68a-fd95-4dfa-9d0f-4ae3650e898d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Switched the static "Implementation Groups:" label to a localized string to support translations while preserving punctuation.
  * Adjusted right-margin spacing on implementation group badges for improved visual spacing and layout consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->