### PR TITLE
fix: bia threshold with 0d0h0m broken display

### DIFF
--- a/frontend/src/lib/components/DataViz/LineHeatmap.svelte
+++ b/frontend/src/lib/components/DataViz/LineHeatmap.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { m } from '$paraglide/messages';
-	import { safeTranslate } from '$lib/utils/i18n';
+	import { safeTranslate, unsafeTranslate } from '$lib/utils/i18n';
 	let { data } = $props();
 </script>
 
@@ -15,7 +15,7 @@
 				<div class="text-lg font-bold">
 					{safeTranslate(entry?.impact?.name || 'unknown')}
 				</div>
-				<div>{safeTranslate(entry?.pit) || '-'}</div>
+				<div>{unsafeTranslate(entry?.pit) || '-'}</div>
 			</div>
 		{/each}
 	{/if}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved translation handling for pit field display in the line heatmap visualization, while preserving fallback behavior for missing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->