### PR TITLE
fix: crowded threat list on risk scenario edit page

### DIFF
--- a/frontend/src/lib/components/Forms/AutocompleteSelect.svelte
+++ b/frontend/src/lib/components/Forms/AutocompleteSelect.svelte
@@ -160,7 +160,7 @@
 		ulSelectedClass: multiple ? '!max-h-24 !overflow-y-auto' : '',
 		inputClass: 'focus:ring-0! focus:outline-hidden!',
 		outerDivClass: '!input !bg-surface-100 !px-2 !flex !relative',
-		ulOptionsClass : multiple ? '!absolute !left-0 !top-full' : '',
+		ulOptionsClass: multiple ? '!absolute !left-0 !top-full' : '',
 		closeDropdownOnSelect: !multiple,
 		...additionalMultiselectOptions
 	};
@@ -521,7 +521,7 @@
 	};
 </script>
 
-<div class="{baseClass}" hidden={hidden || undefined}>
+<div class={baseClass} hidden={hidden || undefined}>
 	{#if label !== undefined}
 		{#if $constraints?.required || mandatory}
 			<label class="text-sm font-semibold" for={field}


### PR DESCRIPTION
There isn't a perfect solution for this ticket, this solution is the one which address the best the problem being described the ticker (without worsening the `AutoCompleteSelect.svelte` component UI/UX).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated default spacing for the autocomplete select component to improve visual consistency.
  * Enhanced multiple selection mode with improved layout positioning and scrollable options list display for better usability when handling multiple selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->