### PR TITLE
fix: disappearing labels on update

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -947,6 +947,7 @@ class BaseModelViewSet(viewsets.ModelViewSet):
 
     def update(self, request: Request, *args, **kwargs) -> Response:
         # Experimental: process evidences on TaskTemplate update
+
         if request.data.get("evidences") and self.model == TaskTemplate:
             folder = Folder.objects.get(id=request.data.get("folder"))
             request.data["evidences"] = self._process_evidences(
@@ -967,16 +968,6 @@ class BaseModelViewSet(viewsets.ModelViewSet):
                     if hasattr(request.data, "_mutable"):
                         request.data._mutable = True
                     request.data["filtering_labels"] = self._process_labels(labels)
-            else:
-                # Field is missing entirely - add empty list to clear labels
-                # Make request.data mutable if needed (e.g., for multipart/form-data)
-                if hasattr(request.data, "_mutable"):
-                    request.data._mutable = True
-                # Use setlist() for QueryDict to properly set an empty list
-                if hasattr(request.data, "setlist"):
-                    request.data.setlist("filtering_labels", [])
-                else:
-                    request.data["filtering_labels"] = []
 
         return super().update(request, *args, **kwargs)
 


### PR DESCRIPTION
When creating an `Asset` with filtering labels, the filtering labels are cleared(erased) from the Asset once it gets updated (PATCH request to the API).
The bug has been reproduced by adding a `Solution` to the asset after creating it with filtering labels.

This is a fix for this issue: https://github.com/intuitem/ciso-assistant-community/issues/3683

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Task template updates now preserve existing labels when the label filter is not explicitly specified in the request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->