### PR TITLE
chores: fix indentation to avoid caddy warnings

### DIFF
--- a/config/templates/docker-compose-postgresql-caddy.yml.j2
+++ b/config/templates/docker-compose-postgresql-caddy.yml.j2
@@ -120,11 +120,11 @@ services:
       - {{ cert_config.cert_path }}:/etc/caddy/cert.pem:ro
       - {{ cert_config.key_path }}:/etc/caddy/key.pem:ro{% endif %}
     command: |
-      sh -c 'echo $$CISO_ASSISTANT_URL "{
-      reverse_proxy /api/* backend:8000
-      reverse_proxy /* frontend:3000{% if not can_do_tls %}{% if use_custom_cert %}
-      tls /etc/caddy/cert.pem /etc/caddy/key.pem{% else %}
-      tls internal{% endif %}{% endif %}
+      sh -c 'echo "$$CISO_ASSISTANT_URL {
+        reverse_proxy /api/* backend:8000
+        reverse_proxy /* frontend:3000{% if not can_do_tls %}{% if use_custom_cert %}
+        tls /etc/caddy/cert.pem /etc/caddy/key.pem{% else %}
+        tls internal{% endif %}{% endif %}
       }" > Caddyfile && caddy run'
 
   {% if kafka_dispatcher.enabled %}

--- a/config/templates/docker-compose-sqlite-caddy.yml.j2
+++ b/config/templates/docker-compose-sqlite-caddy.yml.j2
@@ -85,11 +85,11 @@ services:
       - {{ cert_config.cert_path }}:/etc/caddy/cert.pem:ro
       - {{ cert_config.key_path }}:/etc/caddy/key.pem:ro{% endif %}
     command: |
-      sh -c 'echo $$CISO_ASSISTANT_URL "{
-      reverse_proxy /api/* backend:8000
-      reverse_proxy /* frontend:3000{% if not can_do_tls %}{% if use_custom_cert %}
-      tls /etc/caddy/cert.pem /etc/caddy/key.pem{% else %}
-      tls internal{% endif %}{% endif %}
+      sh -c 'echo "$$CISO_ASSISTANT_URL {
+        reverse_proxy /api/* backend:8000
+        reverse_proxy /* frontend:3000{% if not can_do_tls %}{% if use_custom_cert %}
+        tls /etc/caddy/cert.pem /etc/caddy/key.pem{% else %}
+        tls internal{% endif %}{% endif %}
       }" > Caddyfile && caddy run'
 
   {% if kafka_dispatcher.enabled %}

--- a/enterprise/config/templates/docker-compose-postgresql-caddy.yml.j2
+++ b/enterprise/config/templates/docker-compose-postgresql-caddy.yml.j2
@@ -123,9 +123,9 @@ services:
       - {{ cert_config.cert_path }}:/etc/caddy/cert.pem:ro
       - {{ cert_config.key_path }}:/etc/caddy/key.pem:ro{% endif %}
     command: |
-      sh -c 'echo $$CISO_ASSISTANT_URL "{
-      reverse_proxy /api/* backend:8000
-      reverse_proxy /* frontend:3000{% if not can_do_tls %}{% if use_custom_cert %}
-      tls /etc/caddy/cert.pem /etc/caddy/key.pem{% else %}
-      tls internal{% endif %}{% endif %}
+      sh -c 'echo "$$CISO_ASSISTANT_URL {
+        reverse_proxy /api/* backend:8000
+        reverse_proxy /* frontend:3000{% if not can_do_tls %}{% if use_custom_cert %}
+        tls /etc/caddy/cert.pem /etc/caddy/key.pem{% else %}
+        tls internal{% endif %}{% endif %}
       }" > Caddyfile && caddy run'

--- a/enterprise/config/templates/docker-compose-sqlite-caddy.yml.j2
+++ b/enterprise/config/templates/docker-compose-sqlite-caddy.yml.j2
@@ -88,9 +88,9 @@ services:
       - {{ cert_config.cert_path }}:/etc/caddy/cert.pem:ro
       - {{ cert_config.key_path }}:/etc/caddy/key.pem:ro{% endif %}
     command: |
-      sh -c 'echo $$CISO_ASSISTANT_URL "{
-      reverse_proxy /api/* backend:8000
-      reverse_proxy /* frontend:3000{% if not can_do_tls %}{% if use_custom_cert %}
-      tls /etc/caddy/cert.pem /etc/caddy/key.pem{% else %}
-      tls internal{% endif %}{% endif %}
+      sh -c 'echo "$$CISO_ASSISTANT_URL {
+        reverse_proxy /api/* backend:8000
+        reverse_proxy /* frontend:3000{% if not can_do_tls %}{% if use_custom_cert %}
+        tls /etc/caddy/cert.pem /etc/caddy/key.pem{% else %}
+        tls internal{% endif %}{% endif %}
       }" > Caddyfile && caddy run'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed environment variable interpolation in Docker Compose configurations for Caddy reverse proxy to ensure proper quoting and escaping of configuration values across all deployment variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->