### PR TITLE
feat: add variable to force TLS1.2 for SMTP

### DIFF
--- a/backend/ciso_assistant/settings.py
+++ b/backend/ciso_assistant/settings.py
@@ -322,7 +322,7 @@ EMAIL_USE_TLS_RESCUE = os.environ.get("EMAIL_USE_TLS_RESCUE", "False").lower() i
     "1",
     "yes",
 )
-EMAIL_FORCE_TLS12 = os.environ.get("EMAIL_FORCE_TLS12", "False").lower() in (
+EMAIL_FORCE_TLS_1_2 = os.environ.get("EMAIL_FORCE_TLS_1_2", "False").lower() in (
     "true",
     "1",
     "yes",
@@ -336,7 +336,7 @@ def _build_tls12_context():
     return context
 
 
-EMAIL_SSL_CONTEXT = _build_tls12_context() if EMAIL_FORCE_TLS12 else None
+EMAIL_SSL_CONTEXT = _build_tls12_context() if EMAIL_FORCE_TLS_1_2 else None
 
 EMAIL_TIMEOUT = int(os.environ.get("EMAIL_TIMEOUT", default="5"))  # seconds
 

--- a/backend/core/tasks.py
+++ b/backend/core/tasks.py
@@ -15,7 +15,7 @@ from core.models import (
     ValidationFlow,
 )
 from iam.models import User
-from django.core.mail import send_mail
+from django.core.mail import get_connection, EmailMessage
 from django.conf import settings
 from django.db import models
 import logging
@@ -572,14 +572,19 @@ def send_notification_email(subject, message, owner_email, html_message=None):
             recipient=owner_email,
             has_html=html_message is not None,
         )
-        send_mail(
-            subject=subject,
-            message=message,
-            from_email=settings.DEFAULT_FROM_EMAIL,
-            recipient_list=[owner_email],
-            fail_silently=False,
-            html_message=html_message,
-        )
+        ssl_context = getattr(settings, "EMAIL_SSL_CONTEXT", None)
+        with get_connection(ssl_context=ssl_context) as connection:
+            msg = EmailMessage(
+                subject=subject,
+                body=message,
+                from_email=settings.DEFAULT_FROM_EMAIL,
+                to=[owner_email],
+                connection=connection,
+            )
+            if html_message:
+                msg.content_subtype = "html"
+                msg.body = html_message
+            msg.send()
         logger.info(
             "Notification email sent successfully",
             recipient=owner_email,

--- a/backend/iam/models.py
+++ b/backend/iam/models.py
@@ -36,7 +36,7 @@ from django.utils.http import urlsafe_base64_encode
 from django.contrib.auth.tokens import default_token_generator
 from django.utils.encoding import force_bytes
 from django.template.loader import render_to_string
-from django.core.mail import send_mail, get_connection, EmailMessage
+from django.core.mail import get_connection, EmailMessage
 from django.core.validators import validate_email
 from ciso_assistant.settings import (
     CISO_ASSISTANT_URL,
@@ -788,14 +788,19 @@ class User(ActorSyncMixin, AbstractBaseUser, AbstractBaseModel, FolderMixin):
     def _send_email(self, subject, body, html_body=None):
         """Send an email with primary/rescue server fallback."""
         try:
-            send_mail(
-                subject=subject,
-                message=body,
-                from_email=None,
-                recipient_list=[self.email],
-                fail_silently=False,
-                html_message=html_body,
-            )
+            ssl_context = getattr(settings, "EMAIL_SSL_CONTEXT", None)
+            with get_connection(ssl_context=ssl_context) as connection:
+                msg = EmailMessage(
+                    subject=subject,
+                    body=body,
+                    from_email=None,
+                    to=[self.email],
+                    connection=connection,
+                )
+                if html_body:
+                    msg.content_subtype = "html"
+                    msg.body = html_body
+                msg.send()
             logger.info(
                 "Email sent successfully", recipient=self.email, subject=subject
             )

--- a/enterprise/backend/enterprise_core/settings.py
+++ b/enterprise/backend/enterprise_core/settings.py
@@ -320,7 +320,7 @@ EMAIL_USE_TLS_RESCUE = os.environ.get("EMAIL_USE_TLS_RESCUE", "False").lower() i
     "1",
     "yes",
 )
-EMAIL_FORCE_TLS12 = os.environ.get("EMAIL_FORCE_TLS12", "False").lower() in (
+EMAIL_FORCE_TLS_1_2 = os.environ.get("EMAIL_FORCE_TLS_1_2", "False").lower() in (
     "true",
     "1",
     "yes",
@@ -334,7 +334,7 @@ def _build_tls12_context():
     return context
 
 
-EMAIL_SSL_CONTEXT = _build_tls12_context() if EMAIL_FORCE_TLS12 else None
+EMAIL_SSL_CONTEXT = _build_tls12_context() if EMAIL_FORCE_TLS_1_2 else None
 
 EMAIL_TIMEOUT = int(os.environ.get("EMAIL_TIMEOUT", default="5"))  # seconds
 


### PR DESCRIPTION
Without this variable the negotiation will start in TLS1.3, which seems to block in some contexts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email communications now support optional, environment-configurable enforcement of TLS 1.2 for outbound mail.
  * Email sending has been updated to use a connection-based approach that preserves HTML message content when provided, improving formatting and delivery consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->