### PR TITLE
fix: fallback path management for libraries path

### DIFF
--- a/enterprise/backend/enterprise_core/settings.py
+++ b/enterprise/backend/enterprise_core/settings.py
@@ -507,7 +507,10 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # SQLIte file can be changed, useful for tests
 SQLITE_FILE = os.environ.get("SQLITE_FILE", BASE_DIR / "db/ciso-assistant.sqlite3")
-LIBRARIES_PATH = library_path = BASE_DIR / "library/libraries"
+_lib_path = BASE_DIR / "library/libraries"
+if not _lib_path.is_dir():
+    _lib_path = BASE_DIR.parent.parent / "backend" / "library" / "libraries"
+LIBRARIES_PATH = library_path = _lib_path
 
 if "POSTGRES_NAME" in os.environ:
     DATABASES = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated library path resolution to prefer a local project library directory when present, with automatic fallback to the legacy backend library location. This simplifies directory selection and improves robustness across deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->