### PR TITLE
fix: filter appliedcontols multiple statuses

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -5432,30 +5432,8 @@ class AppliedControlViewSet(ExportMixin, BaseModelViewSet):
 
 
 class ActionPlanList(generics.ListAPIView):
-    filterset_fields = {
-        "folder": ["exact"],
-        "status": ["exact"],
-        "category": ["exact"],
-        "csf_function": ["exact"],
-        "priority": ["exact"],
-        "reference_control": ["exact"],
-        "effort": ["exact"],
-        "control_impact": ["exact"],
-        "filtering_labels": ["exact"],
-        "risk_scenarios": ["exact"],
-        "risk_scenarios_e": ["exact"],
-        "requirement_assessments": ["exact"],
-        "evidences": ["exact"],
-        "objectives": ["exact"],
-        "assets": ["exact"],
-        "stakeholders": ["exact"],
-        "progress_field": ["exact"],
-        "security_exceptions": ["exact"],
-        "owner": ["exact"],
-        "findings": ["exact"],
-        "eta": ["exact", "lte", "gte", "lt", "gt"],
-    }
     search_fields = ["name", "description", "ref_id"]
+    filterset_class = AppliedControlFilterSet
 
     filter_backends = [
         DjangoFilterBackend,


### PR DESCRIPTION
From a reported bug. In a risk assessment's action plan, the related applied controls could be filtered by status, but only for one type. When two sort of statuses were chosen in the filters, only the last checked one was taken into account.
Now that the action plans follows the filtering standards set by the `AppliedControlsFilterSet`, all the fields are filtered correctly and by a more consistent way

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal filter configuration architecture for action plan filtering to enhance code maintainability and reduce duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->