### PR TITLE
fix: implementation groups for dynamic frameworks

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -11507,7 +11507,8 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
             compliance_assessment.get_requirement_assessments(
                 include_non_assessable=True,
                 lightweight=True,
-                skip_ig_filter=_framework.is_dynamic(),
+                skip_ig_filter=_framework.is_dynamic()
+                and not compliance_assessment.selected_implementation_groups,
             )
         )
         # Auditee filtering: scope to assigned requirements only
@@ -11549,7 +11550,10 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
             _framework.max_score,
         )
         implementation_groups = compliance_assessment.selected_implementation_groups
-        if compliance_assessment.framework.is_dynamic():
+        if (
+            compliance_assessment.framework.is_dynamic()
+            and not compliance_assessment.selected_implementation_groups
+        ):
             implementation_groups = None
         return Response(
             filter_graph_by_implementation_groups(tree, implementation_groups)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved implementation group filtering for dynamic framework compliance assessments. The system now correctly respects user-selected implementation groups when applying filters, rather than using uniform filtering. This ensures more accurate assessment results and consistent filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->