### PR TITLE
feat: reflect client name change in page's title

### DIFF
--- a/enterprise/frontend/src/routes/(app)/+layout.svelte
+++ b/enterprise/frontend/src/routes/(app)/+layout.svelte
@@ -135,6 +135,8 @@
 
 	const modalStore: ModalStore = getModalStore();
 
+	const clientSettings = $page.data.clientSettings;
+
 	// Initialize external link interceptor
 	$effect(() => {
 		if (browser) {
@@ -152,7 +154,7 @@
 </script>
 
 <svelte:head>
-	<title>CISO Assistant | {safeTranslate(displayTitle)}</title>
+	<title>{clientSettings.settings.name || 'CISO Assistant'} | {safeTranslate(displayTitle)}</title>
 </svelte:head>
 
 <!-- App Shell -->

--- a/enterprise/frontend/src/routes/(app)/+layout.svelte
+++ b/enterprise/frontend/src/routes/(app)/+layout.svelte
@@ -135,7 +135,7 @@
 
 	const modalStore: ModalStore = getModalStore();
 
-	const clientSettings = $page.data.clientSettings;
+	const clientSettings = $derived($page.data.clientSettings);
 
 	// Initialize external link interceptor
 	$effect(() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Application title is now configurable via client settings, allowing organizations to set a custom product name.
  * If no custom name is provided, the app falls back to "CISO Assistant" and continues to append the current page title as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->