### PR TITLE
fix: "Executive Summary" in "CRQ Studies" fails to load due to an error retrieving the authors' email

### DIFF
--- a/backend/crq/views.py
+++ b/backend/crq/views.py
@@ -656,7 +656,11 @@ class QuantitativeRiskStudyViewSet(BaseModelViewSet):
                 "study_id": str(study.id),
                 "study_name": study.name,
                 "study_description": study.description,
-                "study_authors": [author.email for author in study.authors.all()],
+                "study_authors": [
+                    email
+                    for author in study.authors.all()
+                    for email in author.get_emails()
+                ],
                 "study_folder": {"id": str(study.folder.id), "name": study.folder.name}
                 if study.folder
                 else None,


### PR DESCRIPTION
## Bug

The following error was encountered whenever we tried to access the `Executive Summary` in the `CRQ studies` section when at least 1 author was defined for a study : 

```log
    "study_authors": [author.email for author in study.authors.all()],
                      ^^^^^^^^^^^^
AttributeError: 'Actor' object has no attribute 'email'
```

## Fix

The file `backend/crq/views.py` has been modified in order to fix this issue. The relevant bit of code was trying to access the `email` value instead of calling the `get_emails()` function of an author.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the executive summary to display all email addresses for each study author, rather than limiting to a single email per author. This ensures complete author contact information is now available in study summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->