### PR TITLE
fix: autocompleteSelect creates partial text instead of selecting existing match

### DIFF
--- a/frontend/src/lib/components/Forms/AutocompleteSelect.svelte
+++ b/frontend/src/lib/components/Forms/AutocompleteSelect.svelte
@@ -623,9 +623,26 @@
 		<MultiSelect
 			bind:selected
 			bind:open={multiSelectOpen}
-			options={effectiveLazy && selected.length > 0 && !lazyHasSearched
-				? [...options, { label: m.typeToSearch(), value: LAZY_HINT_VALUE, disabled: true }]
-				: options}
+			options={new Proxy(
+				effectiveLazy && selected.length > 0 && !lazyHasSearched
+					? [...options, { label: m.typeToSearch(), value: LAZY_HINT_VALUE, disabled: true }]
+					: options,
+				{
+					get(target, prop, receiver) {
+						// Fix: svelte-multiselect's add() uses Array.includes() (reference equality) to
+						// check if a clicked option already exists. In Svelte 5, reactive proxy wrapping
+						// breaks reference identity, causing it to overwrite the clicked option with the
+						// raw search text. Override includes() to compare by .value instead.
+						if (prop === 'includes') {
+							return (item: unknown) =>
+								item !== null && typeof item === 'object' && 'value' in (item as object)
+									? (target as Option[]).some((opt) => opt.value === (item as Option).value)
+									: false;
+						}
+						return Reflect.get(target, prop, receiver);
+					}
+				}
+			)}
 			{...multiSelectOptions}
 			outerDivClass="!input !bg-surface-100 !px-2 !flex {overflowCssClass}"
 			disabled={_disabled}


### PR DESCRIPTION
Problem

When using a label field backed by AutocompleteSelect with allowUserOptions="append", typing a partial string (e.g. he) and then clicking an existing matching option (e.g. hello) creates a new label he instead of selecting hello.

The same issue occurs when pressing Enter on the first matching item: the raw typed text gets created as a new option rather than the matching one being selected.

Root Cause

The bug originates in svelte-multiselect's add() function, which uses Array.prototype.includes() (reference equality) to decide whether a clicked/selected option is already in the options list:
```
if (!options.includes(option_to_add)  // reference equality
    && [true, "append"].includes(allowUserOptions)
    && searchText.length > 0) {
    option_to_add = { label: searchText }; // overwrites the real option with raw text!
}
````
The intent is: "if this option doesn't already exist in the list, treat it as user-created text." When options are a static array this works fine because references stay intact from array -> render -> click handler.

In our AutocompleteSelect, options are fetched asynchronously and stored in Svelte 5 `$state([])`. Svelte 5's reactivity system wraps array elements in reactive proxies. By the time a list item is clicked, the proxy instance in the click event differs from the one currently in the options `array.includes()` returns false even for options that are genuinely present, so the overwrite always fires, replacing the clicked option with whatever is in the search box.

In the project we already acknowledged reference instability elsewhere: the component uses `key={JSON.stringify} `on each list item precisely because identity cannot be trusted. This one `includes()` call in `add()` was the last place that still relied on it.

Fix

Wrap the options array passed to MultiSelect in a Proxy that intercepts `Array.prototype.includes()` and replaces reference comparison with value-based comparison:
```
new Proxy(options, {
    get(target, prop, receiver) {
        if (prop === "includes") {
            return (item) =>
                item !== null && typeof item === "object" && "value" in item
                    ? target.some(opt => opt.value === item.value)
                    : false;
        }
        return Reflect.get(target, prop, receiver);
    }
})
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved option matching logic in the autocomplete select component to ensure consistent value-based comparison when selecting and displaying options, particularly in lazy-loading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->