### PR TITLE
feat(ux): Sort domains in asset graph and fix multi-level domain filtering

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -2029,17 +2029,30 @@ class AssetViewSet(ExportMixin, BaseModelViewSet):
             user=request.user,
             object_type=Asset,
         )
-        # Build category index mapping first (key by UUID to avoid name collisions)
-        domain_to_category = {}
-        for domain in Folder.objects.filter(id__in=viewable_folders):
-            categories.append({"name": domain.name})
-            domain_to_category[domain.id] = len(categories) - 1
 
+        def get_domain_key(domain: Folder) -> str:
+            return "/".join(
+                d.name for d in reversed(domain.get_folder_full_path())
+            )
+
+        sorted_domains = sorted(
+            Folder.objects.filter(id__in=viewable_folders), key=get_domain_key
+        )
+        categories = [
+            {"name": domain.get_folder_full_path_string()}
+            for domain in sorted_domains
+        ]
+        # Build category index mapping first (key by UUID to avoid name collisions)
+        domain_to_category = {
+            domain.id: index for index, domain in enumerate(sorted_domains)
+        }
+
+        for domain in sorted_domains:
             if not hide_domains:
                 nodes_idx[domain.id] = N
                 nodes.append(
                     {
-                        "name": domain.name,
+                        "name": domain.get_folder_full_path_string(),
                         "category": domain_to_category[domain.id],
                         "symbol": "roundRect",
                         "symbolSize": 30,

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -2031,16 +2031,13 @@ class AssetViewSet(ExportMixin, BaseModelViewSet):
         )
 
         def get_domain_key(domain: Folder) -> str:
-            return "/".join(
-                d.name for d in reversed(domain.get_folder_full_path())
-            )
+            return "/".join(d.name for d in reversed(domain.get_folder_full_path()))
 
         sorted_domains = sorted(
             Folder.objects.filter(id__in=viewable_folders), key=get_domain_key
         )
         categories = [
-            {"name": domain.get_folder_full_path_string()}
-            for domain in sorted_domains
+            {"name": domain.get_folder_full_path_string()} for domain in sorted_domains
         ]
         # Build category index mapping first (key by UUID to avoid name collisions)
         domain_to_category = {

--- a/backend/iam/models.py
+++ b/backend/iam/models.py
@@ -210,7 +210,9 @@ class Folder(NameDescriptionMixin):
         Return a stringified slash-separated folder path.
         This string is unique per-folder.
         """
-        return "/".join(f.name for f in self.get_folder_full_path(include_root=include_root))
+        return "/".join(
+            f.name for f in self.get_folder_full_path(include_root=include_root)
+        )
 
     @staticmethod
     def _navigate_structure(start, path):

--- a/backend/iam/models.py
+++ b/backend/iam/models.py
@@ -205,6 +205,13 @@ class Folder(NameDescriptionMixin):
         """
         return get_folder_path(self.id, include_root=include_root)
 
+    def get_folder_full_path_string(self, *, include_root: bool = False) -> str:
+        """
+        Return a stringified slash-separated folder path.
+        This string is unique per-folder.
+        """
+        return "/".join(f.name for f in self.get_folder_full_path(include_root=include_root))
+
     @staticmethod
     def _navigate_structure(start, path):
         """

--- a/frontend/src/lib/components/DataViz/GraphExplorer.svelte
+++ b/frontend/src/lib/components/DataViz/GraphExplorer.svelte
@@ -71,7 +71,8 @@
 	const getCustomEdgeFormatter = () => {
 		return (params) => {
 			// Truncate function - truncates text to maxLength and adds ellipsis
-			const truncate = (text, maxLength = 25) => {
+			const truncate = (text) => {
+				const maxLength = 25;
 				if (text.length <= maxLength) return text;
 				return text.substring(0, maxLength) + '...';
 			};


### PR DESCRIPTION
This PR is the improved implementation of this closed PR: https://github.com/intuitem/ciso-assistant-community/pull/2799
It addresses support ticket: `SUP-312`.

This PR MUST be tested with the enterprise version of ciso-assistant (as it requires testing the the `assets/graph` frontend page using nested domains).

[1] Fix the frontend page `/assets/graph` legend domain names not being lexicographically ordered (bad for UX).

[2] Display full folder path in the legend.
- For domains `X`, `Y == X.parent`, `Z == Y.parent` and `Z.parent == Folder.get_root_folder()`:

**[BEFORE]** `X.name` was displayed in the legend.
**[NOW]** `f"{Z.parent.name}/{Y.parent.name}/{X.name}"`.

[3] Fix `<GraphExplorer/>` legend not displaying both folder `X` and `Y` if `X.name == Y.name`.

[4] Change the backend endpoint `assets/graph` domain nodes  `node["name"]` to their stringified domain path instead (using the newly created `Folder(...).get_folder_full_path_string()`).
- For a domain `X` with `X.get_folder_path_string() == "AAA/BBB/CCC/DDD"`

**[BEFORE]** Searching for `"DDD"` match the domain `X` but `"CCC/DDD"` doesn't.
**[NOW]** Searching for `"DDD"`, `"CCC/DDD"`, `"BBB/CCC"`, `"BBB/CCC/DDD"` will all match the domain `X`.

Satisfying the requirement `[4]` by changing the domain `node["name"]` generated by the backend is better than adding some special case to the the `<GraphExplorer/>` `searchNodes` internal function.

The only downside is that the proportion of the `node["name"]` which will be truncated in the tooltip will increase (as the folder path is a superstring of the domain name itself).

This behavior is due `text.substring(0, maxLength)` in the `truncate` internal function and `const truncatedName = truncate(nodeName);`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Domain categories in graph view now display full folder paths for better clarity and context
  * Domain ordering in graphs is now consistent and hierarchy-aware for predictable navigation
  * Tooltip text truncation in graph explorer adjusted to ensure consistent display formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->