### PR TITLE
Fix currencyHelpText typo in French

### DIFF
--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1014,7 +1014,7 @@
 	"faviconHelpText": "Le favicon s'affichera dans l'onglet du navigateur. Les formats acceptés sont ICO, PNG, JPEG, WEBP, SVG.",
 	"financialSettings": "Paramètres financiers",
 	"currency": "Devise",
-	"currencyHelpText": "Sélectionner votre devis pour les champs financiers",
+	"currencyHelpText": "Sélectionner votre devise pour les champs financiers",
 	"dailyRate": "Taux journalier",
 	"dailyRateHelpText": "Nécessaire pour convertir les jours-personnes en montant",
 	"selectComplianceAssessments": "Audits",


### PR DESCRIPTION
Fix typo, from

> Sélectionner votre devis pour les champs financiers

to

> Sélectionner votre devise pour les champs financiers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated French localization file formatting for currency-related help text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->