### PR TITLE
feat: sanitize finding export for round trip

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -14853,7 +14853,10 @@ class FindingsAssessmentViewSet(BaseModelViewSet):
                 "priority": finding.priority if finding.priority is not None else "",
                 "folder": finding.folder.name if finding.folder else "",
                 "filtering_labels": "|".join(
-                    [label.label for label in finding.filtering_labels.all()]
+                    [
+                        escape_excel_formula(label.label)
+                        for label in finding.filtering_labels.all()
+                    ]
                 ),
                 "applied_controls": "\n".join(
                     [
@@ -14863,9 +14866,12 @@ class FindingsAssessmentViewSet(BaseModelViewSet):
                 ),
                 "evidences": "\n".join([ev.name for ev in finding.evidences.all()]),
                 "vulnerabilities": "|".join(
-                    [v.name for v in finding.vulnerabilities.all()]
+                    [
+                        escape_excel_formula(v.name)
+                        for v in finding.vulnerabilities.all()
+                    ]
                 ),
-                "observation": finding.observation or "",
+                "observation": escape_excel_formula(finding.observation),
                 "created_at": finding.created_at.strftime("%Y-%m-%d %H:%M:%S")
                 if finding.created_at
                 else "",

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -14829,7 +14829,16 @@ class FindingsAssessmentViewSet(BaseModelViewSet):
             )
 
         findings_assessment = FindingsAssessment.objects.get(id=pk)
-        findings = Finding.objects.filter(findings_assessment=pk).order_by("ref_id")
+        findings = (
+            Finding.objects.filter(findings_assessment=pk)
+            .prefetch_related(
+                "applied_controls",
+                "evidences",
+                "vulnerabilities",
+                "filtering_labels",
+            )
+            .order_by("ref_id")
+        )
 
         # Prepare data for Excel export
         entries = []
@@ -14838,9 +14847,13 @@ class FindingsAssessmentViewSet(BaseModelViewSet):
                 "ref_id": finding.ref_id,
                 "name": finding.name,
                 "description": finding.description,
-                "status": finding.get_status_display(),
+                "status": finding.status,
                 "severity": finding.get_severity_display(),
+                "priority": finding.priority if finding.priority is not None else "",
                 "folder": finding.folder.name if finding.folder else "",
+                "filtering_labels": "|".join(
+                    [label.label for label in finding.filtering_labels.all()]
+                ),
                 "applied_controls": "\n".join(
                     [
                         f"{ac.name} [{ac.get_status_display().lower()}]"
@@ -14848,6 +14861,10 @@ class FindingsAssessmentViewSet(BaseModelViewSet):
                     ]
                 ),
                 "evidences": "\n".join([ev.name for ev in finding.evidences.all()]),
+                "vulnerabilities": "|".join(
+                    [v.name for v in finding.vulnerabilities.all()]
+                ),
+                "observation": finding.observation or "",
                 "created_at": finding.created_at.strftime("%Y-%m-%d %H:%M:%S")
                 if finding.created_at
                 else "",
@@ -14869,7 +14886,13 @@ class FindingsAssessmentViewSet(BaseModelViewSet):
             worksheet = writer.sheets["Findings"]
 
             # Apply text wrapping to columns with line breaks
-            wrap_columns = ["name", "description", "applied_controls", "evidences"]
+            wrap_columns = [
+                "name",
+                "description",
+                "applied_controls",
+                "evidences",
+                "observation",
+            ]
             wrap_indices = [
                 df.columns.get_loc(col) + 1 for col in wrap_columns if col in df.columns
             ]

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -14831,6 +14831,7 @@ class FindingsAssessmentViewSet(BaseModelViewSet):
         findings_assessment = FindingsAssessment.objects.get(id=pk)
         findings = (
             Finding.objects.filter(findings_assessment=pk)
+            .select_related("folder")
             .prefetch_related(
                 "applied_controls",
                 "evidences",


### PR DESCRIPTION
Ensure round-trip compatibility between the follow-up Excel export and the data wizard import by exporting the raw status value (instead of its display label) and adding the missing importable columns: filtering_labels, priority, observation, and vulnerabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Excel export: added columns for Priority, Filtering Labels, Vulnerabilities, and Observation.
  * Status column now exports raw status values.
  * Labels and vulnerabilities exported as pipe-separated strings.
  * Observation column supports text wrapping and emits an empty value when not present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->