### PR TITLE
feat: update risk assessment import/export

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -6271,10 +6271,15 @@ class RiskScenarioViewSet(ExportMixin, BaseModelViewSet):
                 "label": "risk_assessment",
                 "escape": True,
             },
-            "treatment": {"source": "get_treatment_display", "label": "treatment"},
-            "inherent_probability": {
+            "treatment": {"source": "treatment", "label": "treatment"},
+            "justification": {
+                "source": "justification",
+                "label": "justification",
+                "escape": True,
+            },
+            "inherent_proba": {
                 "source": "get_inherent_proba",
-                "label": "inherent_probability",
+                "label": "inherent_proba",
                 "format": lambda v: v.get("name", "--"),
             },
             "inherent_impact": {
@@ -6287,9 +6292,9 @@ class RiskScenarioViewSet(ExportMixin, BaseModelViewSet):
                 "label": "inherent_level",
                 "format": lambda v: v.get("name", "--"),
             },
-            "current_probability": {
+            "current_proba": {
                 "source": "get_current_proba",
-                "label": "current_probability",
+                "label": "current_proba",
                 "format": lambda v: v.get("name", "--"),
             },
             "current_impact": {
@@ -6302,9 +6307,9 @@ class RiskScenarioViewSet(ExportMixin, BaseModelViewSet):
                 "label": "current_level",
                 "format": lambda v: v.get("name", "--"),
             },
-            "residual_probability": {
+            "residual_proba": {
                 "source": "get_residual_proba",
-                "label": "residual_probability",
+                "label": "residual_proba",
                 "format": lambda v: v.get("name", "--"),
             },
             "residual_impact": {
@@ -6320,50 +6325,57 @@ class RiskScenarioViewSet(ExportMixin, BaseModelViewSet):
             "owners": {
                 "source": "owner",
                 "label": "owners",
-                "format": lambda qs: ",".join(
+                "format": lambda qs: "|".join(
                     escape_excel_formula(str(o)) for o in qs.all()
                 ),
             },
             "threats": {
                 "source": "threats",
                 "label": "threats",
-                "format": lambda qs: ",".join(
+                "format": lambda qs: "|".join(
                     escape_excel_formula(t.name) for t in qs.all()
                 ),
             },
             "assets": {
                 "source": "assets",
                 "label": "assets",
-                "format": lambda qs: ",".join(
+                "format": lambda qs: "|".join(
                     escape_excel_formula(a.name) for a in qs.all()
                 ),
             },
             "vulnerabilities": {
                 "source": "vulnerabilities",
                 "label": "vulnerabilities",
-                "format": lambda qs: ",".join(
+                "format": lambda qs: "|".join(
                     escape_excel_formula(v.name) for v in qs.all()
                 ),
             },
             "applied_controls": {
                 "source": "applied_controls",
                 "label": "applied_controls",
-                "format": lambda qs: ",".join(
+                "format": lambda qs: "|".join(
                     escape_excel_formula(c.name) for c in qs.all()
                 ),
             },
             "existing_applied_controls": {
                 "source": "existing_applied_controls",
                 "label": "existing_applied_controls",
-                "format": lambda qs: ",".join(
+                "format": lambda qs: "|".join(
                     escape_excel_formula(c.name) for c in qs.all()
                 ),
             },
             "qualifications": {
                 "source": "qualifications",
                 "label": "qualifications",
-                "format": lambda qs: ",".join(
+                "format": lambda qs: "|".join(
                     escape_excel_formula(q.name) for q in qs.all()
+                ),
+            },
+            "filtering_labels": {
+                "source": "filtering_labels",
+                "label": "filtering_labels",
+                "format": lambda qs: "|".join(
+                    escape_excel_formula(label.label) for label in qs.all()
                 ),
             },
         },
@@ -6377,6 +6389,7 @@ class RiskScenarioViewSet(ExportMixin, BaseModelViewSet):
             "applied_controls",
             "existing_applied_controls",
             "qualifications",
+            "filtering_labels",
         ],
     }
 

--- a/backend/data_wizard/views.py
+++ b/backend/data_wizard/views.py
@@ -4063,10 +4063,14 @@ class LoadFileView(APIView):
                 "existing_applied_controls",
             )
 
-            # Link additional controls
+            # Link additional controls. Accept both the legacy column name
+            # (`additional_controls`) and the model field name (`applied_controls`,
+            # used by the CSV/XLSX export) for round-trip compatibility.
             self._link_controls_to_scenario(
                 risk_scenario,
-                record.get("additional_controls", ""),
+                record.get("additional_controls")
+                or record.get("applied_controls")
+                or "",
                 control_mapping,
                 "applied_controls",
             )

--- a/backend/data_wizard/views.py
+++ b/backend/data_wizard/views.py
@@ -3774,26 +3774,23 @@ class LoadFileView(APIView):
             matrix_mappings = self._build_matrix_mappings(risk_matrix)
 
             # Process controls first - collect all unique control names
+            # Accept both the legacy column name (`additional_controls`) and the
+            # model field name (`applied_controls`, as used by the export) for the
+            # to-be-added controls column.
             all_controls = set()
             for record in records:
                 existing_controls = record.get("existing_applied_controls", "").strip()
-                additional_controls = record.get("additional_controls", "").strip()
+                additional_controls = (
+                    record.get("additional_controls")
+                    or record.get("applied_controls")
+                    or ""
+                ).strip()
 
                 if existing_controls:
-                    all_controls.update(
-                        [
-                            ctrl.strip()
-                            for ctrl in existing_controls.split("\n")
-                            if ctrl.strip()
-                        ]
-                    )
+                    all_controls.update(self._split_multi_separator(existing_controls))
                 if additional_controls:
                     all_controls.update(
-                        [
-                            ctrl.strip()
-                            for ctrl in additional_controls.split("\n")
-                            if ctrl.strip()
-                        ]
+                        self._split_multi_separator(additional_controls)
                     )
 
             # Create or find controls in the domain
@@ -3810,6 +3807,7 @@ class LoadFileView(APIView):
                         matrix_mappings,
                         control_mapping,
                         request,
+                        domain,
                     )
                     if scenario_data:
                         results["successful"] += 1
@@ -3952,7 +3950,13 @@ class LoadFileView(APIView):
         return control_mapping
 
     def _process_risk_scenario_record(
-        self, record, risk_assessment, matrix_mappings, control_mapping, request
+        self,
+        record,
+        risk_assessment,
+        matrix_mappings,
+        control_mapping,
+        request,
+        domain,
     ):
         """Process a single risk scenario record"""
         try:
@@ -3964,26 +3968,35 @@ class LoadFileView(APIView):
             if not name:
                 raise ValueError("Risk scenario name is required")
 
-            # Map risk values using matrix mappings
+            # Map risk values using matrix mappings. Accept both the short form
+            # (`*_proba`, used historically) and the long form (`*_probability`,
+            # used by the CSV/XLSX export) so that exported files round-trip cleanly.
             inherent_impact = self._map_risk_value(
                 record.get("inherent_impact", ""), matrix_mappings["impact"]
             )
             inherent_proba = self._map_risk_value(
-                record.get("inherent_proba", ""), matrix_mappings["probability"]
+                record.get("inherent_proba")
+                or record.get("inherent_probability")
+                or "",
+                matrix_mappings["probability"],
             )
 
             current_impact = self._map_risk_value(
                 record.get("current_impact", ""), matrix_mappings["impact"]
             )
             current_proba = self._map_risk_value(
-                record.get("current_proba", ""), matrix_mappings["probability"]
+                record.get("current_proba") or record.get("current_probability") or "",
+                matrix_mappings["probability"],
             )
 
             residual_impact = self._map_risk_value(
                 record.get("residual_impact", ""), matrix_mappings["impact"]
             )
             residual_proba = self._map_risk_value(
-                record.get("residual_proba", ""), matrix_mappings["probability"]
+                record.get("residual_proba")
+                or record.get("residual_probability")
+                or "",
+                matrix_mappings["probability"],
             )
 
             logger.debug(
@@ -4015,6 +4028,7 @@ class LoadFileView(APIView):
                     ),
                     "open",
                 ),
+                "justification": record.get("justification", "") or "",
             }
 
             # Create the risk scenario
@@ -4057,6 +4071,11 @@ class LoadFileView(APIView):
                 "applied_controls",
             )
 
+            # Link assets (must already exist in the domain folder)
+            self._link_assets_to_scenario(
+                risk_scenario, record.get("assets", ""), domain
+            )
+
             return risk_scenario
 
         except Exception as e:
@@ -4087,6 +4106,13 @@ class LoadFileView(APIView):
         )
         return -1
 
+    @staticmethod
+    def _split_multi_separator(text: str) -> list[str]:
+        """Split a string on newline, pipe, semicolon or comma and return trimmed, non-empty items."""
+        if not text:
+            return []
+        return [item.strip() for item in re.split(r"[\n|;,]", text) if item.strip()]
+
     def _link_controls_to_scenario(
         self, risk_scenario, controls_text, control_mapping, field_name
     ):
@@ -4094,9 +4120,7 @@ class LoadFileView(APIView):
         if not controls_text:
             return
 
-        control_names = [
-            ctrl.strip() for ctrl in controls_text.split("\n") if ctrl.strip()
-        ]
+        control_names = self._split_multi_separator(controls_text)
         control_ids = []
 
         for control_name in control_names:
@@ -4107,6 +4131,38 @@ class LoadFileView(APIView):
             # Get the field and set the many-to-many relationship
             field = getattr(risk_scenario, field_name)
             field.set(control_ids)
+
+    def _link_assets_to_scenario(self, risk_scenario, assets_text, domain):
+        """Link assets to a risk scenario based on asset names.
+
+        Assets are looked up by name within the domain folder. Missing assets are
+        created with the model's default type (SUPPORT); users can re-classify
+        them afterward from the UI.
+        """
+        if not assets_text:
+            return
+
+        asset_names = self._split_multi_separator(assets_text)
+        asset_ids = []
+
+        for asset_name in asset_names:
+            try:
+                asset, created = Asset.objects.get_or_create(
+                    name=asset_name, folder=domain
+                )
+                if created:
+                    logger.info(
+                        f"Created asset '{asset_name}' in domain '{domain.name}' "
+                        f"with default type '{asset.get_type_display()}'"
+                    )
+                asset_ids.append(asset.id)
+            except Exception:
+                logger.exception(
+                    f"Failed to resolve asset '{asset_name}' in domain '{domain.name}'"
+                )
+
+        if asset_ids:
+            risk_scenario.assets.set(asset_ids)
 
     def _process_ebios_rm_study_arm(
         self,

--- a/documentation/data_wizard_analysis.md
+++ b/documentation/data_wizard_analysis.md
@@ -284,19 +284,19 @@ For frameworks using dynamic questionnaires, the export/import supports flattene
 | `current_proba` | No | |
 | `residual_impact` | No | |
 | `residual_proba` | No | |
-| `existing_applied_controls` | No | Newline-separated, creates/finds controls |
-| `additional_controls` | No | Newline-separated |
+| `existing_applied_controls` | No | Pipe-, newline-, semicolon- or comma-separated; matching controls are created or found in the domain |
+| `additional_controls` | No | Pipe-, newline-, semicolon- or comma-separated; matching controls are created or found in the domain. Alias: `applied_controls` (used by the CSV/XLSX export). |
 | `treatment` | No | Defaults to "open" |
 | `filtering_labels` | No | Pipe- or comma-separated label names (created if missing, set post-save) |
+| `justification` | No | Free text (max 2000 chars) |
+| `assets` | No | Pipe-, newline-, semicolon- or comma-separated asset names. Missing assets are auto-created in the domain folder with the default type **Support**; users can re-classify them afterward from the UI. |
 
 **Missing RiskScenario Fields:**
 | Field | Type | Priority |
 |-------|------|----------|
 | `strength_of_knowledge` | CharField | Medium |
-| `justification` | TextField | Medium |
 | `owner` | FK User | High |
 | `threats` | M2M | High |
-| `assets` | M2M | High |
 | `vulnerabilities` | M2M | Medium |
 
 ---


### PR DESCRIPTION
Ensure that a risk assessment exported to CSV/XLSX can be re-imported
cleanly through the data wizard:

- Add `assets` and `justification` handling to the import (assets are
  auto-created in the domain folder with the default Support type when
  missing).
- Accept pipe, newline, semicolon or comma as separators for all
  multi-value columns (controls, assets).
- Align naming between export and import: accept both short (`*_proba`)
  and long (`*_probability`) forms, as well as `additional_controls`
  and `applied_controls` for the to-be-added controls column.
- Export the raw `treatment` value instead of its localized display so
  round-trip works across locales.
- Add `filtering_labels` and `justification` columns to the export.
- Switch M2M joins in the export from comma to pipe to avoid collisions
  with the CSV delimiter and with commas inside asset/control names.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exports: added justification and filtering labels columns.
  * Imports: assets can be linked/created during import and justification is preserved.

* **Improvements**
  * Probability export column names standardized (short *_proba variants).
  * Multi-value import/export fields now accept multiple delimiters and exports use pipe delimiters.
  * Import accepts both short and long probability column names and legacy control field names.

* **Documentation**
  * Updated import/export field mapping and asset/control parsing guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->