### PR TITLE
feat: turn the justification in markdown format field

### DIFF
--- a/frontend/src/lib/components/DetailView/DetailView.svelte
+++ b/frontend/src/lib/components/DetailView/DetailView.svelte
@@ -694,7 +694,7 @@
 												>
 											{:else if ISO_8601_REGEX.test(value) && dateFieldsToFormat.includes(key)}
 												{formatDateOrDateTime(value, getLocale())}
-											{:else if key === 'description' || key === 'observation' || key === 'annotation'}
+											{:else if key === 'description' || key === 'observation' || key === 'annotation' || key === 'justification'}
 												<MarkdownRenderer content={value} />
 											{:else if typeof value === 'boolean'}
 												{@const bd = booleanDisplay(value, key, data.urlModel)}

--- a/frontend/src/lib/components/Forms/ModelForm/FearedEventForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/FearedEventForm.svelte
@@ -8,6 +8,7 @@
 	import { m } from '$paraglide/messages';
 	import TextArea from '../TextArea.svelte';
 	import Checkbox from '$lib/components/Forms/Checkbox.svelte';
+	import MarkdownField from '$lib/components/Forms/MarkdownField.svelte';
 
 	interface Props {
 		form: SuperValidated<any>;
@@ -59,12 +60,13 @@
 	bind:cachedValue={formDataCache['gravity']}
 	helpText={m.gravityHelpText()}
 />
-<TextArea
+<MarkdownField
 	{form}
 	field="justification"
 	label={m.justification()}
 	cacheLock={cacheLocks['justification']}
 	bind:cachedValue={formDataCache['justification']}
+	data-focusindex="1"
 />
 <AutocompleteSelect
 	multiple


### PR DESCRIPTION
This PR makes it possible to edit the justification field of the feared event in markdown format
<img width="391" height="140" alt="justification_exemple_markdown" src="https://github.com/user-attachments/assets/484cf668-39b3-481f-85df-3aa0822cfe0c" />

## How to test
1. Create an EbiosRM study
2. In workshop 1, step 3 go to the feared event identification page
3. The justification field is under markdown format


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Form justification field now supports Markdown formatting for richer text input and improved focus behavior.
  * Detail views now render justification as formatted Markdown so saved content displays with proper formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->