### PR TITLE
fix(ui): truncate long options on AutoComplete Select choices

### DIFF
--- a/frontend/src/lib/components/Forms/AutocompleteSelect.svelte
+++ b/frontend/src/lib/components/Forms/AutocompleteSelect.svelte
@@ -719,16 +719,18 @@
 							{/each}
 						</span>
 					{/if}
-					{#if translateOptions && option}
-						{#if field === 'ro_to_couple'}
-							{@const [firstPart, ...restParts] = option.label.split(' - ')}
-							{safeTranslate(firstPart)} - {restParts.join(' - ')}
+					<span class="inline-block max-w-[30ch] truncate align-bottom" title={option.label}>
+						{#if translateOptions && option}
+							{#if field === 'ro_to_couple'}
+								{@const [firstPart, ...restParts] = option.label.split(' - ')}
+								{safeTranslate(firstPart)} - {restParts.join(' - ')}
+							{:else}
+								{option.translatedLabel}
+							{/if}
 						{:else}
-							{option.translatedLabel}
+							{option.label || option}
 						{/if}
-					{:else}
-						{option.label || option}
-					{/if}
+					</span>
 					{#if option.infoString?.position === 'suffix'}
 						<span class="text-xs text-surface-500">&nbsp;{option.infoString.string}</span>
 					{/if}

--- a/frontend/src/lib/components/Forms/AutocompleteSelect.svelte
+++ b/frontend/src/lib/components/Forms/AutocompleteSelect.svelte
@@ -704,6 +704,15 @@
 				{#if overflowCount > 0 && chipIdx === maxVisibleChips}
 					<span use:styleAsBadge>+{overflowCount}</span>
 				{:else}
+					{@const coupleParts =
+						translateOptions && field === 'ro_to_couple' && typeof option.label === 'string'
+							? option.label.split(' - ')
+							: null}
+					{@const displayLabel = coupleParts
+						? `${safeTranslate(coupleParts[0])} - ${coupleParts.slice(1).join(' - ')}`
+						: translateOptions
+							? (option.translatedLabel ?? option.label ?? option)
+							: (option.label ?? option)}
 					{#if option.infoString?.position === 'prefix'}
 						<span class="text-xs text-surface-500">&nbsp;{option.infoString.string}</span>
 					{/if}
@@ -719,17 +728,8 @@
 							{/each}
 						</span>
 					{/if}
-					<span class="inline-block max-w-[30ch] truncate align-bottom" title={option.label}>
-						{#if translateOptions && option}
-							{#if field === 'ro_to_couple'}
-								{@const [firstPart, ...restParts] = option.label.split(' - ')}
-								{safeTranslate(firstPart)} - {restParts.join(' - ')}
-							{:else}
-								{option.translatedLabel}
-							{/if}
-						{:else}
-							{option.label || option}
-						{/if}
+					<span class="inline-block max-w-[30ch] truncate align-bottom" title={displayLabel}>
+						{displayLabel}
 					</span>
 					{#if option.infoString?.position === 'suffix'}
 						<span class="text-xs text-surface-500">&nbsp;{option.infoString.string}</span>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved label rendering in autocomplete chips: better fallback selection and correct handling of translated labels (including special-casing for the related field).
  * Fixed text overflow in autocomplete chips by adding truncation with a hover tooltip to show the full label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->