### PR TITLE
fix: disable evidences creation on the fly for now from task's autocomplete

### DIFF
--- a/frontend/src/lib/components/Forms/ModelForm/TaskTemplateForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/TaskTemplateForm.svelte
@@ -225,7 +225,6 @@
 	helpText={m.taskTemplateEvidenceHelpText()}
 	field="evidences"
 	label={m.evidences()}
-	allowUserOptions="append"
 	translateOptions={false}
 />
 <AutocompleteSelect


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Modified the evidences field behavior in task template forms to prevent custom option additions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->