### PR TITLE
fix: add plural for target frameworks in campaigns

### DIFF
--- a/frontend/messages/ar.json
+++ b/frontend/messages/ar.json
@@ -721,6 +721,7 @@
 	"requirementMappings": "تعيينات المتطلبات",
 	"sourceFramework": "إطار المصدر",
 	"targetFramework": "الإطار المستهدف",
+	"targetFrameworks": "الأطر المستهدفة",
 	"baseline": "خط الأساس",
 	"createAuditFromBaseline": "إنشاء التدقيق من خط الأساس",
 	"coverageColon": "التغطية:",

--- a/frontend/messages/cs.json
+++ b/frontend/messages/cs.json
@@ -723,6 +723,7 @@
 	"requirementMappings": "Mapování požadavků",
 	"sourceFramework": "Zdrojový rámec",
 	"targetFramework": "Cílový rámec",
+	"targetFrameworks": "Cílové rámce",
 	"baseline": "Základní úroveň",
 	"createAuditFromBaseline": "Vytvořit audit z základní úrovně",
 	"coverageColon": "Pokrytí:",

--- a/frontend/messages/da.json
+++ b/frontend/messages/da.json
@@ -734,6 +734,7 @@
 	"requirementMappings": "Kravkortlægninger",
 	"sourceFramework": "Kilde-rammeværk",
 	"targetFramework": "Mål-rammeværk",
+	"targetFrameworks": "Mål-rammeværker",
 	"baseline": "Baseline",
 	"createAuditFromBaseline": "Opret revision fra baseline",
 	"coverageColon": "Dækning:",

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -695,6 +695,7 @@
 	"requirementMappings": "Anforderungszuordnungen",
 	"sourceFramework": "Quellreferenzwerk",
 	"targetFramework": "Zielreferenzwerk",
+	"targetFrameworks": "Zielreferenzwerke",
 	"baseline": "Baseline",
 	"createAuditFromBaseline": "Audit aus Baseline erstellen",
 	"coverageColon": "Abdeckung:",

--- a/frontend/messages/el.json
+++ b/frontend/messages/el.json
@@ -769,6 +769,7 @@
 	"requirementMappings": "Χαρτογραφήσεις απαιτήσεων",
 	"sourceFramework": "Πηγαίο πλαίσιο",
 	"targetFramework": "Στοχευμένο πλαίσιο",
+	"targetFrameworks": "Στοχευμένα πλαίσια",
 	"baseline": "Βασική γραμμή",
 	"createAuditFromBaseline": "Δημιουργία ελέγχου από βασική γραμμή",
 	"coverageColon": "Κάλυψη:",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1013,6 +1013,7 @@
 	"requirementMappings": "Requirement mappings",
 	"sourceFramework": "Source framework",
 	"targetFramework": "Target framework",
+	"targetFrameworks": "Target frameworks",
 	"baseline": "Baseline",
 	"ebiosRmBaseline": "Foundations",
 	"createAuditFromBaseline": "Apply a mapping",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -695,6 +695,7 @@
 	"requirementMappings": "Mappings de requisitos",
 	"sourceFramework": "Marco de trabajo",
 	"targetFramework": "Marco de destino",
+	"targetFrameworks": "Marcos de destino",
 	"baseline": "Base",
 	"createAuditFromBaseline": "Crear auditoría desde una base",
 	"coverageColon": "Cobertura:",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -910,6 +910,7 @@
 	"requirementMappings": "Mappings des exigences",
 	"sourceFramework": "Référentiel source",
 	"targetFramework": "Référentiel cible",
+	"targetFrameworks": "Référentiels cibles",
 	"baseline": "Référentiel de base",
 	"ebiosRmBaseline": "Socle de sécurité",
 	"createAuditFromBaseline": "Appliquer un mapping",

--- a/frontend/messages/hi.json
+++ b/frontend/messages/hi.json
@@ -722,6 +722,7 @@
 	"requirementMappings": "आवश्यकता मैपिंग्स",
 	"sourceFramework": "स्रोत फ्रेमवर्क",
 	"targetFramework": "लक्ष्य फ्रेमवर्क",
+	"targetFrameworks": "लक्ष्य फ्रेमवर्क्स",
 	"baseline": "आधार रेखा",
 	"createAuditFromBaseline": "आधार रेखा से ऑडिट बनाएं",
 	"coverageColon": "कवरेज:",

--- a/frontend/messages/hr.json
+++ b/frontend/messages/hr.json
@@ -781,6 +781,7 @@
 	"requirementMappings": "Mapiranja zahtjeva",
 	"sourceFramework": "Izvorišni okvir",
 	"targetFramework": "Odredišni okvir",
+	"targetFrameworks": "Odredišni okviri",
 	"baseline": "Osnovna vrijednost",
 	"createAuditFromBaseline": "Mapiraj ili kloniraj audit",
 	"coverageColon": "Pokrivenost:",

--- a/frontend/messages/hu.json
+++ b/frontend/messages/hu.json
@@ -725,6 +725,7 @@
 	"requirementMappings": "Követelmény-leképezés",
 	"sourceFramework": "Forráskeret",
 	"targetFramework": "Célkeret",
+	"targetFrameworks": "Célkeretek",
 	"baseline": "Alapállapot",
 	"createAuditFromBaseline": "Audit létrehozása az alapállapotból.",
 	"coverageColon": "Lefedettség:",

--- a/frontend/messages/id.json
+++ b/frontend/messages/id.json
@@ -725,6 +725,7 @@
 	"requirementMappings": "Pemetaan persyaratan",
 	"sourceFramework": "Kerangka sumber",
 	"targetFramework": "Kerangka target",
+	"targetFrameworks": "Kerangka target",
 	"baseline": "Garis dasar",
 	"createAuditFromBaseline": "Buat audit dari garis dasar",
 	"coverageColon": "Cakupan:",

--- a/frontend/messages/it.json
+++ b/frontend/messages/it.json
@@ -704,6 +704,7 @@
 	"requirementMappings": "Mappature requisiti",
 	"sourceFramework": "Framework sorgente",
 	"targetFramework": "Framework target",
+	"targetFrameworks": "Framework target",
 	"baseline": "Baseline",
 	"createAuditFromBaseline": "Crea audit dalla baseline",
 	"coverageColon": "Copertura:",

--- a/frontend/messages/ko.json
+++ b/frontend/messages/ko.json
@@ -956,6 +956,7 @@
 	"requirementMappings": "요구사항 매핑",
 	"sourceFramework": "원본 프레임워크",
 	"targetFramework": "대상 프레임워크",
+	"targetFrameworks": "대상 프레임워크",
 	"baseline": "기준선",
 	"ebiosRmBaseline": "기반",
 	"createAuditFromBaseline": "매핑 적용",

--- a/frontend/messages/lt.json
+++ b/frontend/messages/lt.json
@@ -1010,6 +1010,7 @@
 	"requirementMappings": "Reikalavimų susiejimai",
 	"sourceFramework": "Šaltinio sistema",
 	"targetFramework": "Tikslinė sistema",
+	"targetFrameworks": "Tikslinės sistemos",
 	"baseline": "Bazinis lygis",
 	"ebiosRmBaseline": "Pagrindai",
 	"createAuditFromBaseline": "Taikyti susiejimą",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -695,6 +695,7 @@
 	"requirementMappings": "Vereistentoewijzingen",
 	"sourceFramework": "Bronkader",
 	"targetFramework": "Doelkader",
+	"targetFrameworks": "Doelkaders",
 	"baseline": "Basislijn",
 	"createAuditFromBaseline": "Creëer audit vanuit een basis",
 	"coverageColon": "Dekking:",

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -771,6 +771,7 @@
 	"requirementMappings": "Mapowania wymagań",
 	"sourceFramework": "Struktura źródłowa",
 	"targetFramework": "Struktura docelowa",
+	"targetFrameworks": "Struktury docelowe",
 	"baseline": "Linia bazowa",
 	"createAuditFromBaseline": "Utwórz audyt od poziomu bazowego",
 	"coverageColon": "Zasięg:",

--- a/frontend/messages/pt.json
+++ b/frontend/messages/pt.json
@@ -723,6 +723,7 @@
 	"requirementMappings": "Mapeamentos de requisitos",
 	"sourceFramework": "Quadro de origem",
 	"targetFramework": "Quadro de objectivos",
+	"targetFrameworks": "Quadros de objectivos",
 	"baseline": "Linha de base",
 	"createAuditFromBaseline": "Criar auditoria a partir de uma base",
 	"coverageColon": "Cobertura:",

--- a/frontend/messages/ro.json
+++ b/frontend/messages/ro.json
@@ -722,6 +722,7 @@
 	"requirementMappings": "Mapări ale cerințelor",
 	"sourceFramework": "Cadru sursă",
 	"targetFramework": "Cadru țintă",
+	"targetFrameworks": "Cadre țintă",
 	"baseline": "Bază",
 	"createAuditFromBaseline": "Creați audit din bază",
 	"coverageColon": "Acoperire:",

--- a/frontend/messages/sv.json
+++ b/frontend/messages/sv.json
@@ -724,6 +724,7 @@
 	"requirementMappings": "Kravkartläggningar",
 	"sourceFramework": "Källramverk",
 	"targetFramework": "Målramverk",
+	"targetFrameworks": "Målramverk",
 	"baseline": "Baslinje",
 	"createAuditFromBaseline": "Skapa revision från baslinje",
 	"coverageColon": "Täckning:",

--- a/frontend/messages/tr.json
+++ b/frontend/messages/tr.json
@@ -770,6 +770,7 @@
 	"requirementMappings": "Gereksinim eşlemeleri",
 	"sourceFramework": "Kaynak çerçeve",
 	"targetFramework": "Hedef çerçeve",
+	"targetFrameworks": "Hedef çerçeveler",
 	"baseline": "Taban çizgisi",
 	"createAuditFromBaseline": "Taban çizgisinden denetim oluştur",
 	"coverageColon": "Kapsam:",

--- a/frontend/messages/uk.json
+++ b/frontend/messages/uk.json
@@ -738,6 +738,7 @@
 	"requirementMappings": "Вимоги маппінгів",
 	"sourceFramework": "Вихідний фреймворк",
 	"targetFramework": "Цільовий фреймворк",
+	"targetFrameworks": "Цільові фреймворки",
 	"baseline": "База",
 	"createAuditFromBaseline": "Створити аудит з базового",
 	"coverageColon": "Покриття:",

--- a/frontend/messages/ur.json
+++ b/frontend/messages/ur.json
@@ -721,6 +721,7 @@
 	"requirementMappings": "ضرورت کی نقشہ سازی",
 	"sourceFramework": "ماخذ فریم ورک",
 	"targetFramework": "ہدف فریم ورک",
+	"targetFrameworks": "ہدف فریم ورکس",
 	"baseline": "بنیاد",
 	"createAuditFromBaseline": "بنیاد سے آڈٹ بنائیں",
 	"coverageColon": "کوریج:",

--- a/frontend/messages/zh.json
+++ b/frontend/messages/zh.json
@@ -878,6 +878,7 @@
 	"requirementMappings": "要求映射",
 	"sourceFramework": "源框架",
 	"targetFramework": "目标框架",
+	"targetFrameworks": "目标框架",
 	"baseline": "基线",
 	"ebiosRmBaseline": "基础",
 	"createAuditFromBaseline": "应用映射",

--- a/frontend/src/lib/components/Forms/ModelForm/CampaignForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/CampaignForm.svelte
@@ -58,7 +58,7 @@
 	field="frameworks"
 	cacheLock={cacheLocks['frameworks']}
 	bind:cachedValue={formDataCache['frameworks']}
-	label={m.targetFramework()}
+	label={m.targetFrameworks()}
 	hidden={initialData.frameworks}
 	onChange={async (e) => handleFrameworkChange(e)}
 	mount={async (e) => handleFrameworkChange(e)}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Localization**
- Added multilingual support for plural "target frameworks" label across 24 languages, replacing the singular form in the UI for improved clarity when displaying multiple target framework selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->