### PR TITLE
fix: 500 error and residual tabs when hiding fields on a framework

### DIFF
--- a/backend/app_tests/api/test_api_requirement_assessments.py
+++ b/backend/app_tests/api/test_api_requirement_assessments.py
@@ -128,9 +128,11 @@ class TestRequirementAssessmentsAuthenticated:
                     "max_score": compliance_assessment.max_score,
                     "extended_result_enabled": compliance_assessment.extended_result_enabled,
                     "progress_status_enabled": compliance_assessment.progress_status_enabled,
+                    "field_visibility": compliance_assessment.field_visibility,
                     "name": compliance_assessment.name,
                     "framework": {
                         "implementation_groups_definition": compliance_assessment.framework.implementation_groups_definition,
+                        "field_visibility": compliance_assessment.framework.field_visibility,
                         "str": str(compliance_assessment.framework),
                     },
                 },
@@ -219,9 +221,11 @@ class TestRequirementAssessmentsAuthenticated:
                     "max_score": compliance_assessment.max_score,
                     "extended_result_enabled": compliance_assessment.extended_result_enabled,
                     "progress_status_enabled": compliance_assessment.progress_status_enabled,
+                    "field_visibility": compliance_assessment.field_visibility,
                     "name": compliance_assessment.name,
                     "framework": {
                         "implementation_groups_definition": compliance_assessment.framework.implementation_groups_definition,
+                        "field_visibility": compliance_assessment.framework.field_visibility,
                         "str": str(compliance_assessment.framework),
                     },
                 }
@@ -278,9 +282,11 @@ class TestRequirementAssessmentsAuthenticated:
                     "max_score": compliance_assessment.max_score,
                     "extended_result_enabled": compliance_assessment.extended_result_enabled,
                     "progress_status_enabled": compliance_assessment.progress_status_enabled,
+                    "field_visibility": compliance_assessment.field_visibility,
                     "name": compliance_assessment.name,
                     "framework": {
                         "implementation_groups_definition": compliance_assessment.framework.implementation_groups_definition,
+                        "field_visibility": compliance_assessment.framework.field_visibility,
                         "str": str(compliance_assessment.framework),
                     },
                 },

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -2673,7 +2673,8 @@ class RequirementAssessmentReadSerializer(BaseModelSerializer):
             "max_score",
             "progress_status_enabled",
             "extended_result_enabled",
-            {"framework": ["implementation_groups_definition"]},
+            "field_visibility",
+            {"framework": ["implementation_groups_definition", "field_visibility"]},
         ]
     )
     folder = FieldsRelatedField()

--- a/frontend/src/lib/utils/helpers.ts
+++ b/frontend/src/lib/utils/helpers.ts
@@ -394,7 +394,9 @@ export function getFieldVisibility(
 	viewerRole: 'respondent' | 'auditor' = 'auditor'
 ): {
 	showResult: boolean;
+	showStatus: boolean;
 	showScore: boolean;
+	showDocumentationScore: boolean;
 	showObservation: boolean;
 	showAppliedControls: boolean;
 	showEvidences: boolean;
@@ -402,7 +404,14 @@ export function getFieldVisibility(
 } {
 	return {
 		showResult: isFieldVisible(framework, complianceAssessment, 'result', viewerRole),
+		showStatus: isFieldVisible(framework, complianceAssessment, 'status', viewerRole),
 		showScore: isFieldVisible(framework, complianceAssessment, 'score', viewerRole),
+		showDocumentationScore: isFieldVisible(
+			framework,
+			complianceAssessment,
+			'documentation_score',
+			viewerRole
+		),
 		showObservation: isFieldVisible(framework, complianceAssessment, 'observation', viewerRole),
 		showAppliedControls: isFieldVisible(
 			framework,

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/+page.server.ts
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/+page.server.ts
@@ -19,7 +19,11 @@ export const load = (async ({ fetch, params }) => {
 		`${BASE_API_URL}/compliance-assessments/${requirementAssessment.compliance_assessment.id}/requirements_list/?assessable=true`
 	)
 		.then((res) => (res.ok ? res.json() : null))
-		.catch(() => null);
+		.catch((error) => {
+			console.error('Failed to fetch requirement viewer role:', error);
+			return null;
+		});
+	const viewerRole = requirementsListData?.viewer_role === 'auditor' ? 'auditor' : 'respondent';
 
 	const tables: Record<string, any> = {};
 
@@ -45,6 +49,6 @@ export const load = (async ({ fetch, params }) => {
 		parent,
 		tables,
 		title: requirementAssessment.name,
-		viewerRole: requirementsListData?.viewer_role ?? 'auditor'
+		viewerRole
 	};
 }) satisfies PageServerLoad;

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/+page.server.ts
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/+page.server.ts
@@ -15,6 +15,12 @@ export const load = (async ({ fetch, params }) => {
 	const requirement = requirementAssessment.requirement;
 	const parent = requirementAssessment.requirement.parent_requirement;
 
+	const requirementsListData = await fetch(
+		`${BASE_API_URL}/compliance-assessments/${requirementAssessment.compliance_assessment.id}/requirements_list/?assessable=true`
+	)
+		.then((res) => (res.ok ? res.json() : null))
+		.catch(() => null);
+
 	const tables: Record<string, any> = {};
 
 	for (const key of ['applied-controls', 'evidences'] as urlModel[]) {
@@ -38,6 +44,7 @@ export const load = (async ({ fetch, params }) => {
 		requirement,
 		parent,
 		tables,
-		title: requirementAssessment.name
+		title: requirementAssessment.name,
+		viewerRole: requirementsListData?.viewer_role ?? 'auditor'
 	};
 }) satisfies PageServerLoad;

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/+page.svelte
@@ -6,6 +6,7 @@
 	import {
 		displayScoreColor,
 		formatScoreValue,
+		getFieldVisibility,
 		getRequirementTitle,
 		getSecureRedirect
 	} from '$lib/utils/helpers';
@@ -77,7 +78,23 @@
 
 	let expandedInferences = $state(false);
 
-	let group = $state(page.data.user.is_third_party ? 'evidence' : 'applied_controls');
+	const fw = data.requirementAssessment.compliance_assessment.framework;
+	const complianceAssessment = data.requirementAssessment.compliance_assessment;
+	const viewerRole: 'respondent' | 'auditor' = (data.viewerRole ?? 'auditor') as
+		| 'respondent'
+		| 'auditor';
+	const { showAppliedControls, showEvidences } = getFieldVisibility(
+		fw,
+		complianceAssessment,
+		viewerRole
+	);
+
+	function pickDefaultTab(): string {
+		if (showAppliedControls && !page.data.user.is_third_party) return 'applied_controls';
+		if (showEvidences) return 'evidence';
+		return 'applied_controls';
+	}
+	let group = $state(pickDefaultTab());
 </script>
 
 <div class="card space-y-2 p-4 bg-white shadow-sm">
@@ -318,55 +335,61 @@
 			{/if}
 		</div>
 	{/if}
-	<div>
-		<Tabs
-			value={group}
-			onValueChange={(e) => {
-				group = e.value;
-			}}
-		>
-			<Tabs.List>
-				{#if !page.data.user.is_third_party}
-					<Tabs.Trigger value="applied_controls">{m.appliedControls()}</Tabs.Trigger>
+	{#if showAppliedControls || showEvidences}
+		<div>
+			<Tabs
+				value={group}
+				onValueChange={(e) => {
+					group = e.value;
+				}}
+			>
+				<Tabs.List>
+					{#if showAppliedControls && !page.data.user.is_third_party}
+						<Tabs.Trigger value="applied_controls">{m.appliedControls()}</Tabs.Trigger>
+					{/if}
+					{#if showEvidences}
+						<Tabs.Trigger value="evidence">{m.evidences()}</Tabs.Trigger>
+					{/if}
+					<Tabs.Indicator />
+				</Tabs.List>
+				{#if showAppliedControls && !page.data.user.is_third_party}
+					<Tabs.Content value="applied_controls">
+						<div class="flex items-center mb-2 px-2 text-xs space-x-2">
+							<i class="fa-solid fa-info-circle"></i>
+							<p>{m.requirementAppliedControlHelpText()}</p>
+						</div>
+						<div class="h-full flex flex-col space-y-2 rounded-container p-4">
+							<ModelTable
+								source={data.tables['applied-controls']}
+								hideFilters={true}
+								URLModel="applied-controls"
+								expectedCount={countMasked(data.requirementAssessment.applied_controls)}
+								baseEndpoint="/applied-controls?requirement_assessments={page.data
+									.requirementAssessment.id}"
+							/>
+						</div>
+					</Tabs.Content>
 				{/if}
-				<Tabs.Trigger value="evidence">{m.evidences()}</Tabs.Trigger>
-				<Tabs.Indicator />
-			</Tabs.List>
-			<Tabs.Content value="applied_controls">
-				{#if !page.data.user.is_third_party}
-					<div class="flex items-center mb-2 px-2 text-xs space-x-2">
-						<i class="fa-solid fa-info-circle"></i>
-						<p>{m.requirementAppliedControlHelpText()}</p>
-					</div>
-					<div class="h-full flex flex-col space-y-2 rounded-container p-4">
-						<ModelTable
-							source={data.tables['applied-controls']}
-							hideFilters={true}
-							URLModel="applied-controls"
-							expectedCount={countMasked(data.requirementAssessment.applied_controls)}
-							baseEndpoint="/applied-controls?requirement_assessments={page.data
-								.requirementAssessment.id}"
-						/>
-					</div>
+				{#if showEvidences}
+					<Tabs.Content value="evidence">
+						<div class="flex items-center mb-2 px-2 text-xs space-x-2">
+							<i class="fa-solid fa-info-circle"></i>
+							<p>{m.requirementEvidenceHelpText()}</p>
+						</div>
+						<div class="h-full flex flex-col space-y-2 rounded-container p-4">
+							<ModelTable
+								source={data.tables['evidences']}
+								hideFilters={true}
+								URLModel="evidences"
+								expectedCount={countMasked(data.requirementAssessment.evidences)}
+								baseEndpoint="/evidences?requirement_assessments={page.data.requirementAssessment.id}"
+							/>
+						</div>
+					</Tabs.Content>
 				{/if}
-			</Tabs.Content>
-			<Tabs.Content value="evidence">
-				<div class="flex items-center mb-2 px-2 text-xs space-x-2">
-					<i class="fa-solid fa-info-circle"></i>
-					<p>{m.requirementEvidenceHelpText()}</p>
-				</div>
-				<div class="h-full flex flex-col space-y-2 rounded-container p-4">
-					<ModelTable
-						source={data.tables['evidences']}
-						hideFilters={true}
-						URLModel="evidences"
-						expectedCount={countMasked(data.requirementAssessment.evidences)}
-						baseEndpoint="/evidences?requirement_assessments={page.data.requirementAssessment.id}"
-					/>
-				</div>
-			</Tabs.Content>
-		</Tabs>
-	</div>
+			</Tabs>
+		</div>
+	{/if}
 	{#if data.requirementAssessment.requirement.questions != null && Object.keys(data.requirementAssessment.requirement.questions).length !== 0}
 		<h1 class="font-semibold text-sm">{m.questions()}</h1>
 		{#each Object.entries(data.requirementAssessment.requirement.questions) as [urn, question]}

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/+page.svelte
@@ -80,9 +80,8 @@
 
 	const fw = data.requirementAssessment.compliance_assessment.framework;
 	const complianceAssessment = data.requirementAssessment.compliance_assessment;
-	const viewerRole: 'respondent' | 'auditor' = (data.viewerRole ?? 'auditor') as
-		| 'respondent'
-		| 'auditor';
+	const viewerRole: 'respondent' | 'auditor' =
+		data.viewerRole === 'auditor' ? 'auditor' : 'respondent';
 	const {
 		showAppliedControls,
 		showEvidences,
@@ -92,8 +91,10 @@
 		showDocumentationScore
 	} = getFieldVisibility(fw, complianceAssessment, viewerRole);
 
+	const canShowAppliedControls = showAppliedControls && !page.data.user.is_third_party;
+
 	function pickDefaultTab(): string {
-		if (showAppliedControls && !page.data.user.is_third_party) return 'applied_controls';
+		if (canShowAppliedControls) return 'applied_controls';
 		if (showEvidences) return 'evidence';
 		return 'applied_controls';
 	}
@@ -131,18 +132,20 @@
 				{/each}
 			</div>
 		{/if}
-		{#if showScore && data.complianceAssessmentScore.scoring_enabled && data.requirementAssessment.is_scored}
-			<div class="shrink-0 relative">
-				<Progress value={formatScoreValue(score, max_score)} min={0} max={100}>
-					<Progress.Circle class="[--size:--spacing(10)]">
-						<Progress.CircleTrack />
-						<Progress.CircleRange class={displayScoreColor(score, max_score)} />
-					</Progress.Circle>
-					<div class="absolute inset-0 flex items-center justify-center">
-						<span class="text-xs font-bold">{score}</span>
-					</div>
-				</Progress>
-			</div>
+		{#if data.complianceAssessmentScore.scoring_enabled && data.requirementAssessment.is_scored}
+			{#if showScore}
+				<div class="shrink-0 relative">
+					<Progress value={formatScoreValue(score, max_score)} min={0} max={100}>
+						<Progress.Circle class="[--size:--spacing(10)]">
+							<Progress.CircleTrack />
+							<Progress.CircleRange class={displayScoreColor(score, max_score)} />
+						</Progress.Circle>
+						<div class="absolute inset-0 flex items-center justify-center">
+							<span class="text-xs font-bold">{score}</span>
+						</div>
+					</Progress>
+				</div>
+			{/if}
 			{#if showDocumentationScore && data.complianceAssessmentScore.show_documentation_score}
 				<div class="shrink-0 relative">
 					<Progress value={formatScoreValue(documentationScore, max_score)} min={0} max={100}>
@@ -342,7 +345,7 @@
 			{/if}
 		</div>
 	{/if}
-	{#if showAppliedControls || showEvidences}
+	{#if canShowAppliedControls || showEvidences}
 		<div>
 			<Tabs
 				value={group}
@@ -351,7 +354,7 @@
 				}}
 			>
 				<Tabs.List>
-					{#if showAppliedControls && !page.data.user.is_third_party}
+					{#if canShowAppliedControls}
 						<Tabs.Trigger value="applied_controls">{m.appliedControls()}</Tabs.Trigger>
 					{/if}
 					{#if showEvidences}
@@ -359,7 +362,7 @@
 					{/if}
 					<Tabs.Indicator />
 				</Tabs.List>
-				{#if showAppliedControls && !page.data.user.is_third_party}
+				{#if canShowAppliedControls}
 					<Tabs.Content value="applied_controls">
 						<div class="flex items-center mb-2 px-2 text-xs space-x-2">
 							<i class="fa-solid fa-info-circle"></i>

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/+page.svelte
@@ -83,11 +83,14 @@
 	const viewerRole: 'respondent' | 'auditor' = (data.viewerRole ?? 'auditor') as
 		| 'respondent'
 		| 'auditor';
-	const { showAppliedControls, showEvidences } = getFieldVisibility(
-		fw,
-		complianceAssessment,
-		viewerRole
-	);
+	const {
+		showAppliedControls,
+		showEvidences,
+		showStatus,
+		showResult,
+		showScore,
+		showDocumentationScore
+	} = getFieldVisibility(fw, complianceAssessment, viewerRole);
 
 	function pickDefaultTab(): string {
 		if (showAppliedControls && !page.data.user.is_third_party) return 'applied_controls';
@@ -100,20 +103,24 @@
 <div class="card space-y-2 p-4 bg-white shadow-sm">
 	<div class="flex flex-row space-x-2 items-center">
 		<code class="code">{data.requirement.urn}</code>
-		<span
-			class="badge h-fit"
-			style="background-color: {complianceStatusColorMap[data.requirementAssessment.status] ??
-				'#d1d5db'};"
-		>
-			{safeTranslate(data.requirementAssessment.status)}
-		</span>
-		<span
-			class="badge {classesText} h-fit"
-			style="background-color: {complianceResultColorMap[data.requirementAssessment.result] ??
-				'#d1d5db'};"
-		>
-			{safeTranslate(data.requirementAssessment.result)}
-		</span>
+		{#if showStatus}
+			<span
+				class="badge h-fit"
+				style="background-color: {complianceStatusColorMap[data.requirementAssessment.status] ??
+					'#d1d5db'};"
+			>
+				{safeTranslate(data.requirementAssessment.status)}
+			</span>
+		{/if}
+		{#if showResult}
+			<span
+				class="badge {classesText} h-fit"
+				style="background-color: {complianceResultColorMap[data.requirementAssessment.result] ??
+					'#d1d5db'};"
+			>
+				{safeTranslate(data.requirementAssessment.result)}
+			</span>
+		{/if}
 		{#if data.requirement.implementation_groups && data.requirement.implementation_groups.length > 0}
 			<div class="ml-3">
 				<b class="mr-2">{m.implementationGroups()} :</b>
@@ -124,7 +131,7 @@
 				{/each}
 			</div>
 		{/if}
-		{#if data.complianceAssessmentScore.scoring_enabled && data.requirementAssessment.is_scored}
+		{#if showScore && data.complianceAssessmentScore.scoring_enabled && data.requirementAssessment.is_scored}
 			<div class="shrink-0 relative">
 				<Progress value={formatScoreValue(score, max_score)} min={0} max={100}>
 					<Progress.Circle class="[--size:--spacing(10)]">
@@ -136,7 +143,7 @@
 					</div>
 				</Progress>
 			</div>
-			{#if data.complianceAssessmentScore.show_documentation_score}
+			{#if showDocumentationScore && data.complianceAssessmentScore.show_documentation_score}
 				<div class="shrink-0 relative">
 					<Progress value={formatScoreValue(documentationScore, max_score)} min={0} max={100}>
 						<Progress.Circle class="[--size:--spacing(10)]">

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/+page.svelte
@@ -389,7 +389,8 @@
 								hideFilters={true}
 								URLModel="evidences"
 								expectedCount={countMasked(data.requirementAssessment.evidences)}
-								baseEndpoint="/evidences?requirement_assessments={page.data.requirementAssessment.id}"
+								baseEndpoint="/evidences?requirement_assessments={page.data.requirementAssessment
+									.id}"
 							/>
 						</div>
 					</Tabs.Content>

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.server.ts
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.server.ts
@@ -211,9 +211,36 @@ export const actions: Actions = {
 			return fail(400, { form: form });
 		}
 
-		const formData = form.data;
+		const formData: Record<string, any> = { ...form.data };
+
+		// Strip fields the backend hid from the GET response. Sending them back as
+		// empty arrays / null would silently wipe data the user could not see.
+		const currentRa = await event
+			.fetch(endpoint)
+			.then((r) => (r.ok ? r.json() : null))
+			.catch(() => null);
+		if (currentRa) {
+			const visibilityControlled = [
+				'result',
+				'status',
+				'score',
+				'is_scored',
+				'documentation_score',
+				'observation',
+				'answers',
+				'evidences',
+				'applied_controls',
+				'security_exceptions'
+			];
+			for (const key of visibilityControlled) {
+				if (!(key in currentRa)) {
+					delete formData[key];
+				}
+			}
+		}
+
 		const requestInitOptions: RequestInit = {
-			method: 'PUT',
+			method: 'PATCH',
 			body: JSON.stringify(formData)
 		};
 

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.server.ts
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.server.ts
@@ -59,8 +59,9 @@ export const load = (async ({ fetch, params }) => {
 	}
 
 	const schema = modelSchema(URLModel);
-	object.evidences = object.evidences.map((evidence) => evidence.id);
-	object.applied_controls = object.applied_controls.map((applied_control) => applied_control.id);
+	object.evidences = object.evidences?.map((evidence) => evidence.id) ?? [];
+	object.applied_controls =
+		object.applied_controls?.map((applied_control) => applied_control.id) ?? [];
 	object.security_exceptions =
 		object.security_exceptions?.map((security_exception) => security_exception.id) ?? [];
 	object.nextRequirementAssessmentId = nextRequirementAssessmentId;

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.server.ts
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.server.ts
@@ -215,28 +215,40 @@ export const actions: Actions = {
 
 		// Strip fields the backend hid from the GET response. Sending them back as
 		// empty arrays / null would silently wipe data the user could not see.
-		const currentRa = await event
-			.fetch(endpoint)
-			.then((r) => (r.ok ? r.json() : null))
-			.catch(() => null);
-		if (currentRa) {
-			const visibilityControlled = [
-				'result',
-				'status',
-				'score',
-				'is_scored',
-				'documentation_score',
-				'observation',
-				'answers',
-				'evidences',
-				'applied_controls',
-				'security_exceptions'
-			];
-			for (const key of visibilityControlled) {
-				if (!(key in currentRa)) {
-					delete formData[key];
-				}
+		// Fail closed: if we cannot fetch the current state, abort rather than risk
+		// a PATCH that clears hidden relations.
+		let currentRa: Record<string, any>;
+		try {
+			const currentRaResponse = await event.fetch(endpoint);
+			if (!currentRaResponse.ok) {
+				return handleErrorResponse({ event, response: currentRaResponse, form });
 			}
+			currentRa = await currentRaResponse.json();
+		} catch (error) {
+			console.error('Failed to fetch requirement assessment before update', error);
+			return fail(502, { form });
+		}
+
+		const visibilityControlled = [
+			'result',
+			'status',
+			'score',
+			'is_scored',
+			'documentation_score',
+			'observation',
+			'answers',
+			'evidences',
+			'applied_controls',
+			'security_exceptions'
+		];
+		for (const key of visibilityControlled) {
+			if (!(key in currentRa)) {
+				delete formData[key];
+			}
+		}
+		// extended_result is a qualifier on result — strip it alongside a hidden result.
+		if (!('result' in currentRa)) {
+			delete formData.extended_result;
 		}
 
 		const requestInitOptions: RequestInit = {

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.server.ts
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.server.ts
@@ -195,7 +195,7 @@ export const load = (async ({ fetch, params }) => {
 		securityExceptionCreateForm,
 		tables,
 		nextRequirementAssessmentId,
-		viewerRole: requirementsListData?.viewer_role ?? 'auditor'
+		viewerRole: requirementsListData?.viewer_role === 'auditor' ? 'auditor' : 'respondent'
 	};
 }) satisfies PageServerLoad;
 

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.svelte
@@ -256,20 +256,23 @@
 	// Field visibility
 	const fw = data.requirementAssessment.compliance_assessment.framework;
 	const complianceAssessment = data.requirementAssessment.compliance_assessment;
-	const viewerRole: 'respondent' | 'auditor' = (data.viewerRole ?? 'auditor') as
-		| 'respondent'
-		| 'auditor';
+	const viewerRole: 'respondent' | 'auditor' =
+		data.viewerRole === 'auditor' ? 'auditor' : 'respondent';
 	const {
 		showResult,
+		showStatus,
 		showScore,
+		showDocumentationScore,
 		showObservation,
 		showAppliedControls,
 		showEvidences,
 		showSecurityExceptions
 	} = getFieldVisibility(fw, complianceAssessment, viewerRole);
 
+	const canShowAppliedControls = showAppliedControls && !page.data.user.is_third_party;
+
 	function pickDefaultTab(): string {
-		if (showAppliedControls && !page.data.user.is_third_party) return 'applied_controls';
+		if (canShowAppliedControls) return 'applied_controls';
 		if (showEvidences) return 'evidences';
 		if (showSecurityExceptions) return 'security_exceptions';
 		return 'applied_controls';
@@ -568,7 +571,7 @@
 			{...rest}
 		>
 			{#snippet children({ form, data })}
-				{#if showAppliedControls || showEvidences || showSecurityExceptions}
+				{#if canShowAppliedControls || showEvidences || showSecurityExceptions}
 					<div class="card shadow-lg bg-white">
 						<Tabs
 							value={group}
@@ -577,7 +580,7 @@
 							}}
 						>
 							<Tabs.List>
-								{#if showAppliedControls && !page.data.user.is_third_party}
+								{#if canShowAppliedControls}
 									<Tabs.Trigger value="applied_controls">{m.appliedControls()}</Tabs.Trigger>
 								{/if}
 								{#if showEvidences}
@@ -588,7 +591,7 @@
 								{/if}
 								<Tabs.Indicator />
 							</Tabs.List>
-							{#if showAppliedControls}
+							{#if canShowAppliedControls}
 								<Tabs.Content value="applied_controls">
 									<div class="flex items-center mb-2 px-2 text-xs space-x-2">
 										<i class="fa-solid fa-info-circle"></i>
@@ -740,7 +743,7 @@
 							label={m.questionSingular()}
 						/>
 					{/if}
-					{#if page.data.requirementAssessment.compliance_assessment.progress_status_enabled}
+					{#if showStatus && page.data.requirementAssessment.compliance_assessment.progress_status_enabled}
 						<Select
 							{form}
 							options={page.data.model.selectOptions['status']}
@@ -781,35 +784,35 @@
 							helpText={m.extendedResultHelpText()}
 						/>
 					{/if}
-					{#if showScore}
-						{#if page.data.compliance_assessment_score.scoring_enabled && computedScore !== null}
-							<div class="flex flex-row items-center space-x-4">
-								<span class="font-medium">{m.score()}</span>
-								<div class="shrink-0 relative">
-									<Progress
-										value={formatScoreValue(
-											computedScore || 0,
-											page.data.compliance_assessment_score.max_score
-										)}
-										min={0}
-										max={100}
-									>
-										<Progress.Circle class="[--size:--spacing(10)]">
-											<Progress.CircleTrack />
-											<Progress.CircleRange
-												class={displayScoreColor(
-													computedScore,
-													page.data.compliance_assessment_score.max_score
-												)}
-											/>
-										</Progress.Circle>
-										<div class="absolute inset-0 flex items-center justify-center">
-											<span class="text-xs font-bold">{computedScore}</span>
-										</div>
-									</Progress>
-								</div>
+					{#if showScore && page.data.compliance_assessment_score.scoring_enabled && computedScore !== null}
+						<div class="flex flex-row items-center space-x-4">
+							<span class="font-medium">{m.score()}</span>
+							<div class="shrink-0 relative">
+								<Progress
+									value={formatScoreValue(
+										computedScore || 0,
+										page.data.compliance_assessment_score.max_score
+									)}
+									min={0}
+									max={100}
+								>
+									<Progress.Circle class="[--size:--spacing(10)]">
+										<Progress.CircleTrack />
+										<Progress.CircleRange
+											class={displayScoreColor(
+												computedScore,
+												page.data.compliance_assessment_score.max_score
+											)}
+										/>
+									</Progress.Circle>
+									<div class="absolute inset-0 flex items-center justify-center">
+										<span class="text-xs font-bold">{computedScore}</span>
+									</div>
+								</Progress>
 							</div>
-						{:else if page.data.compliance_assessment_score.scoring_enabled && data.result !== 'not_applicable'}
+						</div>
+					{:else if page.data.compliance_assessment_score.scoring_enabled && data.result !== 'not_applicable'}
+						{#if showScore}
 							<div class="flex flex-col">
 								<Score
 									{form}
@@ -837,18 +840,18 @@
 									{/snippet}
 								</Score>
 							</div>
-							{#if page.data.compliance_assessment_score.show_documentation_score}
-								<Score
-									{form}
-									min_score={page.data.compliance_assessment_score.min_score}
-									max_score={page.data.compliance_assessment_score.max_score}
-									scores_definition={page.data.compliance_assessment_score.scores_definition}
-									field="documentation_score"
-									label={m.documentationScore()}
-									isDoc={true}
-									disabled={!data.is_scored}
-								/>
-							{/if}
+						{/if}
+						{#if showDocumentationScore && page.data.compliance_assessment_score.show_documentation_score}
+							<Score
+								{form}
+								min_score={page.data.compliance_assessment_score.min_score}
+								max_score={page.data.compliance_assessment_score.max_score}
+								scores_definition={page.data.compliance_assessment_score.scores_definition}
+								field="documentation_score"
+								label={m.documentationScore()}
+								isDoc={true}
+								disabled={!data.is_scored}
+							/>
 						{/if}
 					{/if}
 

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.svelte
@@ -784,74 +784,78 @@
 							helpText={m.extendedResultHelpText()}
 						/>
 					{/if}
-					{#if showScore && page.data.compliance_assessment_score.scoring_enabled && computedScore !== null}
-						<div class="flex flex-row items-center space-x-4">
-							<span class="font-medium">{m.score()}</span>
-							<div class="shrink-0 relative">
-								<Progress
-									value={formatScoreValue(
-										computedScore || 0,
-										page.data.compliance_assessment_score.max_score
-									)}
-									min={0}
-									max={100}
-								>
-									<Progress.Circle class="[--size:--spacing(10)]">
-										<Progress.CircleTrack />
-										<Progress.CircleRange
-											class={displayScoreColor(
-												computedScore,
+					{#if page.data.compliance_assessment_score.scoring_enabled}
+						{#if computedScore !== null}
+							{#if showScore}
+								<div class="flex flex-row items-center space-x-4">
+									<span class="font-medium">{m.score()}</span>
+									<div class="shrink-0 relative">
+										<Progress
+											value={formatScoreValue(
+												computedScore || 0,
 												page.data.compliance_assessment_score.max_score
 											)}
-										/>
-									</Progress.Circle>
-									<div class="absolute inset-0 flex items-center justify-center">
-										<span class="text-xs font-bold">{computedScore}</span>
+											min={0}
+											max={100}
+										>
+											<Progress.Circle class="[--size:--spacing(10)]">
+												<Progress.CircleTrack />
+												<Progress.CircleRange
+													class={displayScoreColor(
+														computedScore,
+														page.data.compliance_assessment_score.max_score
+													)}
+												/>
+											</Progress.Circle>
+											<div class="absolute inset-0 flex items-center justify-center">
+												<span class="text-xs font-bold">{computedScore}</span>
+											</div>
+										</Progress>
 									</div>
-								</Progress>
-							</div>
-						</div>
-					{:else if page.data.compliance_assessment_score.scoring_enabled && data.result !== 'not_applicable'}
-						{#if showScore}
-							<div class="flex flex-col">
+								</div>
+							{/if}
+						{:else if data.result !== 'not_applicable'}
+							{#if showScore}
+								<div class="flex flex-col">
+									<Score
+										{form}
+										min_score={page.data.compliance_assessment_score.min_score}
+										max_score={page.data.compliance_assessment_score.max_score}
+										scores_definition={page.data.compliance_assessment_score.scores_definition}
+										field="score"
+										label={page.data.compliance_assessment_score.show_documentation_score
+											? m.implementationScore()
+											: m.score()}
+										disabled={!data.is_scored}
+									>
+										{#snippet left()}
+											<div>
+												<Checkbox
+													{form}
+													field="is_scored"
+													label={''}
+													helpText={m.scoringHelpText()}
+													checkboxComponent="switch"
+													classes="h-full flex flex-row items-center justify-center my-1"
+													classesContainer="h-full flex flex-row items-center space-x-4"
+												/>
+											</div>
+										{/snippet}
+									</Score>
+								</div>
+							{/if}
+							{#if showDocumentationScore && page.data.compliance_assessment_score.show_documentation_score}
 								<Score
 									{form}
 									min_score={page.data.compliance_assessment_score.min_score}
 									max_score={page.data.compliance_assessment_score.max_score}
 									scores_definition={page.data.compliance_assessment_score.scores_definition}
-									field="score"
-									label={page.data.compliance_assessment_score.show_documentation_score
-										? m.implementationScore()
-										: m.score()}
+									field="documentation_score"
+									label={m.documentationScore()}
+									isDoc={true}
 									disabled={!data.is_scored}
-								>
-									{#snippet left()}
-										<div>
-											<Checkbox
-												{form}
-												field="is_scored"
-												label={''}
-												helpText={m.scoringHelpText()}
-												checkboxComponent="switch"
-												classes="h-full flex flex-row items-center justify-center my-1"
-												classesContainer="h-full flex flex-row items-center space-x-4"
-											/>
-										</div>
-									{/snippet}
-								</Score>
-							</div>
-						{/if}
-						{#if showDocumentationScore && page.data.compliance_assessment_score.show_documentation_score}
-							<Score
-								{form}
-								min_score={page.data.compliance_assessment_score.min_score}
-								max_score={page.data.compliance_assessment_score.max_score}
-								scores_definition={page.data.compliance_assessment_score.scores_definition}
-								field="documentation_score"
-								label={m.documentationScore()}
-								isDoc={true}
-								disabled={!data.is_scored}
-							/>
+								/>
+							{/if}
 						{/if}
 					{/if}
 

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.svelte
@@ -775,7 +775,7 @@
 							/>
 						{/if}
 					{/if}
-					{#if page.data.requirementAssessment.compliance_assessment.extended_result_enabled}
+					{#if showResult && page.data.requirementAssessment.compliance_assessment.extended_result_enabled}
 						<Select
 							{form}
 							options={page.data.model.selectOptions['extended_result']}

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.svelte
@@ -268,7 +268,13 @@
 		showSecurityExceptions
 	} = getFieldVisibility(fw, complianceAssessment, viewerRole);
 
-	let group = $state(page.data.user.is_third_party ? 'evidences' : 'applied_controls');
+	function pickDefaultTab(): string {
+		if (showAppliedControls && !page.data.user.is_third_party) return 'applied_controls';
+		if (showEvidences) return 'evidences';
+		if (showSecurityExceptions) return 'security_exceptions';
+		return 'applied_controls';
+	}
+	let group = $state(pickDefaultTab());
 
 	// Refresh AutompleteSelect to assign created applied control/evidence
 	let refreshKey = $state(false);


### PR DESCRIPTION
## Summary

Fixes a 500 error and UI residue when a framework's `field_visibility` hides
`applied_controls` and/or `security_exceptions`.

4 issues were addressed:

1. **500 on requirement-assessment edit** — the edit loader called `.map()`
   unconditionally on `applied_controls` and `evidences`. When the backend
   stripped those fields (because visibility was `"hidden"`), the resulting
   `undefined.map(...)` crashed the page for *all* users, not just the
   responder. Added defensive `?.map(...) ?? []`, matching the pattern
   already used for `security_exceptions` on the same page and for the
   sibling auditee/table-mode loaders.

2. **Tabs still rendered after hiding** — the `RequirementAssessmentRead`
   serializer projected the nested `compliance_assessment` / `framework`
   objects without their `field_visibility` maps, so the frontend's
   `resolveFieldVisibility()` never saw the overrides and always fell back
   to `DEFAULT_FIELD_VISIBILITY` (auditor-visible). Added `field_visibility`
   to both projections so the frontend can correctly hide the tabs.

3. **Default tab could be a hidden one** — both the edit and read-only
   requirement-assessment pages hardcoded `applied_controls` (or `evidences`
   for third-party) as the initial tab, leaving the page blank when that
   tab was hidden. Replaced with a `pickDefaultTab()` that picks the first
   visible tab.

4. **Read-only page didn't gate scalar fields** — the status/result badges and
   score/documentation-score progress circles rendered even when those fields
   were hidden, showing `[undefined]` translations and blank circles. Gated
   them with the corresponding visibility flags. `getFieldVisibility()` was
   extended with `showStatus` and `showDocumentationScore` for reuse.


Also extended the read-only requirement-assessment page (which had no
visibility gating at all) to fetch `viewer_role` and gate its tabs using
`getFieldVisibility()`, matching the edit page's behavior.

## Test plan

- [ ] On a framework, set `applied_controls: hidden` and `security_exceptions: hidden` in `field_visibility`.
- [ ] Open a requirement in an audit using that framework — the edit page loads (no 500) and the Applied Controls / Security Exceptions tabs are not rendered.
- [ ] With only `applied_controls: hidden`, confirm the edit page lands on the Evidences tab by default instead of a blank Applied Controls tab.
- [ ] With all three of `applied_controls`, `evidences`, `security_exceptions` hidden, confirm the entire tab card is gone.
- [ ] Repeat on the read-only requirement-assessment page (non-edit route) and confirm the same gating applies.
- [ ] As a responder (auditee) and as an auditor, confirm each sees the expected tabs based on `field_visibility` (`everyone` / `auditor` / `hidden`).
- [ ] Confirm sibling pages (auditee assessments, compliance-assessment table mode / flash mode) still work as before.
- [ ] With `status: hidden` on a framework, confirm the status badge disappears on both the edit and read-only pages.
- [ ] With `result: hidden`, confirm the result badge disappears.
- [ ] With `score: hidden`, confirm the score progress circle disappears on the read-only page.
- [ ] With `documentation_score: hidden`, confirm the documentation score circle disappears on the read-only page.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Role-aware field visibility: status, result, documentation score, applied-controls and evidence sections now show/hide based on viewer role and framework settings; default tab selection adapts accordingly.
  * Server now surfaces a normalized viewer role for the page payload.

* **Bug Fixes / UX**
  * Safer handling of missing applied_controls/evidences and more precise conditional rendering of score and badges.

* **Tests**
  * Updated tests to expect field_visibility in compliance assessment responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->