### PR TITLE
fix(i18n): add missing i18n keys

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2543,14 +2543,8 @@
 	"associatedFindingsAssessments": "Associated follow-ups",
 	"hourCount": [
 		{
-			"declarations": [
-				"input count",
-				"local countPlural = count: plural"
-			],
-			"selectors": [
-				"count",
-				"countPlural"
-			],
+			"declarations": ["input count", "local countPlural = count: plural"],
+			"selectors": ["count", "countPlural"],
 			"match": {
 				"countPlural=one": "{count} Hour",
 				"countPlural=other": "{count} Hours"
@@ -2559,13 +2553,8 @@
 	],
 	"minuteCount": [
 		{
-			"declarations": [
-				"input count",
-				"local countPlural = count: plural"
-			],
-			"selectors": [
-				"countPlural"
-			],
+			"declarations": ["input count", "local countPlural = count: plural"],
+			"selectors": ["countPlural"],
 			"match": {
 				"countPlural=one": "{count} Minute",
 				"countPlural=other": "{count} Minutes"
@@ -2574,13 +2563,8 @@
 	],
 	"dayCount": [
 		{
-			"declarations": [
-				"input count",
-				"local countPlural = count: plural"
-			],
-			"selectors": [
-				"countPlural"
-			],
+			"declarations": ["input count", "local countPlural = count: plural"],
+			"selectors": ["countPlural"],
 			"match": {
 				"countPlural=one": "{count} Day",
 				"countPlural=other": "{count} Days"
@@ -2589,13 +2573,8 @@
 	],
 	"objectsNotVisible": [
 		{
-			"declarations": [
-				"input count",
-				"local countPlural = count: plural"
-			],
-			"selectors": [
-				"countPlural"
-			],
+			"declarations": ["input count", "local countPlural = count: plural"],
+			"selectors": ["countPlural"],
 			"match": {
 				"countPlural=one": "{count} object is hidden. The link may be lost when editing.",
 				"countPlural=other": "{count} objects are hidden. The links may be lost when editing."
@@ -3978,14 +3957,8 @@
 	"errorFetching": "Unable to load cascade information. Please try again.",
 	"cascadeAffectedNotice": [
 		{
-			"declarations": [
-				"input count",
-				"local countPlural = count: plural"
-			],
-			"selectors": [
-				"count",
-				"countPlural"
-			],
+			"declarations": ["input count", "local countPlural = count: plural"],
+			"selectors": ["count", "countPlural"],
 			"match": {
 				"count=0": "No other objects will be impacted.",
 				"countPlural=one": "{count} related object will not be deleted but will lose one or more relationships.",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2543,8 +2543,14 @@
 	"associatedFindingsAssessments": "Associated follow-ups",
 	"hourCount": [
 		{
-			"declarations": ["input count", "local countPlural = count: plural"],
-			"selectors": ["count", "countPlural"],
+			"declarations": [
+				"input count",
+				"local countPlural = count: plural"
+			],
+			"selectors": [
+				"count",
+				"countPlural"
+			],
 			"match": {
 				"countPlural=one": "{count} Hour",
 				"countPlural=other": "{count} Hours"
@@ -2553,8 +2559,13 @@
 	],
 	"minuteCount": [
 		{
-			"declarations": ["input count", "local countPlural = count: plural"],
-			"selectors": ["countPlural"],
+			"declarations": [
+				"input count",
+				"local countPlural = count: plural"
+			],
+			"selectors": [
+				"countPlural"
+			],
 			"match": {
 				"countPlural=one": "{count} Minute",
 				"countPlural=other": "{count} Minutes"
@@ -2563,8 +2574,13 @@
 	],
 	"dayCount": [
 		{
-			"declarations": ["input count", "local countPlural = count: plural"],
-			"selectors": ["countPlural"],
+			"declarations": [
+				"input count",
+				"local countPlural = count: plural"
+			],
+			"selectors": [
+				"countPlural"
+			],
 			"match": {
 				"countPlural=one": "{count} Day",
 				"countPlural=other": "{count} Days"
@@ -2573,8 +2589,13 @@
 	],
 	"objectsNotVisible": [
 		{
-			"declarations": ["input count", "local countPlural = count: plural"],
-			"selectors": ["countPlural"],
+			"declarations": [
+				"input count",
+				"local countPlural = count: plural"
+			],
+			"selectors": [
+				"countPlural"
+			],
 			"match": {
 				"countPlural=one": "{count} object is hidden. The link may be lost when editing.",
 				"countPlural=other": "{count} objects are hidden. The links may be lost when editing."
@@ -3638,6 +3659,8 @@
 	"securityAdvisories": "Security advisories",
 	"source": "Source",
 	"aliases": "Aliases",
+	"addCwe": "Add CWE",
+	"addSecurityAdvisory": "Add security advisory",
 	"cwe": "CWE",
 	"cwes": "CWEs",
 	"cvssBaseScore": "CVSS base score",
@@ -3955,8 +3978,14 @@
 	"errorFetching": "Unable to load cascade information. Please try again.",
 	"cascadeAffectedNotice": [
 		{
-			"declarations": ["input count", "local countPlural = count: plural"],
-			"selectors": ["count", "countPlural"],
+			"declarations": [
+				"input count",
+				"local countPlural = count: plural"
+			],
+			"selectors": [
+				"count",
+				"countPlural"
+			],
 			"match": {
 				"count=0": "No other objects will be impacted.",
 				"countPlural=one": "{count} related object will not be deleted but will lose one or more relationships.",


### PR DESCRIPTION
## Fix

Added 2 missing i18n keys to the `en.json` file for the `Add` button in the **Security Advisories** and **CWEs** sections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added UI support for adding CWE entries.
  * Added UI support for adding security advisories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->