### PR TITLE
feat(wizard): support detected_at and due_date during vulnerability import

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -5524,7 +5524,10 @@ class Vulnerability(
             self.detected_at = date.today()
             if update_fields is not None:
                 update_fields.add("detected_at")
-        if is_new or severity_changed:
+        # Auto-apply SLA only when due_date is empty. Explicit user values
+        # (from the wizard or manual input) are preserved; the bulk
+        # refresh-due-dates action is the sole path that overrides them.
+        if (is_new or severity_changed) and not self.due_date:
             self._apply_sla_policy()
             if update_fields is not None:
                 update_fields.add("due_date")

--- a/backend/data_wizard/views.py
+++ b/backend/data_wizard/views.py
@@ -1580,6 +1580,14 @@ class VulnerabilityRecordConsumer(RecordConsumer[None]):
             "security_exceptions": security_exceptions,
         }
 
+        detected_at = _parse_date(record.get("detected_at"))
+        if detected_at:
+            data["detected_at"] = detected_at
+
+        due_date = _parse_date(record.get("due_date"))
+        if due_date:
+            data["due_date"] = due_date
+
         filtering_labels = _resolve_filtering_labels(record.get("filtering_labels"))
         if filtering_labels:
             data["filtering_labels"] = filtering_labels

--- a/cli/sample_vulnerabilities.csv
+++ b/cli/sample_vulnerabilities.csv
@@ -1,11 +1,11 @@
-ref_id,name,description,status,severity,assets,applied_controls,security_exceptions,filtering_labels
-CVE-2024-0001,Log4Shell RCE,Remote code execution via JNDI injection in Log4j 2.x,exploitable,critical,,,,
-CVE-2024-0002,OpenSSL Buffer Overflow,Heap buffer overflow allowing potential remote code execution,potential,high,kubernetes cluster,,,test-label
-CVE-2024-0003,Weak TLS Configuration,Server accepts deprecated TLS 1.0 and 1.1 protocols,mitigated,medium,,,,
-CVE-2024-0004,Default Admin Credentials,Application ships with unchanged default admin password,exploitable,high,,,,
-CVE-2024-0005,Unpatched Kernel,Linux kernel version missing critical security patches,potential,high,,,,
-CVE-2024-0006,Informational Header Leak,Server response headers expose version information,not exploitable,info,,,,
-CVE-2024-0007,Deprecated Hash Algorithm,MD5 used for password hashing in legacy module,unaffected,medium,,,,
-CVE-2024-0008,SQL Injection,User-supplied input not sanitised before DB query,fixed,critical,,,,
-,Unlabelled Exposure,No ref_id to test optional field,potential,low,,,,
-,Severity undefined test,Should import with severity -1 (undefined),potential,undefined,,,,
+ref_id,name,description,status,severity,assets,applied_controls,security_exceptions,filtering_labels,detected_at,due_date
+CVE-2024-0001,Log4Shell RCE,Remote code execution via JNDI injection in Log4j 2.x,exploitable,critical,,,,,2024-01-15,2024-02-15
+CVE-2024-0002,OpenSSL Buffer Overflow,Heap buffer overflow allowing potential remote code execution,potential,high,kubernetes cluster,,,test-label,,
+CVE-2024-0003,Weak TLS Configuration,Server accepts deprecated TLS 1.0 and 1.1 protocols,mitigated,medium,,,,,,
+CVE-2024-0004,Default Admin Credentials,Application ships with unchanged default admin password,exploitable,high,,,,,,
+CVE-2024-0005,Unpatched Kernel,Linux kernel version missing critical security patches,potential,high,,,,,,
+CVE-2024-0006,Informational Header Leak,Server response headers expose version information,not exploitable,info,,,,,,
+CVE-2024-0007,Deprecated Hash Algorithm,MD5 used for password hashing in legacy module,unaffected,medium,,,,,,
+CVE-2024-0008,SQL Injection,User-supplied input not sanitised before DB query,fixed,critical,,,,,,
+,Unlabelled Exposure,No ref_id to test optional field,potential,low,,,,,,
+,Severity undefined test,Should import with severity -1 (undefined),potential,undefined,,,,,,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Incoming vulnerability records now correctly parse and retain detected and due dates during ingestion.
  * Explicitly provided due dates are no longer overwritten on save; automatic SLA due-date assignment only applies when no due date exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->