### PR TITLE
fix(perf): "Summary" page performance boost

### DIFF
--- a/backend/core/compliance_summary.py
+++ b/backend/core/compliance_summary.py
@@ -1,3 +1,7 @@
+"""
+Helper for Summary page (Compliance Section)
+"""
+
 from django.db.models import Prefetch
 from django.db.models.functions import Lower
 

--- a/backend/core/compliance_summary.py
+++ b/backend/core/compliance_summary.py
@@ -1,0 +1,157 @@
+from django.db.models import Prefetch
+from django.db.models.functions import Lower
+
+from core.models import RequirementAssessment
+
+
+def _matches_selected_groups(compliance_assessment, requirement) -> bool:
+    """
+    Return whether a requirement should be included for recap computations.
+
+    Recap follows the assessment's selected implementation groups: when groups are
+    configured, requirements outside those groups are ignored. When no groups are
+    configured, all assessable requirements are included.
+    """
+    if not compliance_assessment.selected_implementation_groups:
+        return True
+
+    selected_groups = set(compliance_assessment.selected_implementation_groups)
+    if not selected_groups:
+        return True
+
+    requirement_groups = set(requirement.implementation_groups or [])
+    return bool(selected_groups & requirement_groups)
+
+
+def _build_result_counts(compliance_assessment, requirement_assessments):
+    """
+    Build the raw result counters consumed by the recap frontend.
+
+    The backend intentionally returns counts only; colors, percentages, and chart
+    formatting are rebuilt on the frontend.
+    """
+    counts = {result: 0 for result in RequirementAssessment.Result.values}
+
+    for requirement_assessment in requirement_assessments:
+        if _matches_selected_groups(
+            compliance_assessment, requirement_assessment.requirement
+        ):
+            counts[requirement_assessment.result] = (
+                counts.get(requirement_assessment.result, 0) + 1
+            )
+
+    return counts
+
+
+def _build_score_summary(compliance_assessment, requirement_assessments):
+    """
+    Compute the score subset needed by /recap.
+
+    This mirrors the global score business rules already used elsewhere in the
+    product, but only returns the fields currently displayed by recap.
+    """
+    if compliance_assessment.anchor_na_to_target:
+        scored = [
+            requirement_assessment
+            for requirement_assessment in requirement_assessments
+            if not (
+                requirement_assessment.result
+                != RequirementAssessment.Result.NOT_APPLICABLE
+                and requirement_assessment.is_scored is False
+            )
+        ]
+    else:
+        scored = [
+            requirement_assessment
+            for requirement_assessment in requirement_assessments
+            if requirement_assessment.is_scored is not False
+            and requirement_assessment.result
+            != RequirementAssessment.Result.NOT_APPLICABLE
+        ]
+
+    implementation_groups = (
+        set(compliance_assessment.selected_implementation_groups)
+        if compliance_assessment.selected_implementation_groups
+        else None
+    )
+
+    na_target = None
+    if compliance_assessment.anchor_na_to_target:
+        na_target = (
+            compliance_assessment.target_score
+            if compliance_assessment.target_score is not None
+            else compliance_assessment.max_score
+        )
+
+    implementation_score = compliance_assessment._compute_score_for_field(
+        scored, implementation_groups, "score", na_target
+    )
+
+    documentation_score = None
+    if compliance_assessment.show_documentation_score:
+        documentation_score = compliance_assessment._compute_score_for_field(
+            scored, implementation_groups, "documentation_score", na_target
+        )
+
+    enabled_scores = [
+        score
+        for score in [implementation_score, documentation_score]
+        if score is not None and score != -1
+    ]
+    if enabled_scores:
+        maturity_score = int(sum(enabled_scores) / len(enabled_scores) * 10) / 10
+    else:
+        maturity_score = implementation_score
+
+    return {
+        "maturity_score": maturity_score,
+        "max_score": compliance_assessment.max_score,
+    }
+
+
+def build_compliance_recap_results(compliance_assessments_queryset):
+    """
+    Build the raw recap payload from a ComplianceAssessment queryset.
+
+    The caller is responsible for providing the base queryset with the correct
+    visibility scope. This helper enriches it with the ORM optimizations and
+    transforms it into the compact response structure expected by the recap route.
+    """
+    assessments = list(
+        compliance_assessments_queryset.select_related("folder", "framework")
+        .prefetch_related(
+            Prefetch(
+                "requirement_assessments",
+                queryset=RequirementAssessment.objects.filter(
+                    requirement__assessable=True
+                ).select_related("requirement"),
+            )
+        )
+        .order_by(Lower("folder__name"), Lower("name"))
+    )
+
+    folders_map = {}
+    for assessment in assessments:
+        folder_id = str(assessment.folder_id)
+        if folder_id not in folders_map:
+            folders_map[folder_id] = {
+                "id": folder_id,
+                "name": assessment.folder.name,
+                "compliance_assessments": [],
+            }
+
+        requirement_assessments = list(assessment.requirement_assessments.all())
+        result_counts = _build_result_counts(assessment, requirement_assessments)
+        global_score = _build_score_summary(assessment, requirement_assessments)
+
+        folders_map[folder_id]["compliance_assessments"].append(
+            {
+                "id": str(assessment.id),
+                "name": assessment.name,
+                "framework_name": assessment.framework.name,
+                "result_counts": result_counts,
+                "global_score": global_score,
+            }
+        )
+
+    return list(folders_map.values())

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -10293,17 +10293,11 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
 
     @action(detail=False, methods=["get"], url_path="recap")
     def recap(self, request):
-        """Return the compact data needed by the /recap page in a single response."""
-        # /recap only renders folder groupings plus per-assessment donut/global scores.
-        # Building that payload here avoids the former frontend request fan-out:
+        """Return the raw data needed by the /recap page in a single response."""
+        # Keep this endpoint presentation-agnostic: it returns counts and scores, while
+        # the Svelte frontend is responsible for colors, percentages, and chart wiring.
+        # This still avoids the former frontend request fan-out:
         # folders -> assessments per folder -> donut/global_score per assessment.
-        result_color_map = {
-            RequirementAssessment.Result.NOT_ASSESSED: "#d1d5db",
-            RequirementAssessment.Result.NON_COMPLIANT: "#f87171",
-            RequirementAssessment.Result.PARTIALLY_COMPLIANT: "#fde047",
-            RequirementAssessment.Result.COMPLIANT: "#86efac",
-            RequirementAssessment.Result.NOT_APPLICABLE: "#000000",
-        }
 
         def matches_selected_groups(compliance_assessment, requirement) -> bool:
             # When an assessment targets a subset of implementation groups, recap must
@@ -10317,10 +10311,9 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
             requirement_groups = set(requirement.implementation_groups or [])
             return bool(selected_groups & requirement_groups)
 
-        def build_result_donut(compliance_assessment, requirement_assessments):
-            # /recap only needs the "result" donut, not the full payload returned by
-            # the legacy donut_data endpoint. Recomputing the small subset here keeps
-            # the response compact and avoids a per-assessment HTTP round trip.
+        def build_result_counts(compliance_assessment, requirement_assessments):
+            # Return only the raw result counters. The frontend can derive donuts,
+            # colors, and percentages from this compact representation.
             counts = {
                 result: 0 for result in RequirementAssessment.Result.values
             }
@@ -10328,18 +10321,9 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
                 if matches_selected_groups(compliance_assessment, ras.requirement):
                     counts[ras.result] = counts.get(ras.result, 0) + 1
 
-            return {
-                "values": [
-                    {
-                        "name": result,
-                        "value": counts.get(result, 0),
-                        "itemStyle": {"color": result_color_map[result]},
-                    }
-                    for result in RequirementAssessment.Result.values
-                ]
-            }
+            return counts
 
-        def build_global_score(compliance_assessment, requirement_assessments):
+        def build_score_summary(compliance_assessment, requirement_assessments):
             # Reuse the same scoring rules as the dedicated global_score endpoint.
             # The filtering below mirrors the existing business rule around
             # "anchor NA to target": in that mode some non-scored rows are still kept
@@ -10405,8 +10389,6 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
                 maturity_score = implementation_score
 
             return {
-                "implementation_score": implementation_score,
-                "documentation_score": documentation_score,
                 "maturity_score": maturity_score,
                 "max_score": compliance_assessment.max_score,
             }
@@ -10438,63 +10420,25 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
                     "id": folder_id,
                     "name": assessment.folder.name,
                     "compliance_assessments": [],
-                    # Internal accumulator used to build folder-level compliance once
-                    # all assessments inside the folder have been processed.
-                    "_overall_counts": {
-                        result: 0 for result in RequirementAssessment.Result.values
-                    },
                 }
 
             requirement_assessments = list(assessment.requirement_assessments.all())
-            # Reuse the prefetched requirement assessments for both widgets so we do not
-            # trigger extra queries per compliance assessment.
-            result_donut = build_result_donut(assessment, requirement_assessments)
-            global_score = build_global_score(assessment, requirement_assessments)
-
-            for item in result_donut["values"]:
-                # Aggregate each assessment donut into a folder-level donut.
-                folders_map[folder_id]["_overall_counts"][item["name"]] += item["value"]
+            # Reuse the prefetched requirement assessments for both raw datasets so we
+            # do not trigger extra queries per compliance assessment.
+            result_counts = build_result_counts(assessment, requirement_assessments)
+            global_score = build_score_summary(assessment, requirement_assessments)
 
             folders_map[folder_id]["compliance_assessments"].append(
                 {
                     "id": str(assessment.id),
                     "name": assessment.name,
-                    "framework": {
-                        "id": str(assessment.framework_id),
-                        "str": str(assessment.framework),
-                    },
-                    "donut": {"result": result_donut},
-                    "globalScore": global_score,
+                    "framework_name": assessment.framework.name,
+                    "result_counts": result_counts,
+                    "global_score": global_score,
                 }
             )
 
-        results = []
-        for folder in folders_map.values():
-            total = sum(folder["_overall_counts"].values())
-            # overallCompliance mirrors the previous frontend aggregation, but it is now
-            # computed once on the server from the same per-assessment donut counts.
-            folder["overallCompliance"] = {
-                "values": [
-                    {
-                        "name": result,
-                        "value": folder["_overall_counts"][result],
-                        "itemStyle": {"color": result_color_map[result]},
-                        "percentage": (
-                            # Keep the historical payload shape: percentages are sent
-                            # as formatted strings because the existing UI expects that.
-                            f"{(folder['_overall_counts'][result] / total) * 100:.1f}"
-                            if total > 0
-                            else "0"
-                        ),
-                    }
-                    for result in RequirementAssessment.Result.values
-                ],
-                "total": total,
-            }
-            del folder["_overall_counts"]
-            results.append(folder)
-
-        return Response({"results": results})
+        return Response({"results": list(folders_map.values())})
 
     @method_decorator(cache_page(60 * LONG_CACHE_TTL))
     @action(detail=False, name="Get score calculation method choices")

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -64,6 +64,7 @@ from docxtpl import DocxTemplate
 from integrations.models import SyncMapping
 from integrations.tasks import sync_object_to_integrations
 from webhooks.service import dispatch_webhook_event
+from .compliance_summary import build_compliance_recap_results
 from .generators import gen_audit_context
 from .serializer_fields import FieldsRelatedField
 
@@ -10294,151 +10295,8 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
     @action(detail=False, methods=["get"], url_path="recap")
     def recap(self, request):
         """Return the raw data needed by the /recap page in a single response."""
-        # Keep this endpoint presentation-agnostic: it returns counts and scores, while
-        # the Svelte frontend is responsible for colors, percentages, and chart wiring.
-        # This still avoids the former frontend request fan-out:
-        # folders -> assessments per folder -> donut/global_score per assessment.
-
-        def matches_selected_groups(compliance_assessment, requirement) -> bool:
-            # When an assessment targets a subset of implementation groups, recap must
-            # ignore requirements outside that subset. If no subset is configured, we
-            # keep the historical behavior and include every assessable requirement.
-            if not compliance_assessment.selected_implementation_groups:
-                return True
-            selected_groups = set(compliance_assessment.selected_implementation_groups)
-            if not selected_groups:
-                return True
-            requirement_groups = set(requirement.implementation_groups or [])
-            return bool(selected_groups & requirement_groups)
-
-        def build_result_counts(compliance_assessment, requirement_assessments):
-            # Return only the raw result counters. The frontend can derive donuts,
-            # colors, and percentages from this compact representation.
-            counts = {
-                result: 0 for result in RequirementAssessment.Result.values
-            }
-            for ras in requirement_assessments:
-                if matches_selected_groups(compliance_assessment, ras.requirement):
-                    counts[ras.result] = counts.get(ras.result, 0) + 1
-
-            return counts
-
-        def build_score_summary(compliance_assessment, requirement_assessments):
-            # Reuse the same scoring rules as the dedicated global_score endpoint.
-            # The filtering below mirrors the existing business rule around
-            # "anchor NA to target": in that mode some non-scored rows are still kept
-            # so the target anchoring stays consistent with the rest of the product.
-            if compliance_assessment.anchor_na_to_target:
-                scored = [
-                    ras
-                    for ras in requirement_assessments
-                    if not (
-                        ras.result != RequirementAssessment.Result.NOT_APPLICABLE
-                        and ras.is_scored is False
-                    )
-                ]
-            else:
-                scored = [
-                    ras
-                    for ras in requirement_assessments
-                    if ras.is_scored is not False
-                    and ras.result != RequirementAssessment.Result.NOT_APPLICABLE
-                ]
-
-            # The scoring helper accepts an optional implementation-group filter. We
-            # pass the selected groups once so both implementation and documentation
-            # scores stay aligned with the assessment configuration.
-            implementation_groups = (
-                set(compliance_assessment.selected_implementation_groups)
-                if compliance_assessment.selected_implementation_groups
-                else None
-            )
-            na_target = None
-            if compliance_assessment.anchor_na_to_target:
-                # If a custom target exists, NA answers are anchored to that target;
-                # otherwise they fall back to the framework max score.
-                na_target = (
-                    compliance_assessment.target_score
-                    if compliance_assessment.target_score is not None
-                    else compliance_assessment.max_score
-                )
-
-            implementation_score = compliance_assessment._compute_score_for_field(
-                scored, implementation_groups, "score", na_target
-            )
-
-            documentation_score = None
-            if compliance_assessment.show_documentation_score:
-                # Documentation is optional in the UI, so only compute it when this
-                # assessment is configured to display it.
-                documentation_score = compliance_assessment._compute_score_for_field(
-                    scored, implementation_groups, "documentation_score", na_target
-                )
-
-            enabled_scores = [
-                score
-                for score in [implementation_score, documentation_score]
-                if score is not None and score != -1
-            ]
-            if enabled_scores:
-                # /recap expects the same "maturity" summary as the old global_score
-                # endpoint: the mean of the enabled score dimensions, rounded to 1
-                # decimal place.
-                maturity_score = int(sum(enabled_scores) / len(enabled_scores) * 10) / 10
-            else:
-                maturity_score = implementation_score
-
-            return {
-                "maturity_score": maturity_score,
-                "max_score": compliance_assessment.max_score,
-            }
-
-        assessments = list(
-            # Reuse get_queryset() so the endpoint keeps the same visibility rules and
-            # request-level filtering as the rest of the ComplianceAssessment API.
-            self.get_queryset()
-            .select_related("folder", "framework")
-            .prefetch_related(
-                Prefetch(
-                    "requirement_assessments",
-                    queryset=RequirementAssessment.objects.filter(
-                        requirement__assessable=True
-                    ).select_related("requirement"),
-                )
-            )
-            # We need requirement on each requirement_assessment because the recap
-            # calculations inspect requirement.implementation_groups.
-            # Keep the response ordering stable so the page does not need to sort again.
-            .order_by(Lower("folder__name"), Lower("name"))
-        )
-
-        folders_map = {}
-        for assessment in assessments:
-            folder_id = str(assessment.folder_id)
-            if folder_id not in folders_map:
-                folders_map[folder_id] = {
-                    "id": folder_id,
-                    "name": assessment.folder.name,
-                    "compliance_assessments": [],
-                }
-
-            requirement_assessments = list(assessment.requirement_assessments.all())
-            # Reuse the prefetched requirement assessments for both raw datasets so we
-            # do not trigger extra queries per compliance assessment.
-            result_counts = build_result_counts(assessment, requirement_assessments)
-            global_score = build_score_summary(assessment, requirement_assessments)
-
-            folders_map[folder_id]["compliance_assessments"].append(
-                {
-                    "id": str(assessment.id),
-                    "name": assessment.name,
-                    "framework_name": assessment.framework.name,
-                    "result_counts": result_counts,
-                    "global_score": global_score,
-                }
-            )
-
-        return Response({"results": list(folders_map.values())})
+        results = build_compliance_recap_results(self.get_queryset())
+        return Response({"results": results})
 
     @method_decorator(cache_page(60 * LONG_CACHE_TTL))
     @action(detail=False, name="Get score calculation method choices")

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -10291,6 +10291,211 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
     def status(self, request):
         return Response(dict(ComplianceAssessment.Status.choices))
 
+    @action(detail=False, methods=["get"], url_path="recap")
+    def recap(self, request):
+        """Return the compact data needed by the /recap page in a single response."""
+        # /recap only renders folder groupings plus per-assessment donut/global scores.
+        # Building that payload here avoids the former frontend request fan-out:
+        # folders -> assessments per folder -> donut/global_score per assessment.
+        result_color_map = {
+            RequirementAssessment.Result.NOT_ASSESSED: "#d1d5db",
+            RequirementAssessment.Result.NON_COMPLIANT: "#f87171",
+            RequirementAssessment.Result.PARTIALLY_COMPLIANT: "#fde047",
+            RequirementAssessment.Result.COMPLIANT: "#86efac",
+            RequirementAssessment.Result.NOT_APPLICABLE: "#000000",
+        }
+
+        def matches_selected_groups(compliance_assessment, requirement) -> bool:
+            # When an assessment targets a subset of implementation groups, recap must
+            # ignore requirements outside that subset. If no subset is configured, we
+            # keep the historical behavior and include every assessable requirement.
+            if not compliance_assessment.selected_implementation_groups:
+                return True
+            selected_groups = set(compliance_assessment.selected_implementation_groups)
+            if not selected_groups:
+                return True
+            requirement_groups = set(requirement.implementation_groups or [])
+            return bool(selected_groups & requirement_groups)
+
+        def build_result_donut(compliance_assessment, requirement_assessments):
+            # /recap only needs the "result" donut, not the full payload returned by
+            # the legacy donut_data endpoint. Recomputing the small subset here keeps
+            # the response compact and avoids a per-assessment HTTP round trip.
+            counts = {
+                result: 0 for result in RequirementAssessment.Result.values
+            }
+            for ras in requirement_assessments:
+                if matches_selected_groups(compliance_assessment, ras.requirement):
+                    counts[ras.result] = counts.get(ras.result, 0) + 1
+
+            return {
+                "values": [
+                    {
+                        "name": result,
+                        "value": counts.get(result, 0),
+                        "itemStyle": {"color": result_color_map[result]},
+                    }
+                    for result in RequirementAssessment.Result.values
+                ]
+            }
+
+        def build_global_score(compliance_assessment, requirement_assessments):
+            # Reuse the same scoring rules as the dedicated global_score endpoint.
+            # The filtering below mirrors the existing business rule around
+            # "anchor NA to target": in that mode some non-scored rows are still kept
+            # so the target anchoring stays consistent with the rest of the product.
+            if compliance_assessment.anchor_na_to_target:
+                scored = [
+                    ras
+                    for ras in requirement_assessments
+                    if not (
+                        ras.result != RequirementAssessment.Result.NOT_APPLICABLE
+                        and ras.is_scored is False
+                    )
+                ]
+            else:
+                scored = [
+                    ras
+                    for ras in requirement_assessments
+                    if ras.is_scored is not False
+                    and ras.result != RequirementAssessment.Result.NOT_APPLICABLE
+                ]
+
+            # The scoring helper accepts an optional implementation-group filter. We
+            # pass the selected groups once so both implementation and documentation
+            # scores stay aligned with the assessment configuration.
+            implementation_groups = (
+                set(compliance_assessment.selected_implementation_groups)
+                if compliance_assessment.selected_implementation_groups
+                else None
+            )
+            na_target = None
+            if compliance_assessment.anchor_na_to_target:
+                # If a custom target exists, NA answers are anchored to that target;
+                # otherwise they fall back to the framework max score.
+                na_target = (
+                    compliance_assessment.target_score
+                    if compliance_assessment.target_score is not None
+                    else compliance_assessment.max_score
+                )
+
+            implementation_score = compliance_assessment._compute_score_for_field(
+                scored, implementation_groups, "score", na_target
+            )
+
+            documentation_score = None
+            if compliance_assessment.show_documentation_score:
+                # Documentation is optional in the UI, so only compute it when this
+                # assessment is configured to display it.
+                documentation_score = compliance_assessment._compute_score_for_field(
+                    scored, implementation_groups, "documentation_score", na_target
+                )
+
+            enabled_scores = [
+                score
+                for score in [implementation_score, documentation_score]
+                if score is not None and score != -1
+            ]
+            if enabled_scores:
+                # /recap expects the same "maturity" summary as the old global_score
+                # endpoint: the mean of the enabled score dimensions, rounded to 1
+                # decimal place.
+                maturity_score = int(sum(enabled_scores) / len(enabled_scores) * 10) / 10
+            else:
+                maturity_score = implementation_score
+
+            return {
+                "implementation_score": implementation_score,
+                "documentation_score": documentation_score,
+                "maturity_score": maturity_score,
+                "max_score": compliance_assessment.max_score,
+            }
+
+        assessments = list(
+            # Reuse get_queryset() so the endpoint keeps the same visibility rules and
+            # request-level filtering as the rest of the ComplianceAssessment API.
+            self.get_queryset()
+            .select_related("folder", "framework")
+            .prefetch_related(
+                Prefetch(
+                    "requirement_assessments",
+                    queryset=RequirementAssessment.objects.filter(
+                        requirement__assessable=True
+                    ).select_related("requirement"),
+                )
+            )
+            # We need requirement on each requirement_assessment because the recap
+            # calculations inspect requirement.implementation_groups.
+            # Keep the response ordering stable so the page does not need to sort again.
+            .order_by(Lower("folder__name"), Lower("name"))
+        )
+
+        folders_map = {}
+        for assessment in assessments:
+            folder_id = str(assessment.folder_id)
+            if folder_id not in folders_map:
+                folders_map[folder_id] = {
+                    "id": folder_id,
+                    "name": assessment.folder.name,
+                    "compliance_assessments": [],
+                    # Internal accumulator used to build folder-level compliance once
+                    # all assessments inside the folder have been processed.
+                    "_overall_counts": {
+                        result: 0 for result in RequirementAssessment.Result.values
+                    },
+                }
+
+            requirement_assessments = list(assessment.requirement_assessments.all())
+            # Reuse the prefetched requirement assessments for both widgets so we do not
+            # trigger extra queries per compliance assessment.
+            result_donut = build_result_donut(assessment, requirement_assessments)
+            global_score = build_global_score(assessment, requirement_assessments)
+
+            for item in result_donut["values"]:
+                # Aggregate each assessment donut into a folder-level donut.
+                folders_map[folder_id]["_overall_counts"][item["name"]] += item["value"]
+
+            folders_map[folder_id]["compliance_assessments"].append(
+                {
+                    "id": str(assessment.id),
+                    "name": assessment.name,
+                    "framework": {
+                        "id": str(assessment.framework_id),
+                        "str": str(assessment.framework),
+                    },
+                    "donut": {"result": result_donut},
+                    "globalScore": global_score,
+                }
+            )
+
+        results = []
+        for folder in folders_map.values():
+            total = sum(folder["_overall_counts"].values())
+            # overallCompliance mirrors the previous frontend aggregation, but it is now
+            # computed once on the server from the same per-assessment donut counts.
+            folder["overallCompliance"] = {
+                "values": [
+                    {
+                        "name": result,
+                        "value": folder["_overall_counts"][result],
+                        "itemStyle": {"color": result_color_map[result]},
+                        "percentage": (
+                            # Keep the historical payload shape: percentages are sent
+                            # as formatted strings because the existing UI expects that.
+                            f"{(folder['_overall_counts'][result] / total) * 100:.1f}"
+                            if total > 0
+                            else "0"
+                        ),
+                    }
+                    for result in RequirementAssessment.Result.values
+                ],
+                "total": total,
+            }
+            del folder["_overall_counts"]
+            results.append(folder)
+
+        return Response({"results": results})
+
     @method_decorator(cache_page(60 * LONG_CACHE_TTL))
     @action(detail=False, name="Get score calculation method choices")
     def score_calculation_method(self, request):

--- a/frontend/src/routes/(app)/(internal)/recap/+page.server.ts
+++ b/frontend/src/routes/(app)/(internal)/recap/+page.server.ts
@@ -2,148 +2,24 @@ import { BASE_API_URL } from '$lib/utils/constants';
 import type { PageServerLoad } from './$types';
 import { m } from '$paraglide/messages';
 
-const REQUIREMENT_ASSESSMENT_STATUS = [
-	'compliant',
-	'partially_compliant',
-	'in_progress',
-	'non_compliant',
-	'not_applicable',
-	'to_do'
-] as const;
-
-interface DonutItem {
-	name: string;
-	localName?: string;
-	value: number;
-	itemStyle: Record<string, unknown>;
-}
-
-interface RequirementAssessmentDonutItem extends Omit<DonutItem, 'name'> {
-	name: (typeof REQUIREMENT_ASSESSMENT_STATUS)[number];
-	percentage: string;
-}
-
-interface FolderAnalytics {
-	id: string;
-	name: string;
-	compliance_assessments: Record<string, any>[];
-	overallCompliance: {
-		values: RequirementAssessmentDonutItem[];
-		total: number;
-	};
-}
-
 export const load: PageServerLoad = async ({ locals, fetch }) => {
-	const folders: FolderAnalytics[] = await fetch(`${BASE_API_URL}/folders/`)
-		.then((res) => res.json())
-		.then(async (folders) => {
-			if (folders && Array.isArray(folders.results)) {
-				const folderPromises = folders.results.map(async (folder) => {
-					try {
-						const complianceAssessmentsResponse = await fetch(
-							`${BASE_API_URL}/compliance-assessments/?folder=${folder.id}`
-						);
-						const complianceAssessmentsData = await complianceAssessmentsResponse.json();
-
-						if (complianceAssessmentsData && Array.isArray(complianceAssessmentsData.results)) {
-							const updatedAssessmentsPromises = complianceAssessmentsData.results.map(
-								async (complianceAssessment) => {
-									try {
-										const [donutDataResponse, globalScoreResponse] = await Promise.all([
-											fetch(
-												`${BASE_API_URL}/compliance-assessments/${complianceAssessment.id}/donut_data/`
-											),
-											fetch(
-												`${BASE_API_URL}/compliance-assessments/${complianceAssessment.id}/global_score/`
-											)
-										]);
-
-										const [donutData, globalScoreData] = await Promise.all([
-											donutDataResponse.json(),
-											globalScoreResponse.json()
-										]);
-
-										complianceAssessment.donut = donutData;
-										complianceAssessment.globalScore = globalScoreData;
-										return complianceAssessment;
-									} catch (error) {
-										console.error('Error fetching data for compliance assessment:', error);
-										throw error;
-									}
-								}
-							);
-
-							const updatedAssessments = await Promise.all(updatedAssessmentsPromises);
-							folder.compliance_assessments = updatedAssessments;
-							return folder;
-						} else {
-							folder.compliance_assessments = [];
-							return folder;
-						}
-					} catch (error) {
-						console.error('Error fetching compliance assessments:', error);
-						folder.compliance_assessments = [];
-						return folder;
-					}
-				});
-
-				return Promise.all(folderPromises);
-			} else {
-				throw new Error('Folders results not found or not an array');
+	// /recap used to trigger a request cascade:
+	// folders -> assessments per folder -> donut/global_score per assessment.
+	// The dedicated backend endpoint returns the exact shape needed by the page
+	// in one call, which removes the previous N+1 pattern from the frontend.
+	const folders = await fetch(`${BASE_API_URL}/compliance-assessments/recap/`)
+		.then(async (res) => {
+			if (!res.ok) {
+				throw new Error(`Failed to load recap data: ${res.status} ${res.statusText}`);
 			}
+			return res.json();
 		})
+		.then((data) => data.results ?? [])
 		.catch((error) => {
-			console.error('Failed to load folders:', error);
+			// Keep the page renderable even if the recap endpoint fails temporarily.
+			console.error('Failed to load recap:', error);
 			return [];
 		});
-
-	if (folders) {
-		folders.forEach((folder) => {
-			// Initialize an object to hold the aggregated donut data
-			const aggregatedDonutData: {
-				values: RequirementAssessmentDonutItem[];
-				total: number;
-			} = {
-				values: [],
-				total: 0
-			};
-
-			// Iterate through each compliance assessment of the folder
-			if (folder.compliance_assessments) {
-				folder.compliance_assessments.forEach((compliance_assessment: Record<string, any>) => {
-					// Process the donut data of each assessment
-					if (compliance_assessment.donut?.result?.values) {
-						compliance_assessment.donut.result.values.forEach(
-							(donutItem: RequirementAssessmentDonutItem) => {
-								// Find the corresponding item in the aggregated data
-								const aggregatedItem: RequirementAssessmentDonutItem | undefined =
-									aggregatedDonutData.values.find((item) => item.name === donutItem.name);
-								if (aggregatedItem) {
-									// If the item already exists, increment its value
-									aggregatedItem.value += donutItem.value;
-								} else {
-									// If it's a new item, add it to the aggregated data
-									aggregatedDonutData.values.push({ ...donutItem });
-								}
-							}
-						);
-					}
-				});
-			}
-
-			// Calculate the total sum of all values
-			const totalValue = aggregatedDonutData.values.reduce((sum, item) => sum + item.value, 0);
-
-			// Calculate and store the percentage for each item
-			aggregatedDonutData.values = aggregatedDonutData.values.map((item) => ({
-				...item,
-				percentage: totalValue > 0 ? ((item.value / totalValue) * 100).toFixed(1) : '0'
-			}));
-
-			// Assign the aggregated donut data to the folder
-			folder.overallCompliance = aggregatedDonutData;
-		});
-	}
 
 	return {
 		folders,

--- a/frontend/src/routes/(app)/(internal)/recap/+page.server.ts
+++ b/frontend/src/routes/(app)/(internal)/recap/+page.server.ts
@@ -84,25 +84,28 @@ function shapeFolderForRecap(folder: RawRecapFolder) {
 }
 
 export const load: PageServerLoad = async ({ locals, fetch }) => {
-	// The backend now returns only recap raw data (counts + score summaries).
-	// Presentation details such as colors, percentages, and donut wiring are
-	// rebuilt here on the frontend side.
-	const folders = await fetch(`${BASE_API_URL}/compliance-assessments/recap/`)
-		.then(async (res) => {
-			if (!res.ok) {
-				throw new Error(`Failed to load recap data: ${res.status} ${res.statusText}`);
-			}
-			return res.json();
-		})
-		.then((data) => ((data.results ?? []) as RawRecapFolder[]).map(shapeFolderForRecap))
-		.catch((error) => {
-			// Keep the page renderable even if the recap endpoint fails temporarily.
-			console.error('Failed to load recap:', error);
-			return [];
-		});
+	const getFolders = async () => {
+		// Stream recap data so the route can render a loading state immediately
+		// after navigation, instead of blocking the whole page transition.
+		return fetch(`${BASE_API_URL}/compliance-assessments/recap/`)
+			.then(async (res) => {
+				if (!res.ok) {
+					throw new Error(`Failed to load recap data: ${res.status} ${res.statusText}`);
+				}
+				return res.json();
+			})
+			.then((data) => ((data.results ?? []) as RawRecapFolder[]).map(shapeFolderForRecap))
+			.catch((error) => {
+				// Keep the page renderable even if the recap endpoint fails temporarily.
+				console.error('Failed to load recap:', error);
+				return [];
+			});
+	};
 
 	return {
-		folders,
+		stream: {
+			folders: getFolders()
+		},
 		user: locals.user,
 		title: m.recap()
 	};

--- a/frontend/src/routes/(app)/(internal)/recap/+page.server.ts
+++ b/frontend/src/routes/(app)/(internal)/recap/+page.server.ts
@@ -1,12 +1,92 @@
-import { BASE_API_URL } from '$lib/utils/constants';
+import { BASE_API_URL, complianceResultColorMap } from '$lib/utils/constants';
 import type { PageServerLoad } from './$types';
 import { m } from '$paraglide/messages';
 
+const RESULT_ORDER = [
+	'not_assessed',
+	'partially_compliant',
+	'non_compliant',
+	'compliant',
+	'not_applicable'
+] as const;
+
+type ResultKey = (typeof RESULT_ORDER)[number];
+type ResultCounts = Partial<Record<ResultKey, number>>;
+
+interface RawRecapAssessment {
+	id: string;
+	name: string;
+	framework_name: string;
+	result_counts: ResultCounts;
+	global_score: {
+		maturity_score: number | null;
+		max_score: number;
+	};
+}
+
+interface RawRecapFolder {
+	id: string;
+	name: string;
+	compliance_assessments: RawRecapAssessment[];
+}
+
+function buildDonutValues(resultCounts: ResultCounts) {
+	return RESULT_ORDER.map((result) => ({
+		name: result,
+		value: resultCounts[result] ?? 0,
+		itemStyle: { color: complianceResultColorMap[result] ?? '#d1d5db' }
+	}));
+}
+
+function buildOverallCompliance(complianceAssessments: RawRecapAssessment[]) {
+	const counts = Object.fromEntries(RESULT_ORDER.map((result) => [result, 0])) as Record<ResultKey, number>;
+
+	for (const assessment of complianceAssessments) {
+		for (const result of RESULT_ORDER) {
+			counts[result] += assessment.result_counts[result] ?? 0;
+		}
+	}
+
+	const total = Object.values(counts).reduce((sum, value) => sum + value, 0);
+
+	return {
+		values: RESULT_ORDER.map((result) => ({
+			name: result,
+			value: counts[result],
+			itemStyle: { color: complianceResultColorMap[result] ?? '#d1d5db' },
+			percentage: total > 0 ? ((counts[result] / total) * 100).toFixed(1) : '0'
+		})),
+		total
+	};
+}
+
+function shapeFolderForRecap(folder: RawRecapFolder) {
+	const complianceAssessments = folder.compliance_assessments.map((assessment) => ({
+		id: assessment.id,
+		name: assessment.name,
+		framework: {
+			str: assessment.framework_name
+		},
+		donut: {
+			result: {
+				values: buildDonutValues(assessment.result_counts)
+			}
+		},
+		globalScore: assessment.global_score
+	}));
+
+	return {
+		id: folder.id,
+		name: folder.name,
+		compliance_assessments: complianceAssessments,
+		overallCompliance: buildOverallCompliance(folder.compliance_assessments)
+	};
+}
+
 export const load: PageServerLoad = async ({ locals, fetch }) => {
-	// /recap used to trigger a request cascade:
-	// folders -> assessments per folder -> donut/global_score per assessment.
-	// The dedicated backend endpoint returns the exact shape needed by the page
-	// in one call, which removes the previous N+1 pattern from the frontend.
+	// The backend now returns only recap raw data (counts + score summaries).
+	// Presentation details such as colors, percentages, and donut wiring are
+	// rebuilt here on the frontend side.
 	const folders = await fetch(`${BASE_API_URL}/compliance-assessments/recap/`)
 		.then(async (res) => {
 			if (!res.ok) {
@@ -14,7 +94,7 @@ export const load: PageServerLoad = async ({ locals, fetch }) => {
 			}
 			return res.json();
 		})
-		.then((data) => data.results ?? [])
+		.then((data) => ((data.results ?? []) as RawRecapFolder[]).map(shapeFolderForRecap))
 		.catch((error) => {
 			// Keep the page renderable even if the recap endpoint fails temporarily.
 			console.error('Failed to load recap:', error);

--- a/frontend/src/routes/(app)/(internal)/recap/+page.server.ts
+++ b/frontend/src/routes/(app)/(internal)/recap/+page.server.ts
@@ -39,7 +39,10 @@ function buildDonutValues(resultCounts: ResultCounts) {
 }
 
 function buildOverallCompliance(complianceAssessments: RawRecapAssessment[]) {
-	const counts = Object.fromEntries(RESULT_ORDER.map((result) => [result, 0])) as Record<ResultKey, number>;
+	const counts = Object.fromEntries(RESULT_ORDER.map((result) => [result, 0])) as Record<
+		ResultKey,
+		number
+	>;
 
 	for (const assessment of complianceAssessments) {
 		for (const result of RESULT_ORDER) {

--- a/frontend/src/routes/(app)/(internal)/recap/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/recap/+page.svelte
@@ -7,6 +7,7 @@
 	import type { PageData } from './$types';
 	import Anchor from '$lib/components/Anchor/Anchor.svelte';
 	import { canPerformAction } from '$lib/utils/access-control';
+	import LoadingSpinner from '$lib/components/utils/LoadingSpinner.svelte';
 
 	const REQUIREMENT_ASSESSMENT_STATUS = [
 		'compliant',
@@ -25,9 +26,9 @@
 
 	let { data }: Props = $props();
 
-	const foldersWithAssessments = $derived(
-		(data?.folders ?? []).filter((f) => (f?.compliance_assessments?.length ?? 0) > 0)
-	);
+	function getFoldersWithAssessments(folders = []) {
+		return folders.filter((f) => (f?.compliance_assessments?.length ?? 0) > 0);
+	}
 
 	const model = URL_MODEL_MAP['folders'];
 	const canEditObject = (folder): boolean =>
@@ -42,136 +43,146 @@
 <div class="p-4 space-y-6 bg-gray-50 min-h-screen card">
 	<h2 class="text-2xl font-extrabold text-gray-800 mb-4">{m.overallCompliance()}</h2>
 
-	<div class="space-y-6">
-		{#if foldersWithAssessments.length === 0}
-			<div class="flex items-center justify-center min-h-[60vh]">
-				<div class="text-center max-w-lg">
-					<p class="text-xl font-bold text-gray-800">
-						{m.createYourFirstAuditToSeeRecapPage()}
-					</p>
-					<p class="mt-2 text-sm text-gray-600">
-						{m.AuditExistsYoullSeeOverallCompliance()}
-					</p>
-				</div>
+	{#await data.stream.folders}
+		<div class="flex items-center justify-center min-h-[60vh]">
+			<div class="text-center max-w-lg">
+				<LoadingSpinner />
+				<p class="mt-4 text-xl font-bold text-gray-800">{m.loading()}</p>
 			</div>
-		{:else}
-			{#each foldersWithAssessments as folder}
-				<div
-					class="bg-white shadow-lg rounded-xl border border-gray-200 overflow-hidden transition hover:shadow-xl transform w-full"
-				>
-					<div
-						class="p-4 bg-gradient-to-r from-primary-400 to-primary-500 text-white flex justify-between items-center"
-					>
-						<a class="text-lg font-bold hover:underline" href="/folders/{folder.id}">
-							{folder.name}
-						</a>
+		</div>
+	{:then folders}
+		{@const foldersWithAssessments = getFoldersWithAssessments(folders)}
+		<div class="space-y-6">
+			{#if foldersWithAssessments.length === 0}
+				<div class="flex items-center justify-center min-h-[60vh]">
+					<div class="text-center max-w-lg">
+						<p class="text-xl font-bold text-gray-800">
+							{m.createYourFirstAuditToSeeRecapPage()}
+						</p>
+						<p class="mt-2 text-sm text-gray-600">
+							{m.AuditExistsYoullSeeOverallCompliance()}
+						</p>
 					</div>
-
-					{#if folder.overallCompliance?.values?.length > 0}
-						<div class="px-4 py-3 bg-gradient-to-r from-primary-50 to-primary-100 rounded-b-lg">
-							<p class="text-sm font-semibold text-primary-700 mb-2">{m.globalOverall()}</p>
-							<div class="flex h-6 rounded-lg overflow-hidden shadow-inner">
-								{#each folder.overallCompliance.values.sort((a, b) => REQUIREMENT_ASSESSMENT_STATUS.indexOf(a.name) - REQUIREMENT_ASSESSMENT_STATUS.indexOf(b.name)) as sp}
-									<div
-										class="flex justify-center items-center text-xs font-semibold"
-										style="
-										width: {sp.percentage}%;
-										background-color: {sp.itemStyle.color};
-										color: {sp.itemStyle.color === '#000000' ? 'white' : 'black'};
-										box-shadow: inset 0 0 1px rgba(0,0,0,0.3);
-									"
-									>
-										{Number(sp.percentage) > 5 ? `${sp.percentage}%` : ''}
-									</div>
-								{/each}
-							</div>
+				</div>
+			{:else}
+				{#each foldersWithAssessments as folder}
+					<div
+						class="bg-white shadow-lg rounded-xl border border-gray-200 overflow-hidden transition hover:shadow-xl transform w-full"
+					>
+						<div
+							class="p-4 bg-gradient-to-r from-primary-400 to-primary-500 text-white flex justify-between items-center"
+						>
+							<a class="text-lg font-bold hover:underline" href="/folders/{folder.id}">
+								{folder.name}
+							</a>
 						</div>
-					{/if}
 
-					<div class="p-4 space-y-4">
-						{#each folder.compliance_assessments as assessment}
-							<div class="bg-gray-50 rounded-lg p-4 shadow-inner transition hover:bg-gray-100">
-								<div class="flex justify-between items-center mb-4">
-									<div>
-										<p class="text-sm font-semibold">{m.name()}</p>
-										<a
-											class="text-blue-600 hover:underline text-lg font-bold"
-											href="/compliance-assessments/{assessment.id}"
+						{#if folder.overallCompliance?.values?.length > 0}
+							<div class="px-4 py-3 bg-gradient-to-r from-primary-50 to-primary-100 rounded-b-lg">
+								<p class="text-sm font-semibold text-primary-700 mb-2">{m.globalOverall()}</p>
+								<div class="flex h-6 rounded-lg overflow-hidden shadow-inner">
+									{#each folder.overallCompliance.values.sort((a, b) => REQUIREMENT_ASSESSMENT_STATUS.indexOf(a.name) - REQUIREMENT_ASSESSMENT_STATUS.indexOf(b.name)) as sp}
+										<div
+											class="flex justify-center items-center text-xs font-semibold"
+											style="
+											width: {sp.percentage}%;
+											background-color: {sp.itemStyle.color};
+											color: {sp.itemStyle.color === '#000000' ? 'white' : 'black'};
+											box-shadow: inset 0 0 1px rgba(0,0,0,0.3);
+										"
 										>
-											{assessment.name}
-										</a>
-									</div>
-									<div>
-										<p class="text-sm font-semibold">{m.framework()}</p>
-										<p>{assessment.framework.str}</p>
-									</div>
-								</div>
-
-								<div class="flex flex-col lg:flex-row items-center justify-between gap-4">
-									{#if assessment.globalScore.maturity_score >= 0}
-										<div class="flex justify-center items-center lg:order-1">
-											<div class="relative">
-												<Progress
-													value={formatScoreValue(
-														assessment.globalScore.maturity_score,
-														assessment.globalScore.max_score
-													)}
-													min={0}
-													max={100}
-												>
-													<Progress.Circle class="[--size:--spacing(24)]">
-														<Progress.CircleTrack />
-														<Progress.CircleRange
-															class={displayScoreColor(
-																assessment.globalScore.maturity_score,
-																assessment.globalScore.max_score
-															)}
-														/>
-													</Progress.Circle>
-													<div class="absolute inset-0 flex items-center justify-center">
-														<p class="font-semibold text-2xl">
-															{assessment.globalScore.maturity_score}
-														</p>
-													</div>
-												</Progress>
-											</div>
+											{Number(sp.percentage) > 5 ? `${sp.percentage}%` : ''}
 										</div>
-									{/if}
+									{/each}
+								</div>
+							</div>
+						{/if}
 
-									<div class="w-full lg:w-3/5 h-40 lg:h-32">
-										<DonutChart
-											s_label={m.complianceAssessments()}
-											name={assessment.name + '_donut'}
-											values={assessment.donut.result.values}
-										/>
+						<div class="p-4 space-y-4">
+							{#each folder.compliance_assessments as assessment}
+								<div class="bg-gray-50 rounded-lg p-4 shadow-inner transition hover:bg-gray-100">
+									<div class="flex justify-between items-center mb-4">
+										<div>
+											<p class="text-sm font-semibold">{m.name()}</p>
+											<a
+												class="text-blue-600 hover:underline text-lg font-bold"
+												href="/compliance-assessments/{assessment.id}"
+											>
+												{assessment.name}
+											</a>
+										</div>
+										<div>
+											<p class="text-sm font-semibold">{m.framework()}</p>
+											<p>{assessment.framework.str}</p>
+										</div>
 									</div>
 
-									<div
-										class="flex flex-row lg:flex-col space-x-2 lg:space-x-0 lg:space-y-2 lg:order-3"
-									>
-										{#if canEditObject(folder)}
-											<Anchor
-												href="/compliance-assessments/{assessment.id}/edit?next=/recap"
+									<div class="flex flex-col lg:flex-row items-center justify-between gap-4">
+										{#if assessment.globalScore.maturity_score >= 0}
+											<div class="flex justify-center items-center lg:order-1">
+												<div class="relative">
+													<Progress
+														value={formatScoreValue(
+															assessment.globalScore.maturity_score,
+															assessment.globalScore.max_score
+														)}
+														min={0}
+														max={100}
+													>
+														<Progress.Circle class="[--size:--spacing(24)]">
+															<Progress.CircleTrack />
+															<Progress.CircleRange
+																class={displayScoreColor(
+																	assessment.globalScore.maturity_score,
+																	assessment.globalScore.max_score
+																)}
+															/>
+														</Progress.Circle>
+														<div class="absolute inset-0 flex items-center justify-center">
+															<p class="font-semibold text-2xl">
+																{assessment.globalScore.maturity_score}
+															</p>
+														</div>
+													</Progress>
+												</div>
+											</div>
+										{/if}
+
+										<div class="w-full lg:w-3/5 h-40 lg:h-32">
+											<DonutChart
+												s_label={m.complianceAssessments()}
+												name={assessment.name + '_donut'}
+												values={assessment.donut.result.values}
+											/>
+										</div>
+
+										<div
+											class="flex flex-row lg:flex-col space-x-2 lg:space-x-0 lg:space-y-2 lg:order-3"
+										>
+											{#if canEditObject(folder)}
+												<Anchor
+													href="/compliance-assessments/{assessment.id}/edit?next=/recap"
+													class="btn preset-filled-primary-500 w-1/2 lg:w-full"
+												>
+													<i class="fa-solid fa-edit mr-2"></i>
+													{m.edit()}
+												</Anchor>
+											{/if}
+											<a
+												href="/compliance-assessments/{assessment.id}/export"
 												class="btn preset-filled-primary-500 w-1/2 lg:w-full"
 											>
-												<i class="fa-solid fa-edit mr-2"></i>
-												{m.edit()}
-											</Anchor>
-										{/if}
-										<a
-											href="/compliance-assessments/{assessment.id}/export"
-											class="btn preset-filled-primary-500 w-1/2 lg:w-full"
-										>
-											<i class="fa-solid fa-download mr-2"></i>
-											{m.exportButton()}
-										</a>
+												<i class="fa-solid fa-download mr-2"></i>
+												{m.exportButton()}
+											</a>
+										</div>
 									</div>
 								</div>
-							</div>
-						{/each}
+							{/each}
+						</div>
 					</div>
-				</div>
-			{/each}
-		{/if}
-	</div>
+				{/each}
+			{/if}
+		</div>
+	{/await}
 </div>


### PR DESCRIPTION
## Fix

Fixed an issue where the `Summary` section was very slow (it was taking 2 minutes to load 81 audits on my end).
The frontend now makes only 1 call to the backend instead of `1 + F + 2A` (**F**: Amount of folders ; **A**: Amount of audits) in the previous version.
A new dedicated backend endpoint provides minimum info required for the frontend to display the summary.

The following lines of codes in the backend boosted performance :
```py
assessments = list(
    # Reuse get_queryset() so the endpoint keeps the same visibility rules and
    # request-level filtering as the rest of the ComplianceAssessment API.
    self.get_queryset()
    .select_related("folder", "framework")
    .prefetch_related(
        Prefetch(
            "requirement_assessments",
            queryset=RequirementAssessment.objects.filter(
                requirement__assessable=True
            ).select_related("requirement"),
        )
    )
    # We need requirement on each requirement_assessment because the recap
    # calculations inspect requirement.implementation_groups.
    # Keep the response ordering stable so the page does not need to sort again.
    .order_by(Lower("folder__name"), Lower("name"))
)
```

Also, the `Summary` page now loads data asynchronously to ensure that the page has been clicked on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consolidated recap endpoint for single-request recap data
  * Folder-level aggregates and updated donut/percentage visuals from consolidated counts

* **Refactor**
  * Simplified recap page loading to stream folders and reduce rendering complexity
  * Scoring and aggregation logic revised for more accurate NA/score handling

* **Bug Fixes**
  * Improved error handling and empty-state fallback when recap load fails
<!-- end of auto-generated comment: release notes by coderabbit.ai -->