### PR TITLE
fix: improve perimeter fetching logic and handle django validation errors more robustly

### DIFF
--- a/backend/core/helpers.py
+++ b/backend/core/helpers.py
@@ -1991,10 +1991,13 @@ def handle(exc, context):
     # translate django validation error which ...
     # .. causes HTTP 500 status ==> DRF validation which will cause 400 HTTP status
     if isinstance(exc, DjValidationError):
-        data = exc.message_dict
-        if DJ_NON_FIELD_ERRORS in data:
-            data[DRF_NON_FIELD_ERRORS] = data[DJ_NON_FIELD_ERRORS]
-            del data[DJ_NON_FIELD_ERRORS]
+        if hasattr(exc, "error_dict"):
+            data = exc.message_dict
+            if DJ_NON_FIELD_ERRORS in data:
+                data[DRF_NON_FIELD_ERRORS] = data[DJ_NON_FIELD_ERRORS]
+                del data[DJ_NON_FIELD_ERRORS]
+        else:
+            data = {DRF_NON_FIELD_ERRORS: exc.messages}
 
         exc = DRFValidationError(detail=data)
 

--- a/backend/serdes/domain_io.py
+++ b/backend/serdes/domain_io.py
@@ -754,9 +754,9 @@ def process_model_relationships(
             )
 
         case "complianceassessment":
-            _fields["perimeter"] = Perimeter.objects.get(
+            _fields["perimeter"] = Perimeter.objects.filter(
                 id=link_dump_database_ids.get(_fields["perimeter"])
-            )
+            ).first()
             _fields["framework"] = Framework.objects.get(urn=_fields["framework"])
 
         case "appliedcontrol":


### PR DESCRIPTION
### Root cause

In `domain_io.py`, the `complianceassessment` case calls `Perimeter.objects.get(id=...)` which raises `DoesNotExist` when:

1. **The CA has no perimeter** (`perimeter=null` in the dump) -> `link_dump_database_ids.get(None)` returns `None` -> `Perimeter.objects.get(id=None)` raises `DoesNotExist`
---

### Reproduction steps ( null perimeter)

1. Log in to a CISO Assistant instance
2. Create a **domain** (e.g. "Test Domain")
3. Create a **compliance assessment** inside that domain, **do not set a perimeter** (leave it blank)
4. Export the domain via
5. Import the `.bak` on the same or another instance via
6. **500 error**: `Perimeter matching query does not exist`

The secondary bug (the `AttributeError: 'ValidationError' object has no attribute 'error_dict'` in `helpers.py:1994`) fires on top of bug 1, turning the 400-class validation error into an unhandled 500.

### Fix

The `riskassessment` case handles this correctly with `.filter(...).first()` so the same - serdes/domain_io.py: complianceassessment perimeter lookup now uses .filter(...).first() which returns None safely when perimeter is null, no more DoesNotExist and the  core/helpers.py: handle() now checks hasattr(exc, "error_dict") before calling message_dict, falling back to exc.messages for list-based ValidationError no more AttributeError causing the 500


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined validation error handling to consistently and reliably process Django validation errors across all error types, improving error message consistency in API responses.
  * Enhanced relationship resolution robustness to gracefully tolerate missing or unresolvable references without interrupting data mapping operations, improving system stability and preventing unexpected failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->