### PR TITLE
fix: Processing natures are not permissions-gated anymore

### DIFF
--- a/backend/privacy/models.py
+++ b/backend/privacy/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from iam.models import User, FolderMixin
+from iam.models import User, FolderMixin, PublishInRootFolderMixin
 from tprm.models import Entity
 from core.models import Actor, AppliedControl, Asset, Evidence, Incident, Perimeter
 from core.models import FilteringLabelMixin, I18nObjectMixin, ReferentialObjectMixin
@@ -60,7 +60,9 @@ TRANSFER_MECHANISM_CHOICES = (
 )
 
 
-class ProcessingNature(ReferentialObjectMixin, I18nObjectMixin):
+class ProcessingNature(
+    ReferentialObjectMixin, I18nObjectMixin, PublishInRootFolderMixin
+):
     DEFAULT_PROCESSING_NATURE = [
         "privacy_collection",
         "privacy_recording",
@@ -88,6 +90,7 @@ class ProcessingNature(ReferentialObjectMixin, I18nObjectMixin):
         for value in cls.DEFAULT_PROCESSING_NATURE:
             ProcessingNature.objects.update_or_create(
                 name=value,
+                defaults={"is_published": True},
             )
 
     class Meta:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Processing Nature entries are now automatically published by default, ensuring immediate availability throughout the system without requiring manual publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->