### PR TITLE
feat: button to reset filters on table and clear out the cache

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1034,6 +1034,7 @@
 	"partial": "Partial",
 	"noResultFound": "No result found",
 	"filters": "Filters",
+	"resetFilters": "Reset filters",
 	"notApplicableScore": "You cannot score if the requirement assessment is not applicable",
 	"maturity": "Maturity",
 	"progress": "Progress",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -921,6 +921,7 @@
 	"partial": "Partielle",
 	"noResultFound": "Aucun résultat trouvé",
 	"filters": "Filtres",
+	"resetFilters": "Réinitialiser les filtres",
 	"notApplicableScore": "Vous ne pouvez pas scorer si l'évaluation des exigences n'est pas applicable",
 	"maturity": "Maturité",
 	"progress": "Progression",

--- a/frontend/src/lib/components/ModelTable/ModelTable.svelte
+++ b/frontend/src/lib/components/ModelTable/ModelTable.svelte
@@ -10,7 +10,7 @@
 	import { CUSTOM_ACTIONS_COMPONENT, getFieldComponentMap, URL_MODEL_MAP } from '$lib/utils/crud';
 	import { safeTranslate, unsafeTranslate } from '$lib/utils/i18n';
 	import { toCamelCase } from '$lib/utils/locales.js';
-	import { onMount, tick } from 'svelte';
+	import { onMount, tick, untrack } from 'svelte';
 
 	import { tableA11y } from '$lib/components/ModelTable/actions';
 	// Types
@@ -359,9 +359,11 @@
 			}
 		}
 		history.replaceState(history.state, '', page.url.pathname + page.url.search);
-		// Persist all filter values (including empty) so cleared defaults stay cleared
+		// untracked so resetFilters can delete the entry without retriggering us
 		if (isStandaloneTable) {
-			$tableFilterStates[filterStoreKey] = { ...filterValues };
+			untrack(() => {
+				$tableFilterStates[filterStoreKey] = { ...filterValues };
+			});
 		}
 		setTimeout(() => {
 			handler.invalidate();
@@ -537,12 +539,10 @@
 		for (const field of filteredFields) {
 			const defaultValue = defaultFilters[field] ?? [];
 			filterValues[field] = Array.isArray(defaultValue)
-				? defaultValue.map((v: any) => ({ ...v }))
+				? defaultValue.map((v: { value: string }) => ({ ...v }))
 				: [];
 		}
 		if (!isStandaloneTable) return;
-		// Let the persistence $effect flush once on the cleared values, then wipe
-		// the cache entry so defaults (if any) can re-apply on next mount.
 		await tick();
 		const next = { ...$tableFilterStates };
 		delete next[filterStoreKey];

--- a/frontend/src/lib/components/ModelTable/ModelTable.svelte
+++ b/frontend/src/lib/components/ModelTable/ModelTable.svelte
@@ -10,7 +10,7 @@
 	import { CUSTOM_ACTIONS_COMPONENT, getFieldComponentMap, URL_MODEL_MAP } from '$lib/utils/crud';
 	import { safeTranslate, unsafeTranslate } from '$lib/utils/i18n';
 	import { toCamelCase } from '$lib/utils/locales.js';
-	import { onMount } from 'svelte';
+	import { onMount, tick } from 'svelte';
 
 	import { tableA11y } from '$lib/components/ModelTable/actions';
 	// Types
@@ -533,6 +533,22 @@
 		filteredFields?.reduce((acc, field) => acc + filterValues?.[field]?.length, 0)
 	);
 
+	async function resetFilters() {
+		for (const field of filteredFields) {
+			const defaultValue = defaultFilters[field] ?? [];
+			filterValues[field] = Array.isArray(defaultValue)
+				? defaultValue.map((v: any) => ({ ...v }))
+				: [];
+		}
+		if (!isStandaloneTable) return;
+		// Let the persistence $effect flush once on the cleared values, then wipe
+		// the cache entry so defaults (if any) can re-apply on next mount.
+		await tick();
+		const next = { ...$tableFilterStates };
+		delete next[filterStoreKey];
+		$tableFilterStates = next;
+	}
+
 	let classesHexBackgroundText = $derived((backgroundHexColor: string) => {
 		return isDark(backgroundHexColor) ? 'text-white' : '';
 	});
@@ -705,6 +721,21 @@
 											/>
 										{/if}
 									{/each}
+									{#if filterCount > 0}
+										<div class="flex justify-end pt-1">
+											<button
+												type="button"
+												class="btn preset-tonal-surface text-sm"
+												onclick={() => {
+													resetFilters();
+													openState = false;
+												}}
+											>
+												<i class="fa-solid fa-rotate-left mr-2"></i>
+												{m.resetFilters()}
+											</button>
+										</div>
+									{/if}
 								{/snippet}
 							</SuperForm>
 						</Popover.Content>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reset filters button in the filter menu that appears only when filters are active, clears all applied filters, and closes the filter popover to return users to the default view.

* **Localization**
  * Added English and French localized text for the reset filters control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->