### PR TITLE
fix: solve regression for score definition updates

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -1000,6 +1000,7 @@ class LibraryUpdater:
 
                 # Update compliance assessments score boundaries
                 compliance_assessments_to_update = []
+                ca_with_scale_change = []
                 ca_bounds = {}
                 for ca in compliance_assessments:
                     # preserve user overrides: update only if CA still equals previous framework defaults
@@ -1013,6 +1014,7 @@ class LibraryUpdater:
                         ca.min_score = new_framework.min_score
                         ca.max_score = new_framework.max_score
                         needs_update = True
+                        ca_with_scale_change.append(ca)
                     if definition_on_prev_defaults and scores_definition_changed:
                         ca.scores_definition = new_framework.scores_definition
                         needs_update = True
@@ -1046,7 +1048,7 @@ class LibraryUpdater:
                                 )
                             ),
                         )
-                        for ca in compliance_assessments_to_update
+                        for ca in ca_with_scale_change
                     }
 
                 # main loop by requirement_node
@@ -1125,8 +1127,7 @@ class LibraryUpdater:
                         if (
                             ra.is_scored
                             and ra.score is not None
-                            and ra.compliance_assessment
-                            in compliance_assessments_to_update
+                            and ra.compliance_assessment in ca_with_scale_change
                         ):
                             default_min = (
                                 0

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -962,11 +962,12 @@ class LibraryUpdater:
                 order_id = 0
                 all_fields_to_update = set()
 
-                # Check if score boundaries changed
+                # Check if score boundaries changed (triggers warning + strategy prompt)
                 score_boundaries_changed = (
                     prev_min != new_framework.min_score
                     or prev_max != new_framework.max_score
                 )
+                scores_definition_changed = prev_def != new_framework.scores_definition
 
                 # If scores changed and no strategy provided, raise exception for frontend to handle
                 if (
@@ -981,7 +982,6 @@ class LibraryUpdater:
                         if (
                             ca.min_score == prev_min
                             and ca.max_score == prev_max
-                            and ca.scores_definition == prev_def
                         )
                     ]
 
@@ -1006,16 +1006,21 @@ class LibraryUpdater:
                 ca_bounds = {}
                 for ca in compliance_assessments:
                     # preserve user overrides: update only if CA still equals previous framework defaults
-                    still_on_prev_defaults = (
+                    scale_on_prev_defaults = (
                         ca.min_score == prev_min
                         and ca.max_score == prev_max
-                        and ca.scores_definition == prev_def
                     )
+                    definition_on_prev_defaults = ca.scores_definition == prev_def
 
-                    if still_on_prev_defaults and score_boundaries_changed:
+                    needs_update = False
+                    if scale_on_prev_defaults and score_boundaries_changed:
                         ca.min_score = new_framework.min_score
                         ca.max_score = new_framework.max_score
+                        needs_update = True
+                    if definition_on_prev_defaults and scores_definition_changed:
                         ca.scores_definition = new_framework.scores_definition
+                        needs_update = True
+                    if needs_update:
                         compliance_assessments_to_update.append(ca)
 
                 if compliance_assessments_to_update:

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -979,10 +979,7 @@ class LibraryUpdater:
                     affected_cas = [
                         ca
                         for ca in compliance_assessments
-                        if (
-                            ca.min_score == prev_min
-                            and ca.max_score == prev_max
-                        )
+                        if (ca.min_score == prev_min and ca.max_score == prev_max)
                     ]
 
                     if affected_cas:
@@ -1007,8 +1004,7 @@ class LibraryUpdater:
                 for ca in compliance_assessments:
                     # preserve user overrides: update only if CA still equals previous framework defaults
                     scale_on_prev_defaults = (
-                        ca.min_score == prev_min
-                        and ca.max_score == prev_max
+                        ca.min_score == prev_min and ca.max_score == prev_max
                     )
                     definition_on_prev_defaults = ca.scores_definition == prev_def
 


### PR DESCRIPTION
fix regression for score definition updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved framework-update behavior for compliance assessments: score boundaries (min/max) and score definitions are now detected and handled separately. Bulk updates only change assessments that previously relied on the affected boundary or definition defaults, and scalar requirement updates run only for assessments impacted by boundary changes—preventing unintended overrides and preserving user-set values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->