### PR TITLE
fix(lib): two typos in ISO 27001:2022 english wordings

### DIFF
--- a/backend/library/libraries/iso27001-2022.yaml
+++ b/backend/library/libraries/iso27001-2022.yaml
@@ -1025,7 +1025,7 @@ objects:
           \u5E94\u534F\u8BAE\u3002"
   - urn: urn:intuitem:risk:function:doc-pol:a.5.22
     ref_id: A.5.22
-    name: Monitor, review and change management of supplier services
+    name: Monitoring, review and change management of supplier services
     category: process
     description: This control ensures supplier services are monitored, reviewed, and
       adjusted to maintain information security. Measures include service level agreements,

--- a/backend/library/libraries/iso27001-2022.yaml
+++ b/backend/library/libraries/iso27001-2022.yaml
@@ -5470,7 +5470,7 @@ objects:
       depth: 3
       parent_urn: urn:intuitem:risk:req_node:iso27001-2022:9
       ref_id: '9.1'
-      name: Monitoring, measurement, analysis, evaluation
+      name: Monitoring, measurement, analysis and evaluation
       description: "Monitor, measure, analyze, and evaluate the ISMS\u2019s performance\
         \ and effectiveness using appropriate methods aligned with the organization\u2019\
         s objectives."
@@ -7038,7 +7038,7 @@ objects:
       depth: 3
       parent_urn: urn:intuitem:risk:req_node:iso27001-2022:a.5
       ref_id: A.5.22
-      name: Monitor, review and change management of supplier services
+      name: Monitoring, review and change management of supplier services
       description: This control ensures supplier services are monitored, reviewed,
         and adjusted to maintain information security. Measures include service level
         agreements, periodic reviews, and contract updates.

--- a/backend/library/libraries/iso27001-2022.yaml
+++ b/backend/library/libraries/iso27001-2022.yaml
@@ -8,7 +8,7 @@ description: "Information security, cybersecurity and privacy protection \u2014 
   \ security management systems \u2014 Requirements"
 copyright: This is the outline of the ISO27001-2022 standard. You can purchase the
   full standard from https://www.iso.org/standard/27001
-version: 17
+version: 18
 publication_date: 2026-01-10
 provider: ISO/IEC
 packager: intuitem


### PR DESCRIPTION
## Summary

- Line 5473: `Monitoring, measurement, analysis, evaluation` → `Monitoring, measurement, analysis and evaluation`
- Line 7041: `Monitor, review and change management of supplier services` → `Monitoring, review and change management of supplier services`

Both fixes apply to the English-language control names in the ISO 27001:2022 library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated English wording for two ISO 27001:2022 requirement titles to improve clarity and consistency:
    - A.5.22: revised to gerund phrasing for clearer action emphasis.
    - 9.1: changed comma-separated list to an "and" conjunction for improved readability.
  * Bumped the library version to reflect these documentation refinements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->