### PR TITLE
fix(backend): search Threats by "ref_id"

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1680,7 +1680,7 @@ class ThreatViewSet(BaseModelViewSet):
         "filtering_labels",
         "urn",
     ]
-    search_fields = ["name", "provider", "description"]
+    search_fields = ["ref_id", "name", "provider", "description"]
 
     def get_queryset(self):
         return (


### PR DESCRIPTION
## Fix

It's now possible to search Threats by `ref_id`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Threat search now includes additional matching against reference IDs, enabling users to find threats by ref_id in addition to name, provider, and description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->