### PR TITLE
fix: correct docker-compose.sh in config directories 

### DIFF
--- a/config/docker-compose.sh
+++ b/config/docker-compose.sh
@@ -14,6 +14,21 @@ fi
 
 cp ./docker-compose-custom.yml ../docker-compose.yml
 
+mkdir -p ./db
+
+if is_linux_gnu_stat; then
+  DB_OWNER="$(get_owner_linux ./db)"
+  if [ "$DB_OWNER" != "$EXPECTED_OWNER" ]; then
+    echo "Fixing ownership of ./db (was $DB_OWNER, expected $EXPECTED_OWNER)"
+    if ! chown -R "$EXPECTED_OWNER" ./db 2>/dev/null; then
+      echo "chown failed, retrying with sudo..."
+      sudo chown -R "$EXPECTED_OWNER" ./db
+    fi
+  fi
+else
+  echo "Non-Linux (no GNU stat detected): skipping ownership fix for ./db"
+fi
+
 echo "Starting CISO Assistant services..."
 docker compose -f ./docker-compose-custom.yml pull
 echo "Initializing the database. This can take up to 3 minutes, please wait.."

--- a/config/docker-compose.sh
+++ b/config/docker-compose.sh
@@ -1,6 +1,16 @@
 #! /bin/bash
 set -euo pipefail
 
+EXPECTED_OWNER="1001:1001"
+
+is_linux_gnu_stat() {
+  stat -c '%u:%g' . >/dev/null 2>&1
+}
+
+get_owner_linux() {
+  stat -c '%u:%g' "$1"
+}
+
 if [ ! -f ./docker-compose-custom.yml ]; then
   echo "Docker compose file doesn't exist. Run 'python3 make_config.py' first."
   exit 1

--- a/enterprise/config/docker-compose.sh
+++ b/enterprise/config/docker-compose.sh
@@ -11,6 +11,22 @@ if [ -d ./db ]; then
   echo "For a clean start, you can remove the db folder, and then run 'docker compose rm -fs' and start over"
   exit 1
 fi
+
+mkdir -p ./db
+
+if is_linux_gnu_stat; then
+  DB_OWNER="$(get_owner_linux ./db)"
+  if [ "$DB_OWNER" != "$EXPECTED_OWNER" ]; then
+    echo "Fixing ownership of ./db (was $DB_OWNER, expected $EXPECTED_OWNER)"
+    if ! chown -R "$EXPECTED_OWNER" ./db 2>/dev/null; then
+      echo "chown failed, retrying with sudo..."
+      sudo chown -R "$EXPECTED_OWNER" ./db
+    fi
+  fi
+else
+  echo "Non-Linux (no GNU stat detected): skipping ownership fix for ./db"
+fi
+
 echo "Starting CISO Assistant services..."
 docker compose -f ./docker-compose.yml pull
 echo "Initializing the database. This can take up to 2 minutes, please wait.."

--- a/enterprise/config/docker-compose.sh
+++ b/enterprise/config/docker-compose.sh
@@ -1,6 +1,16 @@
 #! /bin/bash
 set -euo pipefail
 
+EXPECTED_OWNER="1001:1001"
+
+is_linux_gnu_stat() {
+  stat -c '%u:%g' . >/dev/null 2>&1
+}
+
+get_owner_linux() {
+  stat -c '%u:%g' "$1"
+}
+
 if [ ! -f ./docker-compose.yml ]; then
   echo "Docker compose file doesn't exist. Run 'python3 make_config.py' first."
   exit 1


### PR DESCRIPTION
We forgot to add in the root-less docker compose scripts the part when we check the ownership of db using linux gnu stat.

this PR is here to fix 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved Docker Compose startup procedures with automatic verification and correction of database directory ownership permissions on Linux systems.
  * Enhanced initialization and configuration process with intelligent platform detection for improved cross-platform compatibility and reliability.
  * Added graceful fallback handling for unsupported environments, ensuring smooth and reliable deployment across all varied system configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->