### PR TITLE
feat(data-wizard): enhance perimeter import functionality with new fields and documentation

### DIFF
--- a/backend/data_wizard/views.py
+++ b/backend/data_wizard/views.py
@@ -1032,6 +1032,60 @@ class UserRecordConsumer(RecordConsumer[None]):
 
 class PerimeterRecordConsumer(RecordConsumer[None]):
     SERIALIZER_CLASS = PerimeterWriteSerializer
+    SOURCE_KEY_MAP: ClassVar[dict[str, tuple[str, ...]]] = {
+        "lc_status": ("lc_status", "status"),
+        "default_assignee": ("default_assignee",),
+    }
+
+    @staticmethod
+    def _normalize_lc_status(value: str) -> Optional[str]:
+        normalized = value.strip().lower()
+        if not normalized:
+            return None
+
+        # Support canonical model keys (e.g. in_prod)
+        by_key = {key.lower(): key for key, _label in Perimeter.PRJ_LC_STATUS}
+        if normalized in by_key:
+            return by_key[normalized]
+
+        # Support display labels (e.g. Production), localized by current language
+        by_label = {
+            str(label).strip().lower(): key for key, label in Perimeter.PRJ_LC_STATUS
+        }
+        return by_label.get(normalized)
+
+    def _build_update_data(self, record: dict, record_data: dict) -> dict:
+        update_data = super()._build_update_data(record, record_data)
+
+        # Keep parity with AppliedControl.owner behavior: if the column is
+        # present (even empty), propagate it so UPDATE mode can clear stale M2M.
+        if "default_assignee" not in update_data and "default_assignee" in record:
+            update_data["default_assignee"] = record_data.get("default_assignee", [])
+
+        return update_data
+
+    @staticmethod
+    def _resolve_default_assignees(value) -> list[UUID]:
+        if not isinstance(value, str):
+            return []
+
+        entries = [
+            entry.strip() for entry in re.split(r"[;,|]", value) if entry.strip()
+        ]
+        actor_ids = []
+
+        for entry in entries:
+            actor = Actor.objects.filter(user__email__iexact=entry).first()
+            if actor is None:
+                actor = Actor.objects.filter(team__name__iexact=entry).first()
+            if actor is not None:
+                actor_ids.append(actor.id)
+            else:
+                logger.warning(
+                    "Could not resolve a perimeter default assignee reference; skipping."
+                )
+
+        return actor_ids
 
     def create_context(self):
         return None, None
@@ -1048,13 +1102,37 @@ class PerimeterRecordConsumer(RecordConsumer[None]):
         if not name:
             return {}, Error(record=record, error="Name field is mandatory")
 
-        return {
+        raw_lc_status = record.get("lc_status") or record.get("status")
+        lc_status = "in_design"
+        if raw_lc_status not in (None, ""):
+            normalized_status = self._normalize_lc_status(str(raw_lc_status))
+            if normalized_status is None:
+                allowed = ", ".join(k for k, _ in Perimeter.PRJ_LC_STATUS)
+                return {}, Error(
+                    record=record,
+                    error=(
+                        f"Unsupported perimeter status '{raw_lc_status}'. "
+                        f"Allowed values: {allowed}"
+                    ),
+                )
+            lc_status = normalized_status
+
+        default_assignee = self._resolve_default_assignees(
+            record.get("default_assignee")
+        )
+
+        data = {
             "name": name,
             "folder": domain,
             "ref_id": record.get("ref_id", ""),
             "description": record.get("description", ""),
-            "status": record.get("status"),
-        }, None
+            "lc_status": lc_status,
+        }
+
+        if "default_assignee" in record:
+            data["default_assignee"] = default_assignee
+
+        return data, None
 
 
 class ThreatRecordConsumer(RecordConsumer[None]):

--- a/backend/data_wizard/views.py
+++ b/backend/data_wizard/views.py
@@ -1036,23 +1036,21 @@ class PerimeterRecordConsumer(RecordConsumer[None]):
         "lc_status": ("lc_status", "status"),
         "default_assignee": ("default_assignee",),
     }
+    _LC_STATUS_BY_KEY: ClassVar[dict[str, str]] = {
+        key.lower(): key for key, _ in Perimeter.PRJ_LC_STATUS
+    }
+    _LC_STATUS_BY_LABEL: ClassVar[dict[str, str]] = {
+        str(label).strip().lower(): key for key, label in Perimeter.PRJ_LC_STATUS
+    }
 
-    @staticmethod
-    def _normalize_lc_status(value: str) -> Optional[str]:
+    @classmethod
+    def _normalize_lc_status(cls, value: str) -> Optional[str]:
         normalized = value.strip().lower()
         if not normalized:
             return None
-
-        # Support canonical model keys (e.g. in_prod)
-        by_key = {key.lower(): key for key, _label in Perimeter.PRJ_LC_STATUS}
-        if normalized in by_key:
-            return by_key[normalized]
-
-        # Support display labels (e.g. Production), localized by current language
-        by_label = {
-            str(label).strip().lower(): key for key, label in Perimeter.PRJ_LC_STATUS
-        }
-        return by_label.get(normalized)
+        return cls._LC_STATUS_BY_KEY.get(normalized) or cls._LC_STATUS_BY_LABEL.get(
+            normalized
+        )
 
     def _build_update_data(self, record: dict, record_data: dict) -> dict:
         update_data = super()._build_update_data(record, record_data)
@@ -1069,9 +1067,7 @@ class PerimeterRecordConsumer(RecordConsumer[None]):
         if not isinstance(value, str):
             return []
 
-        entries = [
-            entry.strip() for entry in re.split(r"[;,|]", value) if entry.strip()
-        ]
+        entries = [entry.strip() for entry in value.split(";") if entry.strip()]
         actor_ids = []
 
         for entry in entries:
@@ -1082,7 +1078,8 @@ class PerimeterRecordConsumer(RecordConsumer[None]):
                 actor_ids.append(actor.id)
             else:
                 logger.warning(
-                    "Could not resolve a perimeter default assignee reference; skipping."
+                    "Could not resolve perimeter default assignee %r; skipping.",
+                    entry,
                 )
 
         return actor_ids

--- a/cli/clica.py
+++ b/cli/clica.py
@@ -321,7 +321,7 @@ DATA_WIZARD_COMMANDS = [
             "Import perimeters using the Data Wizard backend.\n"
             "\nRequired columns: name\n"
             "Optional columns: ref_id, description, domain, lc_status (or status), "
-            "default_assignee (user email or team name; supports comma/semicolon/pipe separators)\n"
+            "default_assignee (user email or team name; supports semicolon)\n"
         ),
         "requires_folder": True,
         "requires_perimeter": False,

--- a/cli/clica.py
+++ b/cli/clica.py
@@ -317,7 +317,12 @@ DATA_WIZARD_COMMANDS = [
     {
         "command": "import_perimeters",
         "model_type": "Perimeter",
-        "help": "Import perimeters using the Data Wizard backend.",
+        "help": (
+            "Import perimeters using the Data Wizard backend.\n"
+            "\nRequired columns: name\n"
+            "Optional columns: ref_id, description, domain, lc_status (or status), "
+            "default_assignee (user email or team name; supports comma/semicolon/pipe separators)\n"
+        ),
         "requires_folder": True,
         "requires_perimeter": False,
         "requires_framework": False,

--- a/documentation/data_wizard_analysis.md
+++ b/documentation/data_wizard_analysis.md
@@ -150,9 +150,10 @@ The Data Wizard defines the following `ModelType` enum for supported imports:
 | `ref_id` | No | Reference ID |
 | `description` | No | |
 | `status` | No | Alias accepted (mapped to `lc_status`) |
-| `default_assignee` | No | User email or team name, comma/semicolon/pipe separated |
+| `default_assignee` | No | User email or team name, semicolon-separated |
 
 **Missing Fields from Model:**
+
 | Field | Type | Priority |
 |-------|------|----------|
 | None | - | - |

--- a/documentation/data_wizard_analysis.md
+++ b/documentation/data_wizard_analysis.md
@@ -149,13 +149,13 @@ The Data Wizard defines the following `ModelType` enum for supported imports:
 | `domain` | No | Folder lookup |
 | `ref_id` | No | Reference ID |
 | `description` | No | |
-| `status` | No | |
+| `status` | No | Alias accepted (mapped to `lc_status`) |
+| `default_assignee` | No | User email or team name, comma/semicolon/pipe separated |
 
 **Missing Fields from Model:**
 | Field | Type | Priority |
 |-------|------|----------|
-| `reference_link` | URLField | Medium |
-| `filtering_labels` | M2M | Medium |
+| None | - | - |
 
 ---
 


### PR DESCRIPTION
Fix the SUP-1236 by taking into account the status field + default_assignee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import now accepts normalized lifecycle status (lc_status) with validation and defaults to "in_design" when empty
  * `default_assignee` accepts user email or team name (semicolon-separated) and will emit warnings for unresolved entries

* **Bug Fixes**
  * Import/update now correctly clears stale assignee links when an empty assignee is provided

* **Documentation**
  * Clarified import schema and CLI help with required/optional columns and input formats
<!-- end of auto-generated comment: release notes by coderabbit.ai -->