### PR TITLE
chore(ci): align node heap size with Dockerfile

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Build community frontend
         working-directory: ${{ env.frontend-directory }}
         env:
-          NODE_OPTIONS: "--max-old-space-size=6144"
+          NODE_OPTIONS: "--max-old-space-size=10240"
         run: pnpm run build
 
       - name: Upload Community Frontend Build Artifact
@@ -100,7 +100,7 @@ jobs:
       - name: Build enterprise frontend
         working-directory: ${{ env.enterprise-frontend-directory }}
         env:
-          NODE_OPTIONS: "--max-old-space-size=6144"
+          NODE_OPTIONS: "--max-old-space-size=10240"
         run: make
 
       - name: Upload Enterprise Frontend Build Artifact

--- a/.github/workflows/startup-tests.yml
+++ b/.github/workflows/startup-tests.yml
@@ -98,7 +98,7 @@ jobs:
           nohup poetry run python manage.py runserver &
       - name: Build frontend
         env:
-          NODE_OPTIONS: "--max-old-space-size=6144"
+          NODE_OPTIONS: "--max-old-space-size=10240"
         working-directory: ${{ env.frontend-directory }}
         run: pnpm run build
       - name: Run tests
@@ -235,7 +235,7 @@ jobs:
       - name: Build enterprise frontend
         working-directory: ${{ env.enterprise-frontend-directory }}
         env:
-          NODE_OPTIONS: "--max-old-space-size=6144"
+          NODE_OPTIONS: "--max-old-space-size=10240"
         run: make
       - name: Install Playwright Browsers
         working-directory: ${{ env.enterprise-frontend-build-directory }}


### PR DESCRIPTION
This will unblock PR #4043, as heap allocations at build time scale linearly with locale strings. This essentially buys us some time to figure out a way to make paraglide messages NOT blow up build-time heap allocation limits.

## Summary
Bumps `--max-old-space-size` in `functional-tests.yml` and `startup-tests.yml` from 6144MB to 10240MB, matching the value already set in both Dockerfiles. Recent builds were hitting the 6 GB cap; the Dockerfile builds were not.