### PR TITLE
fix: asset explorer preserves page title when toggling domain display

### DIFF
--- a/frontend/src/routes/(app)/(internal)/assets/graph/+page.server.ts
+++ b/frontend/src/routes/(app)/(internal)/assets/graph/+page.server.ts
@@ -9,5 +9,5 @@ export const load = (async ({ fetch, url }) => {
 	const res = await fetch(endpoint);
 	const data = await res.json();
 
-	return { data, hideDomains };
+	return { data, hideDomains, title: 'Assets Explorer' };
 }) satisfies PageServerLoad;

--- a/frontend/src/routes/(app)/(internal)/assets/graph/+page.server.ts
+++ b/frontend/src/routes/(app)/(internal)/assets/graph/+page.server.ts
@@ -9,5 +9,5 @@ export const load = (async ({ fetch, url }) => {
 	const res = await fetch(endpoint);
 	const data = await res.json();
 
-	return { data, hideDomains, title: 'Assets Explorer' };
+	return { data, hideDomains, title: 'assetsExplorer' };
 }) satisfies PageServerLoad;

--- a/frontend/src/routes/(app)/(internal)/assets/graph/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/assets/graph/+page.svelte
@@ -35,7 +35,7 @@
 	</div>
 	<div class="w-full h-screen">
 		<GraphExplorer
-			title="Assets Explorer"
+			title={m.assetsExplorer()}
 			data={data.data}
 			edgeLength={100}
 			maxLegendItems={15}

--- a/frontend/src/routes/(app)/(internal)/assets/graph/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/assets/graph/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import type { PageData } from './$types';
 	import GraphExplorer from '$lib/components/DataViz/GraphExplorer.svelte';
-	import { pageTitle } from '$lib/utils/stores';
 	import { m } from '$paraglide/messages';
 	import { goto } from '$lib/utils/breadcrumbs';
 
@@ -10,7 +9,6 @@
 	}
 
 	let { data }: Props = $props();
-	pageTitle.set('Assets Explorer');
 </script>
 
 <div class="bg-white shadow-sm flex flex-col overflow-x-auto">


### PR DESCRIPTION
- **fix: asset explorer preserves page title when toggling domain display**
- **fixup**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved page title management for the assets explorer to enhance code maintainability and consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->