### PR TITLE
perf: list endpoint follow-ups (folder cache, N+1s, prefetch reuse)

### DIFF
--- a/backend/app_tests/api/test_api_requirement_assessments.py
+++ b/backend/app_tests/api/test_api_requirement_assessments.py
@@ -501,8 +501,8 @@ class TestRequirementAssessmentListParentBulkLoad:
             if 'from "core_requirementnode"' in q["sql"].lower()
             and '"urn" in (' in q["sql"].lower()
         )
-        assert bulk_parent_loads >= 1, (
-            "expected at least one bulk parent load via urn__in"
+        assert bulk_parent_loads == 1, (
+            f"expected exactly one bulk parent load via urn__in, got {bulk_parent_loads}"
         )
 
     def test_response_correct_when_no_requirements_have_parents(

--- a/backend/app_tests/api/test_api_requirement_assessments.py
+++ b/backend/app_tests/api/test_api_requirement_assessments.py
@@ -460,9 +460,7 @@ class TestRequirementAssessmentListParentBulkLoad:
                 f"wrong parent for child {req['ref_id']!r}: {parent}"
             )
 
-    def test_query_count_is_bounded_by_page_not_by_rows(
-        self, authenticated_client
-    ):
+    def test_query_count_is_bounded_by_page_not_by_rows(self, authenticated_client):
         """For N RAs whose requirements all have parent_urn, the bulk
         loader should issue ONE query for parents (not N)."""
         from django.db import connection

--- a/backend/app_tests/api/test_api_requirement_assessments.py
+++ b/backend/app_tests/api/test_api_requirement_assessments.py
@@ -364,3 +364,193 @@ class TestRequirementAssessmentsAuthenticated:
             RequirementAssessment.Status.choices,
             user_group=test.user_group,
         )
+
+
+# ---------------------------------------------------------------------------
+# Bulk parent-requirement lookup on /api/requirement-assessments/ list.
+#
+# `RequirementNode.parent_requirement` falls back to
+# `RequirementNode.objects.filter(urn=self.parent_urn).first()` when its
+# `_parent_requirement_obj` cache isn't populated — one query per row, so
+# the RA list paid an N+1 across every requirement that had a parent.
+#
+# `RequirementAssessmentViewSet._get_optimized_object_data` now bulk-fetches
+# all parent nodes for the page (`urn__in=<parent_urns>`) and seeds the
+# `_parent_requirement_obj` cache. The tests below pin:
+#   - output: parent_requirement field is populated correctly,
+#   - perf: query count for parent lookups is bounded by 1 per page.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestRequirementAssessmentListParentBulkLoad:
+    @staticmethod
+    def _build_audit_with_parent_child_requirements(n_pairs=5):
+        """Create a framework with `n_pairs` parent/child requirement pairs,
+        plus an audit and one RA per child requirement. Returns the audit."""
+        import uuid
+
+        folder = Folder.get_root_folder()
+        fw = Framework.objects.create(
+            name=f"parent-bulk-fw-{uuid.uuid4().hex[:6]}",
+            folder=folder,
+            urn=f"urn:test:parent-bulk:{uuid.uuid4().hex[:12]}",
+            is_published=True,
+        )
+        # Create parents (assessable=False is OK; the property only
+        # cares about parent_urn matching).
+        parent_urns = []
+        for i in range(n_pairs):
+            parent_urn = f"{fw.urn}:parent:{i}"
+            RequirementNode.objects.create(
+                framework=fw,
+                urn=parent_urn,
+                ref_id=f"P{i}",
+                name=f"Parent {i}",
+                assessable=False,
+                folder=folder,
+            )
+            parent_urns.append(parent_urn)
+        # Create child requirements pointing at those parents.
+        for i in range(n_pairs):
+            RequirementNode.objects.create(
+                framework=fw,
+                urn=f"{fw.urn}:child:{i}",
+                ref_id=f"C{i}",
+                parent_urn=parent_urns[i],
+                name=f"Child {i}",
+                assessable=True,
+                folder=folder,
+            )
+        audit = ComplianceAssessment.objects.create(
+            folder=folder,
+            framework=fw,
+            name=f"parent-bulk-audit-{uuid.uuid4().hex[:6]}",
+        )
+        audit.create_requirement_assessments()
+        return audit
+
+    def test_response_includes_parent_requirement(self, authenticated_client):
+        audit = self._build_audit_with_parent_child_requirements(n_pairs=3)
+        r = authenticated_client.get(
+            "/api/requirement-assessments/",
+            {
+                "compliance_assessment": str(audit.id),
+                "requirement__assessable": "true",
+                "limit": 10,
+            },
+        )
+        assert r.status_code == 200, r.content
+        body = r.json()
+        results = body["results"] if isinstance(body, dict) else body
+        # Only assessable children are in scope here; the non-assessable
+        # parent rows have no parent_requirement of their own and are
+        # filtered out above.
+        assert len(results) > 0
+        for item in results:
+            req = item.get("requirement") or {}
+            parent = req.get("parent_requirement")
+            assert parent is not None, (
+                f"parent_requirement not populated for {req.get('ref_id')!r}"
+            )
+            # Child ref_id is e.g. "C2"; matching parent urn ends with
+            # ":parent:2".
+            child_idx = req["ref_id"][1:]
+            assert parent["urn"].endswith(f":parent:{child_idx}"), (
+                f"wrong parent for child {req['ref_id']!r}: {parent}"
+            )
+
+    def test_query_count_is_bounded_by_page_not_by_rows(
+        self, authenticated_client
+    ):
+        """For N RAs whose requirements all have parent_urn, the bulk
+        loader should issue ONE query for parents (not N)."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        audit = self._build_audit_with_parent_child_requirements(n_pairs=10)
+
+        with CaptureQueriesContext(connection) as ctx:
+            r = authenticated_client.get(
+                "/api/requirement-assessments/",
+                {
+                    "compliance_assessment": str(audit.id),
+                    "requirement__assessable": "true",
+                    "limit": 10,
+                },
+            )
+        assert r.status_code == 200, r.content
+
+        # Count queries that look like a per-row parent lookup:
+        #   SELECT ... FROM core_requirementnode WHERE urn = ? LIMIT 1
+        per_row_parent_lookups = sum(
+            1
+            for q in ctx.captured_queries
+            if 'from "core_requirementnode"' in q["sql"].lower()
+            and '"urn" =' in q["sql"].lower()
+            and "limit 1" in q["sql"].lower()
+        )
+        assert per_row_parent_lookups == 0, (
+            f"per-row parent lookups detected ({per_row_parent_lookups}); "
+            f"expected the bulk loader in _get_optimized_object_data to "
+            f"replace them with a single urn__in query"
+        )
+
+        # Also: a single bulk parent load — `WHERE urn IN (...)`.
+        bulk_parent_loads = sum(
+            1
+            for q in ctx.captured_queries
+            if 'from "core_requirementnode"' in q["sql"].lower()
+            and '"urn" in (' in q["sql"].lower()
+        )
+        assert bulk_parent_loads >= 1, (
+            "expected at least one bulk parent load via urn__in"
+        )
+
+    def test_response_correct_when_no_requirements_have_parents(
+        self, authenticated_client
+    ):
+        """Bulk loader must not emit a query when the page has no
+        parent_urns to look up."""
+        import uuid
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        folder = Folder.get_root_folder()
+        fw = Framework.objects.create(
+            name=f"no-parent-fw-{uuid.uuid4().hex[:6]}",
+            folder=folder,
+            urn=f"urn:test:no-parent:{uuid.uuid4().hex[:12]}",
+            is_published=True,
+        )
+        for i in range(3):
+            RequirementNode.objects.create(
+                framework=fw,
+                urn=f"{fw.urn}:r:{i}",
+                ref_id=f"R{i}",
+                assessable=True,
+                folder=folder,
+                # parent_urn intentionally None
+            )
+        audit = ComplianceAssessment.objects.create(
+            folder=folder, framework=fw, name=f"no-parent-{uuid.uuid4().hex[:6]}"
+        )
+        audit.create_requirement_assessments()
+
+        with CaptureQueriesContext(connection) as ctx:
+            r = authenticated_client.get(
+                "/api/requirement-assessments/",
+                {"compliance_assessment": str(audit.id), "limit": 10},
+            )
+        assert r.status_code == 200, r.content
+
+        # No urn__in lookup should fire when there are no parent_urns.
+        bulk_parent_loads = sum(
+            1
+            for q in ctx.captured_queries
+            if 'from "core_requirementnode"' in q["sql"].lower()
+            and '"urn" in (' in q["sql"].lower()
+        )
+        assert bulk_parent_loads == 0, (
+            "bulk loader emitted a query despite no parent_urns on the page"
+        )

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -2545,14 +2545,18 @@ class RequirementNode(ReferentialObjectMixin, I18nObjectMixin):
 
     @property
     def get_questions_translated(self) -> dict | None:
-        # If the caller has already prefetched `questions__choices` on this
-        # node's parent queryset, use that cache directly. Calling
-        # `self.questions.prefetch_related("choices").all()` here builds a
-        # new queryset that bypasses the cache, so list serialisation pays
-        # 1-2 fresh queries per requirement node (N+1). Falling back to the
-        # in-property prefetch keeps non-prefetched callers correct.
+        # If the caller has prefetched BOTH `questions` AND
+        # `questions__choices` on this node's parent queryset, read from
+        # the cache directly. If only `questions` is prefetched (no
+        # `__choices`), reading `question.choices.all()` per question
+        # would N+1 — fall back to a fresh `prefetch_related("choices")`
+        # in that case (and when nothing is prefetched at all).
         cache = getattr(self, "_prefetched_objects_cache", None)
-        if cache is not None and "questions" in cache:
+        questions = cache.get("questions") if cache is not None else None
+        if questions is not None and (
+            not questions
+            or "choices" in getattr(questions[0], "_prefetched_objects_cache", {})
+        ):
             questions_qs = self.questions.all()
         else:
             questions_qs = self.questions.prefetch_related("choices").all()

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -2545,7 +2545,17 @@ class RequirementNode(ReferentialObjectMixin, I18nObjectMixin):
 
     @property
     def get_questions_translated(self) -> dict | None:
-        questions_qs = self.questions.prefetch_related("choices").all()
+        # If the caller has already prefetched `questions__choices` on this
+        # node's parent queryset, use that cache directly. Calling
+        # `self.questions.prefetch_related("choices").all()` here builds a
+        # new queryset that bypasses the cache, so list serialisation pays
+        # 1-2 fresh queries per requirement node (N+1). Falling back to the
+        # in-property prefetch keeps non-prefetched callers correct.
+        cache = getattr(self, "_prefetched_objects_cache", None)
+        if cache is not None and "questions" in cache:
+            questions_qs = self.questions.all()
+        else:
+            questions_qs = self.questions.prefetch_related("choices").all()
         if not questions_qs:
             return None
 

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -2584,31 +2584,16 @@ class ComplianceAssessmentListSerializer(BaseModelSerializer):
     progress = serializers.SerializerMethodField()
 
     def get_progress(self, obj):
-        if not obj.selected_implementation_groups:
-            # Fast path: read page-scoped counts from optimized_data
-            # (computed in ComplianceAssessmentViewSet._get_optimized_object_data
-            # via a single bounded GROUP BY query, replacing the previous
-            # Count(distinct=True) annotations).
-            optimized_data = self.context.get("optimized_data") or {}
-            total = optimized_data.get("total_requirements", {}).get(obj.id, 0)
-            assessed = optimized_data.get("assessed_requirements", {}).get(obj.id, 0)
-        else:
-            # Use prefetched requirement_assessments filtered by implementation groups
-            selected_groups = set(obj.selected_implementation_groups)
-            ras = [
-                ra
-                for ra in obj.requirement_assessments.all()
-                if selected_groups & set(ra.requirement.implementation_groups or [])
-            ]
-            total = len(ras)
-            assessed = len(
-                [
-                    ra
-                    for ra in ras
-                    if ra.result != RequirementAssessment.Result.NOT_ASSESSED
-                    or ra.score is not None
-                ]
-            )
+        # Both the no-IG and IG branches read from the page-scoped
+        # counts populated by
+        # `ComplianceAssessmentViewSet._get_optimized_object_data`.
+        # That replaces both the Count(distinct=True) annotations
+        # previously on the queryset and the unconditional
+        # `requirement_assessments` prefetch (which loaded ~5k RA + RN
+        # ORM objects per page).
+        optimized_data = self.context.get("optimized_data") or {}
+        total = optimized_data.get("total_requirements", {}).get(obj.id, 0)
+        assessed = optimized_data.get("assessed_requirements", {}).get(obj.id, 0)
         return int((assessed / total) * 100) if total else 0
 
     class Meta:

--- a/backend/core/tests/test_question_translation.py
+++ b/backend/core/tests/test_question_translation.py
@@ -195,3 +195,68 @@ class TestRequirementNodeSerializerTranslation:
         assert questions["urn:test:trans:qsc"]["text"] == "Pick one color"
         choices = questions["urn:test:trans:qsc"]["choices"]
         assert choices[0]["value"] == "Red"
+
+
+@pytest.mark.django_db
+class TestQuestionsTranslatedPrefetchCache:
+    """Verify `get_questions_translated` honours the parent queryset's
+    prefetch cache for `questions__choices`.
+
+    Before the fix, the property called
+    `self.questions.prefetch_related("choices").all()` unconditionally,
+    which builds a fresh queryset and bypasses any cache populated by
+    the caller — so list serialisation paid 1-2 queries per requirement
+    node (N+1).
+
+    The fix uses the prefetched cache when available and falls back to
+    the in-property prefetch otherwise. These tests pin both:
+      - output equivalence between the cached and uncached path,
+      - query count drops to zero when prefetch is present.
+    """
+
+    def test_output_matches_uncached_path(self, translated_node):
+        """Same node, two access paths (with and without prefetch).
+        Output must be identical."""
+        rn = translated_node["rn"]
+        # Uncached path: hit the property on the model instance directly.
+        with translation_override("en"):
+            uncached = rn.get_questions_translated
+
+        # Cached path: re-fetch via a queryset that prefetches
+        # questions__choices, then read the property.
+        rn_cached = RequirementNode.objects.prefetch_related(
+            "questions__choices"
+        ).get(pk=rn.pk)
+        with translation_override("en"):
+            cached = rn_cached.get_questions_translated
+
+        assert cached == uncached
+
+    def test_no_queries_when_prefetched(self, translated_node):
+        """With prefetch, accessing the property must not hit the DB."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        rn_cached = RequirementNode.objects.prefetch_related(
+            "questions__choices"
+        ).get(pk=translated_node["rn"].pk)
+        with CaptureQueriesContext(connection) as ctx:
+            with translation_override("en"):
+                _ = rn_cached.get_questions_translated
+        # Zero DB hits — the prefetch cache supplies both questions and
+        # their choices.
+        assert len(ctx.captured_queries) == 0, [
+            q["sql"] for q in ctx.captured_queries
+        ]
+
+    def test_queries_when_not_prefetched(self, translated_node):
+        """Without prefetch, the property still works (fallback path)."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        rn = RequirementNode.objects.get(pk=translated_node["rn"].pk)
+        with CaptureQueriesContext(connection) as ctx:
+            with translation_override("en"):
+                _ = rn.get_questions_translated
+        # Non-zero — proves we're not relying on a stale cache.
+        assert len(ctx.captured_queries) > 0

--- a/backend/core/tests/test_question_translation.py
+++ b/backend/core/tests/test_question_translation.py
@@ -224,9 +224,9 @@ class TestQuestionsTranslatedPrefetchCache:
 
         # Cached path: re-fetch via a queryset that prefetches
         # questions__choices, then read the property.
-        rn_cached = RequirementNode.objects.prefetch_related(
-            "questions__choices"
-        ).get(pk=rn.pk)
+        rn_cached = RequirementNode.objects.prefetch_related("questions__choices").get(
+            pk=rn.pk
+        )
         with translation_override("en"):
             cached = rn_cached.get_questions_translated
 
@@ -237,17 +237,15 @@ class TestQuestionsTranslatedPrefetchCache:
         from django.db import connection
         from django.test.utils import CaptureQueriesContext
 
-        rn_cached = RequirementNode.objects.prefetch_related(
-            "questions__choices"
-        ).get(pk=translated_node["rn"].pk)
+        rn_cached = RequirementNode.objects.prefetch_related("questions__choices").get(
+            pk=translated_node["rn"].pk
+        )
         with CaptureQueriesContext(connection) as ctx:
             with translation_override("en"):
                 _ = rn_cached.get_questions_translated
         # Zero DB hits — the prefetch cache supplies both questions and
         # their choices.
-        assert len(ctx.captured_queries) == 0, [
-            q["sql"] for q in ctx.captured_queries
-        ]
+        assert len(ctx.captured_queries) == 0, [q["sql"] for q in ctx.captured_queries]
 
     def test_queries_when_not_prefetched(self, translated_node):
         """Without prefetch, the property still works (fallback path)."""

--- a/backend/core/tests/test_question_translation.py
+++ b/backend/core/tests/test_question_translation.py
@@ -6,6 +6,8 @@ locale is active, and falls back to default text otherwise.
 """
 
 import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.utils.translation import override as translation_override
 
 from core.models import (
@@ -234,9 +236,6 @@ class TestQuestionsTranslatedPrefetchCache:
 
     def test_no_queries_when_prefetched(self, translated_node):
         """With prefetch, accessing the property must not hit the DB."""
-        from django.db import connection
-        from django.test.utils import CaptureQueriesContext
-
         rn_cached = RequirementNode.objects.prefetch_related("questions__choices").get(
             pk=translated_node["rn"].pk
         )
@@ -249,9 +248,6 @@ class TestQuestionsTranslatedPrefetchCache:
 
     def test_queries_when_not_prefetched(self, translated_node):
         """Without prefetch, the property still works (fallback path)."""
-        from django.db import connection
-        from django.test.utils import CaptureQueriesContext
-
         rn = RequirementNode.objects.get(pk=translated_node["rn"].pk)
         with CaptureQueriesContext(connection) as ctx:
             with translation_override("en"):
@@ -268,9 +264,6 @@ class TestQuestionsTranslatedPrefetchCache:
         must detect the missing `choices` cache and fall back to the
         in-property `prefetch_related("choices")` so the work stays
         bounded."""
-        from django.db import connection
-        from django.test.utils import CaptureQueriesContext
-
         rn_partial = RequirementNode.objects.prefetch_related("questions").get(
             pk=translated_node["rn"].pk
         )

--- a/backend/core/tests/test_question_translation.py
+++ b/backend/core/tests/test_question_translation.py
@@ -258,3 +258,28 @@ class TestQuestionsTranslatedPrefetchCache:
                 _ = rn.get_questions_translated
         # Non-zero — proves we're not relying on a stale cache.
         assert len(ctx.captured_queries) > 0
+
+    def test_falls_back_when_questions_prefetched_without_choices(
+        self, translated_node
+    ):
+        """If the caller prefetches `questions` but NOT
+        `questions__choices`, using the cached questions and then
+        accessing `question.choices.all()` per row would N+1. The guard
+        must detect the missing `choices` cache and fall back to the
+        in-property `prefetch_related("choices")` so the work stays
+        bounded."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        rn_partial = RequirementNode.objects.prefetch_related("questions").get(
+            pk=translated_node["rn"].pk
+        )
+        with CaptureQueriesContext(connection) as ctx:
+            with translation_override("en"):
+                result = rn_partial.get_questions_translated
+        assert result is not None
+        # Fallback path runs `self.questions.prefetch_related("choices").all()` —
+        # 2 queries (questions + choices via IN), not 1 + N.
+        assert len(ctx.captured_queries) <= 2, [
+            q["sql"][:120] for q in ctx.captured_queries
+        ]

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -13985,6 +13985,40 @@ class RequirementAssessmentViewSet(BaseModelViewSet):
     """
 
     model = RequirementAssessment
+
+    def _get_optimized_object_data(self, queryset):
+        """Bulk-load parent requirement nodes for the page so the
+        `RequirementNode.parent_requirement` property short-circuits its
+        per-row `.filter(urn=self.parent_urn).first()` fallback.
+
+        Mirrors the `_parent_requirement_obj` cache pattern used in the
+        other places that build requirement trees. Bounded by the page —
+        a single `urn__in=<page parent_urns>` query.
+        """
+        optimized_data = super()._get_optimized_object_data(queryset)
+        page = list(queryset)
+        if not page:
+            return optimized_data
+        parent_urns = {
+            req.parent_urn
+            for ra in page
+            for req in [getattr(ra, "requirement", None)]
+            if req is not None and req.parent_urn
+        }
+        if not parent_urns:
+            return optimized_data
+        parents_by_urn = {
+            p.urn: p
+            for p in RequirementNode.objects.filter(urn__in=parent_urns)
+        }
+        for ra in page:
+            req = getattr(ra, "requirement", None)
+            if req is None:
+                continue
+            parent = parents_by_urn.get(req.parent_urn)
+            if parent is not None:
+                req._parent_requirement_obj = parent
+        return optimized_data
     filterset_fields = [
         "folder",
         "folder__name",

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1555,35 +1555,58 @@ class BaseModelViewSet(viewsets.ModelViewSet):
 
     def _get_optimized_object_data(self, queryset):
         """
-        Calculate folder full paths for objects in the queryset in 1 DB request.
+        Calculate folder full paths for objects in the queryset, reusing
+        the IAM snapshot cache instead of re-running `Folder.objects.all()`
+        on every list response. The snapshot already exposes a
+        folder_id → Folder map (with `name` loaded) and a parent_map; both
+        are kept in sync via Folder.save/delete invalidation.
+
+        Object-side accesses go through `*_id` columns rather than FK
+        attributes so this also works for callers that did not
+        `select_related("folder")` on their queryset.
         """
         initial_objects = list(queryset)
         if not initial_objects:
             return {}
 
+        from iam.cache_builders import get_folder_state
+
+        state = get_folder_state()
+        folders = state.folders
+        parent_map = state.parent_map
+
         path_results = {}
-        folders = {f.id: f for f in Folder.objects.all()}
         for obj in initial_objects:
-            path = []
-            if hasattr(obj, "folder"):
-                queue = deque([obj.folder.id])
-            elif hasattr(obj, "parent_folder") and obj.parent_folder:
-                queue = deque([obj.parent_folder.id])
+            if hasattr(obj, "folder_id"):
+                start_id = obj.folder_id
+            elif getattr(obj, "parent_folder_id", None):
+                start_id = obj.parent_folder_id
             else:
                 continue
+            if start_id is None:
+                continue
+
+            path = []
+            queue = deque([start_id])
             while queue:
                 folder_id = queue.popleft()
-                folder = folders[folder_id]
-                if folder.parent_folder:
+                folder = folders.get(folder_id)
+                if folder is None:
+                    # Cache may briefly miss a folder created in the same
+                    # request before invalidation propagates; bail rather
+                    # than KeyError so the response shape is preserved.
+                    continue
+                parent_id = parent_map.get(folder_id)
+                if parent_id is not None:
                     path.append(
                         {
                             "str": str(folder),
                             "id": folder.id,
-                            "parent_id": folder.parent_folder.id,
+                            "parent_id": parent_id,
                         }
                     )
-                    queue.append(folder.parent_folder.id)
-            path_results[obj.id] = path[::-1]  # Reverse to get root to leaf order
+                    queue.append(parent_id)
+            path_results[obj.id] = path[::-1]  # root → leaf order
 
         return {
             "paths": path_results,

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -11175,41 +11175,77 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
         return super().get_serializer_class(**kwargs)
 
     def _get_optimized_object_data(self, queryset):
-        """Compute per-page requirement counts in one bounded GROUP BY,
-        replacing the Count(distinct=True) annotations dropped from the
-        list queryset. Bounded by `len(queryset)` (≤ page size), so the
-        cost is independent of the total RA table size.
+        """Compute per-page requirement counts in (at most) two bounded
+        queries, replacing both the Count(distinct=True) annotations
+        previously on the queryset and the unconditional
+        `requirement_assessments` prefetch on the list path.
 
-        Only the no-implementation-groups case is computed here; audits
-        with `selected_implementation_groups` still rely on the prefetched
-        `requirement_assessments` for in-Python IG filtering inside
-        `ComplianceAssessmentListSerializer.get_progress`.
+        - Audits without `selected_implementation_groups`: one GROUP BY
+          aggregates `total` / `assessed` via `Count(filter=Q())`.
+        - Audits with `selected_implementation_groups`: one fetch of
+          their requirement_assessments + requirement nodes, filtered
+          in Python by `selected_groups ∩ requirement.implementation_groups`.
+          Same logic the serializer used to walk on the prefetch.
+
+        Bounded by the page size, so cost is independent of the total
+        RA table size — and the common no-IG page now skips touching
+        the RA table altogether on the prefetch path.
         """
         optimized_data = super()._get_optimized_object_data(queryset)
-        audit_ids = [a.id for a in queryset]
-        if not audit_ids:
+        audits = list(queryset)
+        if not audits:
             return optimized_data
 
         not_assessed = RequirementAssessment.Result.NOT_ASSESSED
-        rows = (
-            RequirementAssessment.objects.filter(
-                compliance_assessment_id__in=audit_ids,
-                requirement__assessable=True,
-            )
-            .values("compliance_assessment_id")
-            .annotate(
-                total=Count("id"),
-                assessed=Count(
-                    "id",
-                    filter=~Q(result=not_assessed) | Q(score__isnull=False),
-                ),
-            )
-        )
+        ig_audits = [a for a in audits if a.selected_implementation_groups]
+        plain_ids = [
+            a.id for a in audits if not a.selected_implementation_groups
+        ]
+
         total_map: dict = {}
         assessed_map: dict = {}
-        for r in rows:
-            total_map[r["compliance_assessment_id"]] = r["total"]
-            assessed_map[r["compliance_assessment_id"]] = r["assessed"]
+
+        if plain_ids:
+            rows = (
+                RequirementAssessment.objects.filter(
+                    compliance_assessment_id__in=plain_ids,
+                    requirement__assessable=True,
+                )
+                .values("compliance_assessment_id")
+                .annotate(
+                    total=Count("id"),
+                    assessed=Count(
+                        "id",
+                        filter=~Q(result=not_assessed) | Q(score__isnull=False),
+                    ),
+                )
+            )
+            for r in rows:
+                total_map[r["compliance_assessment_id"]] = r["total"]
+                assessed_map[r["compliance_assessment_id"]] = r["assessed"]
+
+        if ig_audits:
+            ig_groups_by_audit = {
+                a.id: set(a.selected_implementation_groups) for a in ig_audits
+            }
+            for aid in ig_groups_by_audit:
+                total_map.setdefault(aid, 0)
+                assessed_map.setdefault(aid, 0)
+            ras = RequirementAssessment.objects.filter(
+                compliance_assessment_id__in=list(ig_groups_by_audit),
+                requirement__assessable=True,
+            ).select_related("requirement")
+            for ra in ras:
+                req_groups = ra.requirement.implementation_groups or []
+                if not (
+                    ig_groups_by_audit[ra.compliance_assessment_id]
+                    & set(req_groups)
+                ):
+                    continue
+                total_map[ra.compliance_assessment_id] += 1
+                if ra.result != not_assessed or ra.score is not None:
+                    assessed_map[ra.compliance_assessment_id] += 1
+
         optimized_data["total_requirements"] = total_map
         optimized_data["assessed_requirements"] = assessed_map
         return optimized_data
@@ -11237,15 +11273,10 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
         )
 
         if self.action == "list":
-            # List view: lightweight prefetch for progress with implementation groups
-            qs = qs.prefetch_related(
-                Prefetch(
-                    "requirement_assessments",
-                    queryset=RequirementAssessment.objects.filter(
-                        requirement__assessable=True
-                    ).select_related("requirement"),
-                ),
-            )
+            # List view: no requirement_assessments prefetch — both the
+            # IG and no-IG progress paths are computed in
+            # `_get_optimized_object_data` via bounded per-page queries.
+            pass
         elif self.action == "retrieve":
             # Detail view only: full prefetches for the read serializer
             qs = qs.select_related(

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -42,7 +42,7 @@ from django.db.models import (
 )
 from django.db.models.functions import Coalesce
 
-from collections import defaultdict
+from collections import defaultdict, deque
 import pytz
 from uuid import UUID
 from itertools import chain, cycle

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1665,6 +1665,19 @@ class PerimeterViewSet(BaseModelViewSet):
     search_fields = ["name", "ref_id", "description"]
     filterset_fields = ["name", "folder", "campaigns"]
 
+    def get_queryset(self):
+        # `Perimeter.__str__` returns `self.folder.name + "/" + self.name`,
+        # so any list response that serialises perimeters must
+        # select_related("folder") or pay an N+1. The default_assignee
+        # M2M is rendered by FieldsRelatedField and similarly needs to
+        # be prefetched.
+        return (
+            super()
+            .get_queryset()
+            .select_related("folder")
+            .prefetch_related("default_assignee")
+        )
+
     @method_decorator(cache_page(60 * LONG_CACHE_TTL))
     @action(detail=False, name="Get status choices")
     def lc_status(self, request):
@@ -11262,6 +11275,7 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
                 "folder__parent_folder",  # For get_folder_full_path() optimization
                 "framework",  # Displayed in table
                 "perimeter",  # Displayed in table
+                "perimeter__folder",  # Perimeter.__str__ uses folder.name -> avoid N+1
             )
             .annotate(
                 _has_questions=Exists(
@@ -14016,6 +14030,11 @@ class RequirementAssessmentViewSet(BaseModelViewSet):
                 "answers__selected_choices",  # Needed by build_answers_dict() to get choice ref_ids
                 "requirement__questions",  # Needed by FilteredNodeSerializer.questions
                 "requirement__questions__choices",  # Needed by get_questions_translated
+                # Avoid per-row N+1 from RequirementNode.associated_reference_controls
+                # and associated_threats — both are M2Ms iterated by the
+                # FilteredNodeSerializer used inside the read serializer.
+                "requirement__reference_controls",
+                "requirement__threats",
             )
         )
         auditee_folders = get_auditee_filtered_folder_ids(self.request.user)

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -11211,9 +11211,7 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
 
         not_assessed = RequirementAssessment.Result.NOT_ASSESSED
         ig_audits = [a for a in audits if a.selected_implementation_groups]
-        plain_ids = [
-            a.id for a in audits if not a.selected_implementation_groups
-        ]
+        plain_ids = [a.id for a in audits if not a.selected_implementation_groups]
 
         total_map: dict = {}
         assessed_map: dict = {}
@@ -11251,8 +11249,7 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
             for ra in ras:
                 req_groups = ra.requirement.implementation_groups or []
                 if not (
-                    ig_groups_by_audit[ra.compliance_assessment_id]
-                    & set(req_groups)
+                    ig_groups_by_audit[ra.compliance_assessment_id] & set(req_groups)
                 ):
                     continue
                 total_map[ra.compliance_assessment_id] += 1
@@ -14008,8 +14005,7 @@ class RequirementAssessmentViewSet(BaseModelViewSet):
         if not parent_urns:
             return optimized_data
         parents_by_urn = {
-            p.urn: p
-            for p in RequirementNode.objects.filter(urn__in=parent_urns)
+            p.urn: p for p in RequirementNode.objects.filter(urn__in=parent_urns)
         }
         for ra in page:
             req = getattr(ra, "requirement", None)
@@ -14019,6 +14015,7 @@ class RequirementAssessmentViewSet(BaseModelViewSet):
             if parent is not None:
                 req._parent_requirement_obj = parent
         return optimized_data
+
     filterset_fields = [
         "folder",
         "folder__name",


### PR DESCRIPTION
Five follow-ups to PR #4068 — same investigation thread, all targeting list-endpoint hot paths in `BaseModelViewSet` and downstream viewsets/serializers.

## Gains (admin user, lab medians, page size 25)

| endpoint | wall before → after | queries before → after |
|---|---|---|
| `/compliance-assessments/` | 240 → **56 ms** (−77 %) | 27 → 7 |
| `/perimeters/` | 53 → **23 ms** (−57 %) | 89 → 7 |
| `/folders/` | 35 → **22 ms** (−37 %) | 7 → 6 |
| `/filtering-labels/` | 33 → **20 ms** (−38 %) | 27 → 26 |
| `/assets/` | 251 → 234 ms (−7 %) | 18 → 13 |
| `/applied-controls/` | 187 → 178 ms | 11 → 10 |
| `/requirement-assessments/` | 3805 → 3701 ms | 113 → **16** |

Restricted users see similar or larger relative gains (e.g. `/folders/` scoped-reader −62 %, auditee −63 %).

## What changed

Five atomic commits:

1. Folder paths read from the IAM snapshot cache instead of `Folder.objects.all()` per list response — applies to every viewset inheriting `BaseModelViewSet`.
2. CA list drops the `requirement_assessments` prefetch; IG-aware progress computed in `_get_optimized_object_data` alongside the no-IG path. ~5 k fewer ORM objects per page.
3. Three N+1 fixes from HAR analysis: `Perimeter.__str__` chains through `folder.name` (fixed on `PerimeterViewSet` + CA list `perimeter__folder` `select_related`); `RequirementNode.reference_controls` / `threats` added to RA prefetch.
4. `RequirementNode.get_questions_translated` uses the prefetched cache when available (was always re-prefetching, bypassing the caller's cache).
5. RA list bulk-loads `parent_requirement` via `_get_optimized_object_data` (one `urn__in` query for the page), seeding `_parent_requirement_obj` so the property short-circuits its per-row fallback.

Dual-DB safe (SQLite + PostgreSQL); no raw SQL, no PG-specific ORM.

## Test environment

Same lab as #4068: 1 k folders, 250 users across 4 RBAC profiles, 10 k assets, 10 k applied controls, 5 frameworks × 200 requirements (25 % audits with `selected_implementation_groups`), 1 k audits → 200 k requirement assessments, plus M2M wiring. Dev SQLite, page size 25, in-process Django test client, medians of warm runs.

## Test plan
- [x] \`pytest app_tests/api/test_api_{compliance_assessments,applied_controls,assets,requirement_assessments}.py core/tests/test_question_translation.py --reuse-db -q\` — 333 passed locally
- [x] Output equivalence: 60 paired list responses (5 endpoints × 4 RBAC profiles × 3 page offsets) sha256-identical between \`main\` and the branch (\`diff -r\` exits 0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests covering bulk-loading of parent requirements, prefetch caching for question translation, and query-count guards to ensure list responses include parent links without per-row DB lookups.

* **Refactor**
  * List endpoints optimized: parent relationships and related data are bulk-loaded per page, progress is computed from page-scoped counts, and folder/path resolution reuses cached state for faster list views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->