### PR TITLE
fix(templates): standardize mandatory language to `shall` per ISO/IEC Directives Part 2

### DIFF
--- a/backend/library/policy_templates/en/acceptable_use.md
+++ b/backend/library/policy_templates/en/acceptable_use.md
@@ -45,17 +45,17 @@ Users shall not:
 
 ## 6. Mobile and Remote Working
 
-- Mobile devices used for business must be secured with a passcode or biometric authentication
-- Lost or stolen devices must be reported immediately
+- Mobile devices used for business shall be secured with a passcode or biometric authentication
+- Lost or stolen devices shall be reported immediately
 - Public Wi-Fi networks shall not be used for accessing sensitive data without a VPN
-- Remote workers must ensure their work environment maintains confidentiality
+- Remote workers shall ensure their work environment maintains confidentiality
 
 ## 7. Data Handling
 
 - Data shall be handled in accordance with its classification level
 - Sensitive data shall not be stored on personal devices without authorization
 - Data shall not be transferred to external media without approval
-- Cloud storage services must be approved by IT before use
+- Cloud storage services shall be approved by IT before use
 
 ## 8. Monitoring
 

--- a/backend/library/policy_templates/en/access_control.md
+++ b/backend/library/policy_templates/en/access_control.md
@@ -75,4 +75,4 @@ This policy covers all access to organizational information systems, networks, a
 
 ## 10. Policy Review
 
-This policy shall be reviewed at least annually and updated as needed. Changes must be approved by the Information Security Officer.
+This policy shall be reviewed at least annually and updated as needed. Changes shall be approved by the Information Security Officer.

--- a/backend/library/policy_templates/en/cryptography.md
+++ b/backend/library/policy_templates/en/cryptography.md
@@ -17,16 +17,16 @@ This policy applies to all systems, applications, and data owned or managed by [
 
 ### 3.1 Data at Rest
 
-- All sensitive and confidential data stored on servers, databases, and storage media must be encrypted.
-- Full-disk encryption must be enabled on all endpoints (laptops, workstations, mobile devices).
+- All sensitive and confidential data stored on servers, databases, and storage media shall be encrypted.
+- Full-disk encryption shall be enabled on all endpoints (laptops, workstations, mobile devices).
 - Approved algorithms: AES-256 for symmetric encryption.
 
 ### 3.2 Data in Transit
 
-- All network communications carrying sensitive data must use encrypted channels.
+- All network communications carrying sensitive data shall use encrypted channels.
 - TLS 1.2 or higher is required for all web and API communications.
 - Legacy protocols (SSL, TLS 1.0, TLS 1.1) are prohibited.
-- VPN connections must use approved encryption standards for remote access.
+- VPN connections shall use approved encryption standards for remote access.
 
 ### 3.3 Data in Use
 
@@ -37,30 +37,30 @@ This policy applies to all systems, applications, and data owned or managed by [
 
 ### 4.1 Key Generation
 
-- Cryptographic keys must be generated using approved random number generators.
-- Key lengths must meet or exceed current industry recommendations.
+- Cryptographic keys shall be generated using approved random number generators.
+- Key lengths shall meet or exceed current industry recommendations.
 
 ### 4.2 Key Storage and Protection
 
-- Private keys must never be stored in plaintext.
+- Private keys shall never be stored in plaintext.
 - Hardware security modules (HSMs) or equivalent key management services should be used for critical keys.
-- Access to cryptographic keys must be restricted to authorized personnel only.
+- Access to cryptographic keys shall be restricted to authorized personnel only.
 
 ### 4.3 Key Rotation and Expiry
 
-- Encryption keys must be rotated according to a defined schedule based on risk assessment.
-- Compromised or suspected-compromised keys must be revoked and replaced immediately.
-- Expired keys must be securely archived or destroyed according to retention requirements.
+- Encryption keys shall be rotated according to a defined schedule based on risk assessment.
+- Compromised or suspected-compromised keys shall be revoked and replaced immediately.
+- Expired keys shall be securely archived or destroyed according to retention requirements.
 
 ### 4.4 Key Destruction
 
-- Keys that are no longer needed must be securely destroyed using approved methods.
-- Key destruction must be documented and auditable.
+- Keys that are no longer needed shall be securely destroyed using approved methods.
+- Key destruction shall be documented and auditable.
 
 ## 5. Certificate Management
 
-- Digital certificates must be issued by trusted certificate authorities.
-- Certificate expiration must be monitored, and renewals must be completed before expiry.
+- Digital certificates shall be issued by trusted certificate authorities.
+- Certificate expiration shall be monitored, and renewals shall be completed before expiry.
 - Self-signed certificates are prohibited in production environments.
 
 ## 6. Prohibited Practices

--- a/backend/library/policy_templates/en/data_classification.md
+++ b/backend/library/policy_templates/en/data_classification.md
@@ -96,7 +96,7 @@ This policy applies to all data created, collected, processed, stored, or transm
 
 ## 8. Exceptions
 
-Exceptions to this policy must be approved in writing by the Information Security Officer and documented with:
+Exceptions to this policy shall be approved in writing by the Information Security Officer and documented with:
 - Business justification
 - Risk assessment
 - Compensating controls

--- a/backend/library/policy_templates/en/information_security.md
+++ b/backend/library/policy_templates/en/information_security.md
@@ -76,4 +76,4 @@ The organization shall:
 
 ## 10. Policy Review
 
-This policy shall be reviewed at least annually or when significant changes occur. All amendments must be approved by senior management.
+This policy shall be reviewed at least annually or when significant changes occur. All amendments shall be approved by senior management.

--- a/backend/library/policy_templates/en/physical_security.md
+++ b/backend/library/policy_templates/en/physical_security.md
@@ -17,63 +17,63 @@ This policy applies to all facilities owned, leased, or operated by [Organizatio
 
 ### 3.1 Security Perimeters
 
-- Physical security perimeters must be defined to protect areas containing sensitive information and systems.
-- Perimeters must be physically sound with no gaps that could allow unauthorized entry.
-- External doors and windows must be secured when unattended.
+- Physical security perimeters shall be defined to protect areas containing sensitive information and systems.
+- Perimeters shall be physically sound with no gaps that could allow unauthorized entry.
+- External doors and windows shall be secured when unattended.
 
 ### 3.2 Entry Controls
 
-- Access to secure areas must be restricted to authorized personnel only.
-- Electronic access control systems (badge, biometric) must be used for sensitive areas.
-- Access rights must be reviewed regularly and revoked promptly when no longer needed.
-- Access logs must be maintained and reviewed periodically.
+- Access to secure areas shall be restricted to authorized personnel only.
+- Electronic access control systems (badge, biometric) shall be used for sensitive areas.
+- Access rights shall be reviewed regularly and revoked promptly when no longer needed.
+- Access logs shall be maintained and reviewed periodically.
 
 ### 3.3 Visitor Management
 
-- All visitors must be registered, escorted, and supervised while on premises.
-- Visitors must wear visible identification at all times.
-- Visitor access logs must be maintained with entry and exit times.
+- All visitors shall be registered, escorted, and supervised while on premises.
+- Visitors shall wear visible identification at all times.
+- Visitor access logs shall be maintained with entry and exit times.
 
 ## 4. Equipment Security
 
 ### 4.1 Equipment Placement and Protection
 
-- Critical equipment must be sited to minimize risk from environmental hazards and unauthorized access.
-- Server rooms and network equipment must be housed in controlled environments with appropriate temperature and humidity controls.
+- Critical equipment shall be sited to minimize risk from environmental hazards and unauthorized access.
+- Server rooms and network equipment shall be housed in controlled environments with appropriate temperature and humidity controls.
 
 ### 4.2 Power and Cabling
 
-- Uninterruptible power supplies (UPS) must protect critical systems from power failures.
-- Power and telecommunications cabling must be protected from interception and damage.
+- Uninterruptible power supplies (UPS) shall protect critical systems from power failures.
+- Power and telecommunications cabling shall be protected from interception and damage.
 
 ### 4.3 Equipment Maintenance
 
-- Equipment must be maintained in accordance with manufacturer specifications.
+- Equipment shall be maintained in accordance with manufacturer specifications.
 - Only authorized maintenance personnel may service equipment.
-- Maintenance activities must be logged.
+- Maintenance activities shall be logged.
 
 ### 4.4 Secure Disposal
 
-- Equipment containing storage media must be securely wiped or destroyed before disposal or reuse.
-- Disposal of sensitive equipment must be documented with certificates of destruction.
+- Equipment containing storage media shall be securely wiped or destroyed before disposal or reuse.
+- Disposal of sensitive equipment shall be documented with certificates of destruction.
 
 ## 5. Off-Site and Mobile Equipment
 
-- Organization equipment used outside premises must be protected against theft and unauthorized access.
-- Laptops and mobile devices must use full-disk encryption.
-- Equipment must not be left unattended in public or unsecured locations.
+- Organization equipment used outside premises shall be protected against theft and unauthorized access.
+- Laptops and mobile devices shall use full-disk encryption.
+- Equipment shall not be left unattended in public or unsecured locations.
 
 ## 6. Environmental Controls
 
-- Fire detection and suppression systems must be installed in server rooms and data centers.
-- Water leak detection must be implemented in areas housing critical equipment.
-- Environmental monitoring (temperature, humidity) must be in place with alerting.
+- Fire detection and suppression systems shall be installed in server rooms and data centers.
+- Water leak detection shall be implemented in areas housing critical equipment.
+- Environmental monitoring (temperature, humidity) shall be in place with alerting.
 
 ## 7. Clear Desk and Clear Screen
 
-- Sensitive information must not be left visible on desks or screens when unattended.
-- Workstations must be locked when the user is away.
-- Sensitive documents must be stored in locked cabinets when not in use.
+- Sensitive information shall not be left visible on desks or screens when unattended.
+- Workstations shall be locked when the user is away.
+- Sensitive documents shall be stored in locked cabinets when not in use.
 
 ## 8. Roles and Responsibilities
 

--- a/backend/library/policy_templates/en/secure_development.md
+++ b/backend/library/policy_templates/en/secure_development.md
@@ -15,67 +15,67 @@ This policy applies to all software development activities at [Organization Name
 
 ## 3. Security Requirements
 
-- Security requirements must be identified and documented during the requirements phase of every project.
-- Requirements must address authentication, authorization, data protection, logging, and input validation.
+- Security requirements shall be identified and documented during the requirements phase of every project.
+- Requirements shall address authentication, authorization, data protection, logging, and input validation.
 - Threat modeling should be performed for applications handling sensitive data or exposed to external networks.
 
 ## 4. Secure Coding Standards
 
 ### 4.1 General Principles
 
-- All development must follow recognized secure coding guidelines (e.g., OWASP Top 10, SANS Top 25).
-- Input validation must be applied to all user-supplied data.
-- Output encoding must be used to prevent injection attacks.
-- Sensitive data must never be hardcoded in source code (credentials, keys, tokens).
+- All development shall follow recognized secure coding guidelines (e.g., OWASP Top 10, SANS Top 25).
+- Input validation shall be applied to all user-supplied data.
+- Output encoding shall be used to prevent injection attacks.
+- Sensitive data shall never be hardcoded in source code (credentials, keys, tokens).
 
 ### 4.2 Dependency Management
 
-- Third-party libraries and dependencies must be inventoried and monitored for known vulnerabilities.
-- Dependencies must be updated regularly and pinned to specific versions.
+- Third-party libraries and dependencies shall be inventoried and monitored for known vulnerabilities.
+- Dependencies shall be updated regularly and pinned to specific versions.
 - Use of unmaintained or deprecated libraries is discouraged.
 
 ### 4.3 Secrets Management
 
-- Application secrets must be stored in approved secrets management solutions.
-- Secrets must not be committed to version control repositories.
+- Application secrets shall be stored in approved secrets management solutions.
+- Secrets shall not be committed to version control repositories.
 - Pre-commit hooks or automated scanning should be used to detect accidental secret exposure.
 
 ## 5. Code Review
 
-- All code changes must undergo peer review before merging to main branches.
-- Security-focused reviews must be conducted for changes affecting authentication, authorization, data handling, and cryptography.
+- All code changes shall undergo peer review before merging to main branches.
+- Security-focused reviews shall be conducted for changes affecting authentication, authorization, data handling, and cryptography.
 - Automated static analysis tools should be integrated into the development pipeline.
 
 ## 6. Testing
 
 ### 6.1 Security Testing
 
-- Automated security testing (SAST, DAST) must be integrated into the CI/CD pipeline.
-- Manual security testing must be conducted for high-risk applications before major releases.
-- Identified vulnerabilities must be remediated before production deployment.
+- Automated security testing (SAST, DAST) shall be integrated into the CI/CD pipeline.
+- Manual security testing shall be conducted for high-risk applications before major releases.
+- Identified vulnerabilities shall be remediated before production deployment.
 
 ### 6.2 Test Environments
 
-- Test environments must not contain production data unless anonymized or masked.
-- Test environments must be isolated from production systems.
+- Test environments shall not contain production data unless anonymized or masked.
+- Test environments shall be isolated from production systems.
 
 ## 7. Deployment Security
 
-- Deployments to production must follow the established change management process.
-- Automated deployment pipelines must enforce security gates (tests pass, no critical vulnerabilities).
-- Rollback procedures must be defined and tested for all production deployments.
+- Deployments to production shall follow the established change management process.
+- Automated deployment pipelines shall enforce security gates (tests pass, no critical vulnerabilities).
+- Rollback procedures shall be defined and tested for all production deployments.
 
 ## 8. Environment Separation
 
-- Development, testing, staging, and production environments must be logically or physically separated.
-- Access to production environments must be restricted and audited.
-- Developers must not have direct write access to production systems.
+- Development, testing, staging, and production environments shall be logically or physically separated.
+- Access to production environments shall be restricted and audited.
+- Developers shall not have direct write access to production systems.
 
 ## 9. Source Code Protection
 
-- Source code repositories must be access-controlled with role-based permissions.
-- Branch protection rules must be enforced on main and release branches.
-- Repository access must be reviewed periodically and revoked for departed personnel.
+- Source code repositories shall be access-controlled with role-based permissions.
+- Branch protection rules shall be enforced on main and release branches.
+- Repository access shall be reviewed periodically and revoked for departed personnel.
 
 ## 10. Roles and Responsibilities
 

--- a/backend/library/policy_templates/en/security_awareness.md
+++ b/backend/library/policy_templates/en/security_awareness.md
@@ -17,13 +17,13 @@ This policy applies to all employees, contractors, temporary staff, and third pa
 
 ### 3.1 General Awareness
 
-- All personnel must complete security awareness training upon onboarding and annually thereafter.
-- Awareness content must cover current threats, organizational policies, and individual responsibilities.
-- Training completion must be tracked and documented.
+- All personnel shall complete security awareness training upon onboarding and annually thereafter.
+- Awareness content shall cover current threats, organizational policies, and individual responsibilities.
+- Training completion shall be tracked and documented.
 
 ### 3.2 Core Topics
 
-The awareness program must include at a minimum:
+The awareness program shall include at a minimum:
 
 - Phishing and social engineering recognition.
 - Password security and authentication best practices.
@@ -36,45 +36,45 @@ The awareness program must include at a minimum:
 
 ### 3.3 Ongoing Reinforcement
 
-- Security reminders and updates must be communicated regularly through appropriate channels.
-- Significant threats or incidents must trigger targeted awareness communications.
+- Security reminders and updates shall be communicated regularly through appropriate channels.
+- Significant threats or incidents shall trigger targeted awareness communications.
 
 ## 4. Role-Based Training
 
 ### 4.1 Technical Staff
 
-- IT administrators, developers, and security personnel must receive specialized training relevant to their roles.
-- Topics must include secure coding, system hardening, incident response, and security tool usage.
+- IT administrators, developers, and security personnel shall receive specialized training relevant to their roles.
+- Topics shall include secure coding, system hardening, incident response, and security tool usage.
 
 ### 4.2 Management
 
-- Managers must receive training on their responsibilities for information security governance, risk management, and compliance oversight.
+- Managers shall receive training on their responsibilities for information security governance, risk management, and compliance oversight.
 
 ### 4.3 Privileged Users
 
-- Users with elevated access rights must receive additional training on the risks and responsibilities associated with privileged access.
+- Users with elevated access rights shall receive additional training on the risks and responsibilities associated with privileged access.
 
 ## 5. Phishing Simulations
 
-- Simulated phishing exercises must be conducted at least quarterly.
-- Results must be analyzed to identify trends and areas requiring additional training.
-- Personnel who repeatedly fail simulations must receive targeted remedial training.
+- Simulated phishing exercises shall be conducted at least quarterly.
+- Results shall be analyzed to identify trends and areas requiring additional training.
+- Personnel who repeatedly fail simulations shall receive targeted remedial training.
 
 ## 6. New Threats and Policy Changes
 
-- Training content must be updated to reflect emerging threats, new attack techniques, and regulatory changes.
-- Policy changes must be communicated with associated training or guidance.
+- Training content shall be updated to reflect emerging threats, new attack techniques, and regulatory changes.
+- Policy changes shall be communicated with associated training or guidance.
 
 ## 7. Metrics and Reporting
 
-The effectiveness of the awareness program must be measured through:
+The effectiveness of the awareness program shall be measured through:
 
 - Training completion rates.
 - Phishing simulation click and report rates.
 - Number of security incidents attributable to human error.
 - Employee feedback and assessment scores.
 
-Results must be reported to management at least annually.
+Results shall be reported to management at least annually.
 
 ## 8. Roles and Responsibilities
 

--- a/backend/library/policy_templates/en/supplier_management.md
+++ b/backend/library/policy_templates/en/supplier_management.md
@@ -17,13 +17,13 @@ This policy applies to all third-party relationships where external parties acce
 
 ### 3.1 Risk Assessment
 
-- All prospective suppliers must undergo a security risk assessment before engagement.
-- The depth of assessment must be proportional to the sensitivity of data and criticality of services involved.
-- Assessments must evaluate the supplier's security posture, certifications, incident history, and financial stability.
+- All prospective suppliers shall undergo a security risk assessment before engagement.
+- The depth of assessment shall be proportional to the sensitivity of data and criticality of services involved.
+- Assessments shall evaluate the supplier's security posture, certifications, incident history, and financial stability.
 
 ### 3.2 Classification
 
-Suppliers must be classified based on risk:
+Suppliers shall be classified based on risk:
 
 - **Critical**: Direct access to sensitive data or critical systems.
 - **Important**: Access to internal systems or non-sensitive data.
@@ -33,7 +33,7 @@ Suppliers must be classified based on risk:
 
 ### 4.1 Security Clauses
 
-All supplier contracts must include:
+All supplier contracts shall include:
 
 - Confidentiality and non-disclosure obligations.
 - Data protection and privacy requirements.
@@ -44,32 +44,32 @@ All supplier contracts must include:
 
 ### 4.2 Service Level Agreements
 
-- Security-related SLAs must be defined for critical and important suppliers.
-- SLAs must include availability, incident response times, and patch management timelines.
+- Security-related SLAs shall be defined for critical and important suppliers.
+- SLAs shall include availability, incident response times, and patch management timelines.
 
 ## 5. Ongoing Monitoring
 
-- Critical suppliers must be reviewed at least annually.
-- Important suppliers must be reviewed at least every two years.
-- Monitoring must include security performance, compliance status, and incident reports.
-- Significant changes in a supplier's security posture must trigger a reassessment.
+- Critical suppliers shall be reviewed at least annually.
+- Important suppliers shall be reviewed at least every two years.
+- Monitoring shall include security performance, compliance status, and incident reports.
+- Significant changes in a supplier's security posture shall trigger a reassessment.
 
 ## 6. Supply Chain Security
 
-- Suppliers must demonstrate controls to protect the integrity of products and services delivered.
-- Software suppliers must provide evidence of secure development practices.
-- Hardware suppliers must ensure tamper-evidence and chain-of-custody controls.
+- Suppliers shall demonstrate controls to protect the integrity of products and services delivered.
+- Software suppliers shall provide evidence of secure development practices.
+- Hardware suppliers shall ensure tamper-evidence and chain-of-custody controls.
 
 ## 7. Incident Management
 
-- Suppliers must notify [Organization Name] of security incidents affecting shared data or services within the contractually agreed timeframe.
-- Joint incident response procedures must be established for critical suppliers.
+- Suppliers shall notify [Organization Name] of security incidents affecting shared data or services within the contractually agreed timeframe.
+- Joint incident response procedures shall be established for critical suppliers.
 
 ## 8. Termination and Transition
 
-- Upon contract termination, suppliers must return or securely destroy all [Organization Name] data.
-- Access credentials and system access must be revoked promptly upon termination.
-- Transition plans must be established for critical services.
+- Upon contract termination, suppliers shall return or securely destroy all [Organization Name] data.
+- Access credentials and system access shall be revoked promptly upon termination.
+- Transition plans shall be established for critical services.
 
 ## 9. Roles and Responsibilities
 

--- a/backend/library/policy_templates/en/vulnerability_management.md
+++ b/backend/library/policy_templates/en/vulnerability_management.md
@@ -17,24 +17,24 @@ This policy applies to all systems, applications, network devices, and infrastru
 
 ### 3.1 Scanning
 
-- Automated vulnerability scans must be performed on all internet-facing systems at least weekly.
-- Internal network scans must be performed at least monthly.
-- Application security scans must be integrated into the development lifecycle.
+- Automated vulnerability scans shall be performed on all internet-facing systems at least weekly.
+- Internal network scans shall be performed at least monthly.
+- Application security scans shall be integrated into the development lifecycle.
 
 ### 3.2 Threat Intelligence
 
-- Vulnerability feeds and advisories from vendors, CERTs, and industry sources must be monitored continuously.
-- Zero-day vulnerabilities affecting organizational systems must be assessed immediately upon disclosure.
+- Vulnerability feeds and advisories from vendors, CERTs, and industry sources shall be monitored continuously.
+- Zero-day vulnerabilities affecting organizational systems shall be assessed immediately upon disclosure.
 
 ### 3.3 Penetration Testing
 
-- External penetration tests must be conducted at least annually.
-- Internal penetration tests must be conducted at least annually or after significant infrastructure changes.
-- Findings must be tracked through the standard remediation process.
+- External penetration tests shall be conducted at least annually.
+- Internal penetration tests shall be conducted at least annually or after significant infrastructure changes.
+- Findings shall be tracked through the standard remediation process.
 
 ## 4. Severity Classification
 
-Vulnerabilities must be classified using a standard scoring system (e.g., CVSS):
+Vulnerabilities shall be classified using a standard scoring system (e.g., CVSS):
 
 | Severity | CVSS Score | Description |
 |----------|-----------|-------------|
@@ -54,26 +54,26 @@ Vulnerabilities must be classified using a standard scoring system (e.g., CVSS):
 
 ### 5.2 Patch Management
 
-- Security patches must be tested in a non-production environment before deployment.
+- Security patches shall be tested in a non-production environment before deployment.
 - Emergency patches for critical vulnerabilities may bypass standard change management with documented justification.
 - Automated patch deployment should be used where feasible for operating systems and standard software.
 
 ### 5.3 Compensating Controls
 
-- When immediate patching is not possible, compensating controls must be documented and implemented.
-- Compensating controls must be reviewed regularly until the vulnerability is fully remediated.
+- When immediate patching is not possible, compensating controls shall be documented and implemented.
+- Compensating controls shall be reviewed regularly until the vulnerability is fully remediated.
 
 ## 6. Exception Handling
 
-- Vulnerabilities that cannot be remediated within required timelines must have a documented exception.
-- Exceptions must include a risk assessment, compensating controls, and an approved remediation plan.
-- Exceptions must be approved by the IT Security Team and reviewed at least quarterly.
+- Vulnerabilities that cannot be remediated within required timelines shall have a documented exception.
+- Exceptions shall include a risk assessment, compensating controls, and an approved remediation plan.
+- Exceptions shall be approved by the IT Security Team and reviewed at least quarterly.
 
 ## 7. Reporting
 
-- Vulnerability status reports must be provided to management at least monthly.
-- Reports must include total vulnerabilities, remediation progress, overdue items, and trend analysis.
-- Critical and high vulnerabilities must be escalated immediately to relevant stakeholders.
+- Vulnerability status reports shall be provided to management at least monthly.
+- Reports shall include total vulnerabilities, remediation progress, overdue items, and trend analysis.
+- Critical and high vulnerabilities shall be escalated immediately to relevant stakeholders.
 
 ## 8. Roles and Responsibilities
 


### PR DESCRIPTION
## Summary

- Replace `must` with `shall` in all 11 English policy templates to align with ISO/IEC Directives Part 2, which reserves `shall` for normative requirements imposed by the document, and `must` solely for external constraints (physical laws, mathematical conditions)
- Several existing templates (`acceptable_use`, `access_control`, `data_classification`, `incident_response`, `information_security`) already used `shall` consistently; this change aligns the remaining 6 templates for full consistency across the set
- French templates reviewed: all 11 files consistently use `doit`/`doivent`, the ISO/IEC Directives Part 2 French equivalent of `shall` — no changes needed

## Test plan

- [ ] Verify all 11 EN templates use `shall` exclusively for mandatory requirements
- [ ] Verify no `must` remains in any EN template
- [ ] Verify FR templates are unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security policy documentation to standardize requirement language across all organizational policies, ensuring consistent terminology and improved clarity throughout policy materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->