### PR TITLE
fix: honor line breaks on html exports

### DIFF
--- a/backend/core/templates/core/findings_assessment_pdf.html
+++ b/backend/core/templates/core/findings_assessment_pdf.html
@@ -26,7 +26,7 @@
                 <p><strong>Reviewers:</strong> {% for reviewer in findings_assessment.reviewers.all %}{{ reviewer.email }}{% if not forloop.last %}, {% endif %}{% endfor %}</p>
                 {% endif %}
                 {% if findings_assessment.observation %}
-                <p><strong>Observation:</strong> {{ findings_assessment.observation }}</p>
+                <p><strong>Observation:</strong> {{ findings_assessment.observation|linebreaksbr }}</p>
                 {% endif %}
             </div>
         </div>
@@ -140,7 +140,7 @@
                     <td class="border p-2 text-sm">{{ finding.name }}</td>
                     <td class="border p-2 text-sm capitalize">{{ finding.get_severity_display }}</td>
                     <td class="border p-2 text-sm capitalize">{{ finding.get_status_display }}</td>
-                    <td class="border p-2 text-sm">{{ finding.observation|default:"N/A"|truncatechars:100 }}</td>
+                    <td class="border p-2 text-sm">{{ finding.observation|default:"N/A"|truncatechars:100|linebreaksbr }}</td>
                 </tr>
                 {% endfor %}
             </tbody>
@@ -176,7 +176,7 @@
                 </div>
                 <div>
                     <p class="text-sm font-medium">Observation:</p>
-                    <p class="text-sm text-gray-600">{{ finding.observation|default:"N/A" }}</p>
+                    <p class="text-sm text-gray-600">{{ finding.observation|default:"N/A"|linebreaksbr }}</p>
                 </div>
             </div>
 

--- a/backend/core/templates/snippets/req_node.html
+++ b/backend/core/templates/snippets/req_node.html
@@ -56,7 +56,7 @@
       {% if node.assessments.observation %}
           <div class="text-left w-full">
             <p class="font-semibold">{% trans "Observation:" %}</p>
-            <p>{{ node.assessments.observation }}</p>
+            <p>{{ node.assessments.observation|linebreaksbr }}</p>
           </div>
       {% endif %}
     </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed observation field rendering to properly display line breaks as formatted text instead of plain characters
  * Applies to assessment PDFs, findings summaries, and detailed findings sections
  * Improves readability of multi-line observations throughout the application

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/intuitem/ciso-assistant-community/pull/4106)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->