### PR TITLE
chore(windows-native-dev): increase dev backlog for Django

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ cli/db_backup
 /.claude/*
 !/.claude/skills/
 /frontend/project.inlang/cache
+
+# Ignore Windows-specific dev script helpers
+backend.ps1
+backend/.win_native_dev_runserver.py

--- a/README.md
+++ b/README.md
@@ -607,7 +607,16 @@ poetry run python manage.py createsuperuser
 poetry run python manage.py runserver
 ```
 
-11. for Huey (tasks runner)
+<details>
+<summary>[EXPERIMENTAL] How to run development server natively on Windows?</summary>
+
+When running Django's development server natively on Windows, SvelteKit SSR can open enough concurrent API connections to hit the server's small default listen backlog. This may cause intermittent `ECONNREFUSED` / `TypeError: fetch failed` errors in the frontend.
+
+Use the helper scripts documented in [`tools/.windows/README.md`](tools/.windows/README.md) for the native Windows development setup.
+
+</details>
+
+11. For Huey (tasks runner)
 
 - prepare a mailer for testing.
 - run `python manage.py run_huey -w 2 -k process` or equivalent in a separate shell.

--- a/tools/.windows/.win_native_dev_runserver.py
+++ b/tools/.windows/.win_native_dev_runserver.py
@@ -1,0 +1,31 @@
+"""
+Native Windows development runserver entrypoint.
+
+Place this script at the following path from the CISO Assistant repository root:
+backend/.win_native_dev_runserver.py
+
+Django's default development server listen backlog is small. In native Windows
+development, runserver can drain bursts of incoming API connections more slowly
+than on Linux. SvelteKit SSR may then open enough concurrent API connections to
+fill that queue, which intermittently causes ECONNREFUSED on 127.0.0.1:8000
+before requests reach Django. This wrapper keeps the normal Django runserver
+behavior, but raises the listen backlog through DJANGO_RUNSERVER_BACKLOG.
+"""
+
+import os
+import sys
+
+from django.core.management import execute_from_command_line
+from django.core.servers import basehttp
+
+
+def configure_runserver_backlog() -> None:
+    backlog = int(os.environ.get("DJANGO_RUNSERVER_BACKLOG", "512"))
+    basehttp.WSGIServer.request_queue_size = backlog
+    basehttp.ThreadedWSGIServer.request_queue_size = backlog
+
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ciso_assistant.settings")
+    configure_runserver_backlog()
+    execute_from_command_line(["manage.py", "runserver", *sys.argv[1:]])

--- a/tools/.windows/.win_native_dev_runserver.py
+++ b/tools/.windows/.win_native_dev_runserver.py
@@ -1,5 +1,5 @@
 """
-Native Windows development runserver entrypoint.
+Native Windows development runserver entrypoint
 
 Place this script at the following path from the CISO Assistant repository root:
 backend/.win_native_dev_runserver.py
@@ -7,7 +7,7 @@ backend/.win_native_dev_runserver.py
 Django's default development server listen backlog is small. In native Windows
 development, runserver can drain bursts of incoming API connections more slowly
 than on Linux. SvelteKit SSR may then open enough concurrent API connections to
-fill that queue, which intermittently causes ECONNREFUSED on 127.0.0.1:8000
+fill that queue, which intermittently causes `ECONNREFUSED` on `127.0.0.1:8000`
 before requests reach Django. This wrapper keeps the normal Django runserver
 behavior, but raises the listen backlog through DJANGO_RUNSERVER_BACKLOG.
 """

--- a/tools/.windows/README.md
+++ b/tools/.windows/README.md
@@ -9,7 +9,7 @@ native Windows development.
 - `.win_native_dev_runserver.py`: Django `runserver` wrapper that increases the
   development server listen backlog.
 
-## Where To Place Them
+## Where to place them?
 
 Place the scripts from this folder at these paths from the CISO Assistant
 repository root:
@@ -25,7 +25,7 @@ Then start the backend from the repository root:
 .\backend.ps1
 ```
 
-## Why They Exist
+## Why they exist?
 
 On native Windows, Django's development server can drain bursts of incoming API
 connections more slowly than on Linux. During SvelteKit SSR, the frontend can
@@ -35,7 +35,7 @@ may intermittently return `ECONNREFUSED` before requests reach Django.
 The Python wrapper keeps normal `runserver` behavior but raises the backlog with
 `DJANGO_RUNSERVER_BACKLOG` (`512` by default).
 
-## Python Virtual Environment
+## About Python Virtual Environment (.venv)
 
 In `backend.ps1`, set `$PythonRelativeExecutablePath` to the Python executable
 that should run Django. A local `.venv` is recommended because it keeps

--- a/tools/.windows/README.md
+++ b/tools/.windows/README.md
@@ -11,7 +11,7 @@ native Windows development.
 
 ## Where to place them?
 
-Place the scripts from this folder at these paths from the CISO Assistant
+Copy the scripts from this folder at these paths from the CISO Assistant
 repository root:
 
 ```text

--- a/tools/.windows/README.md
+++ b/tools/.windows/README.md
@@ -1,0 +1,46 @@
+# Native Windows Development Scripts
+
+This folder contains helper scripts for running the CISO Assistant backend in
+native Windows development.
+
+## Files
+
+- `backend.ps1`: PowerShell launcher for the backend.
+- `.win_native_dev_runserver.py`: Django `runserver` wrapper that increases the
+  development server listen backlog.
+
+## Where To Place Them
+
+Place the scripts from this folder at these paths from the CISO Assistant
+repository root:
+
+```text
+backend.ps1
+backend/.win_native_dev_runserver.py
+```
+
+Then start the backend from the repository root:
+
+```powershell
+.\backend.ps1
+```
+
+## Why They Exist
+
+On native Windows, Django's development server can drain bursts of incoming API
+connections more slowly than on Linux. During SvelteKit SSR, the frontend can
+open many API connections at once; with Django's small default backlog, Windows
+may intermittently return `ECONNREFUSED` before requests reach Django.
+
+The Python wrapper keeps normal `runserver` behavior but raises the backlog with
+`DJANGO_RUNSERVER_BACKLOG` (`512` by default).
+
+## Python Virtual Environment
+
+In `backend.ps1`, set `$PythonRelativeExecutablePath` to the Python executable
+that should run Django. A local `.venv` is recommended because it keeps
+dependencies isolated and gives a predictable path, for example:
+
+```powershell
+$PythonRelativeExecutablePath = ".venv\Scripts\python.exe"
+```

--- a/tools/.windows/backend.ps1
+++ b/tools/.windows/backend.ps1
@@ -1,0 +1,122 @@
+#Requires -Version 5.1
+
+# Starts the CISO Assistant backend with the right native Windows development
+# settings. Place this script at the root of the CISO Assistant project, next to
+# the backend/ directory.
+
+$ErrorActionPreference = "Stop"
+
+$ProjectDir = if ($PSScriptRoot) { $PSScriptRoot } else { (Get-Location).Path }
+$BackendDir = Join-Path $ProjectDir "backend"
+
+# Put the path to the Python executable that should run Django here. A local
+# .venv is recommended because it keeps dependencies isolated and makes this
+# path predictable.
+$PythonRelativeExecutablePath = ".venv\Scripts\python.exe"
+$PythonExecutablePath = Join-Path $ProjectDir $PythonRelativeExecutablePath
+
+# Compatibility fallback for local workspaces where the virtual environment is
+# stored one directory above the CISO Assistant repository.
+$ParentPythonExecutablePath = Join-Path (Split-Path -Parent $ProjectDir) $PythonRelativeExecutablePath
+$SelectedPythonExecutablePath = if (Test-Path -LiteralPath $PythonExecutablePath -PathType Leaf) {
+    $PythonExecutablePath
+}
+else {
+    $ParentPythonExecutablePath
+}
+$RunserverScript = Join-Path $BackendDir ".win_native_dev_runserver.py"
+
+# Sets or removes one process-level environment variable.
+function Set-EnvValue {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Name,
+
+        [AllowNull()]
+        [string] $Value
+    )
+
+    if ([string]::IsNullOrEmpty($Value)) {
+        Remove-Item -LiteralPath "Env:$Name" -ErrorAction SilentlyContinue
+        return
+    }
+
+    Set-Item -LiteralPath "Env:$Name" -Value $Value
+}
+
+# Runs a command with temporary environment variables, then restores the previous
+# process environment so migrations and runserver do not leak settings globally.
+function Invoke-WithEnvironment {
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable] $Environment,
+
+        [Parameter(Mandatory = $true)]
+        [string] $FilePath,
+
+        [string[]] $ArgumentList = @(),
+
+        [string] $CommandName = ""
+    )
+
+    $previousValues = @{}
+    foreach ($name in $Environment.Keys) {
+        $previousValues[$name] = [Environment]::GetEnvironmentVariable($name, "Process")
+    }
+
+    try {
+        foreach ($entry in $Environment.GetEnumerator()) {
+            Set-EnvValue -Name $entry.Key -Value $entry.Value
+        }
+
+        & $FilePath @ArgumentList
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -ne 0) {
+            if ([string]::IsNullOrEmpty($CommandName)) {
+                $CommandName = "$FilePath $($ArgumentList -join ' ')"
+            }
+
+            throw "$CommandName failed with exit code $exitCode."
+        }
+    }
+    finally {
+        foreach ($name in $previousValues.Keys) {
+            Set-EnvValue -Name $name -Value $previousValues[$name]
+        }
+    }
+}
+
+if (-not (Test-Path -LiteralPath $BackendDir -PathType Container)) {
+    throw "Backend directory not found: $BackendDir"
+}
+
+if (-not (Test-Path -LiteralPath $SelectedPythonExecutablePath -PathType Leaf)) {
+    throw "Python executable not found: $SelectedPythonExecutablePath"
+}
+
+if (-not (Test-Path -LiteralPath $RunserverScript -PathType Leaf)) {
+    throw "Windows development runserver script not found: $RunserverScript"
+}
+
+$MigrateEnvironment = @{
+    DJANGO_DEBUG = "True"
+}
+
+# Django's default development server listen backlog is 10, which can refuse
+# SvelteKit SSR connection bursts on Windows before requests reach Django.
+$RunserverBacklog = if ($env:DJANGO_RUNSERVER_BACKLOG) { $env:DJANGO_RUNSERVER_BACKLOG } else { "512" }
+$RunserverEnvironment = @{
+    DJANGO_DEBUG = "True"
+    LOG_LEVEL = "INFO"
+    DJANGO_RUNSERVER_BACKLOG = $RunserverBacklog
+}
+
+Push-Location -LiteralPath $BackendDir
+try {
+    # Run from backend/ so manage.py and relative paths resolve like Django expects.
+    Invoke-WithEnvironment -Environment $MigrateEnvironment -FilePath $SelectedPythonExecutablePath -ArgumentList @("manage.py", "migrate") -CommandName "manage.py migrate"
+    Invoke-WithEnvironment -Environment $RunserverEnvironment -FilePath $SelectedPythonExecutablePath -ArgumentList @($RunserverScript) -CommandName "manage.py runserver"
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Why?

When running Django's development server natively on Windows, SvelteKit SSR can open enough concurrent API connections to hit the server's small default listen backlog. Windows is less efficient than Linux when it comes to processing the backlog. This may cause intermittent `ECONNREFUSED` / `TypeError: fetch failed` errors in the frontend. To fix this issue on Windows, 2 helper scripts have been created in `tools/.windows` with a dedicated `README.md`:
-  `backend.ps1`
- `.win_native_dev_runserver.py`

## Notes
- The `.gitignore` has been updated to ignore those helper scripts in the repo.
- The global `README.md` has been updated in order to explain to users how to run backend on native Windows.
- The custom scripts also make the backend significantly more responsive
- The base code remains unchanged



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added native Windows backend development environment with automated startup scripts to improve stability

* **Documentation**
  * Added Windows development setup guide with troubleshooting and configuration instructions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/intuitem/ciso-assistant-community/pull/4109)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->