### PR TITLE
feat(cli): add name option for bia import

### DIFF
--- a/backend/data_wizard/views.py
+++ b/backend/data_wizard/views.py
@@ -3001,12 +3001,19 @@ class LoadFileView(APIView):
             excel_data = pd.ExcelFile(excel_file)
             sheet_names = excel_data.sheet_names
 
+            # Header override wins over the name found in the Summary sheet.
+            # Only applied when a single BIA is being imported to keep the
+            # multi-sheet (Summary + per-BIA sheets) linkage consistent.
+            override_name = (request.headers.get("X-Name") or "").strip()
+
             if len(sheet_names) == 1:
                 # Single-sheet file: treat it as a Summary-only import.
                 df = normalize_datetime_columns(
                     pd.read_excel(excel_file, sheet_name=sheet_names[0])
                 ).fillna("")
                 records = df.to_dict(orient="records")
+                if override_name and len(records) == 1:
+                    records[0]["name"] = override_name
                 base_context = BaseContext(
                     request,
                     folders_map=folders_map,
@@ -3040,6 +3047,11 @@ class LoadFileView(APIView):
                 pd.read_excel(excel_file, sheet_name="Summary")
             ).fillna("")
             summary_records = summary_df.to_dict(orient="records")
+
+            bia_name_override: Optional[str] = None
+            if override_name and len(summary_records) == 1:
+                summary_records[0]["name"] = override_name
+                bia_name_override = override_name
 
             base_context = BaseContext(
                 request,
@@ -3082,7 +3094,9 @@ class LoadFileView(APIView):
                 ).fillna("")
                 sheet_records = sheet_df.to_dict(orient="records")
 
-                sheet_records = _inject_bia_hint(sheet_records, base_name)
+                sheet_records = _inject_bia_hint(
+                    sheet_records, bia_name_override or base_name
+                )
 
                 if is_threshold_sheet:
                     thresholds_result = (

--- a/backend/data_wizard/views.py
+++ b/backend/data_wizard/views.py
@@ -3094,9 +3094,12 @@ class LoadFileView(APIView):
                 ).fillna("")
                 sheet_records = sheet_df.to_dict(orient="records")
 
-                sheet_records = _inject_bia_hint(
-                    sheet_records, bia_name_override or base_name
-                )
+                if bia_name_override:
+                    for record in sheet_records:
+                        record.pop("bia", None)
+                        record["bia_name"] = bia_name_override
+                else:
+                    sheet_records = _inject_bia_hint(sheet_records, base_name)
 
                 if is_threshold_sheet:
                     thresholds_result = (

--- a/cli/clica.py
+++ b/cli/clica.py
@@ -629,6 +629,7 @@ def register_data_wizard_command(config: Dict[str, object]) -> None:
         "FindingsAssessment",
         "EbiosRMStudyARM",
         "EbiosRMStudyExcel",
+        "BusinessImpactAnalysis",
     }
 
     @cli.command(name=cli_name, help=help_text)


### PR DESCRIPTION
Add a name option for BIA through the CLI, to specify a name at the import

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Business Impact Analysis imports now support custom naming via the CLI --name option and the X-Name request header. When provided, the supplied name will override imported BIA record names for single-record sheets or when a Summary sheet yields a single summary; per-BIA sheets receive consistent name overrides where applicable.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/intuitem/ciso-assistant-community/pull/4121)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->