### PR TITLE
fix(backend+ui): blank fields in Matrix Editor after Matrix duplication & YAML Import + fix page title

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -3016,6 +3016,9 @@ class RiskMatrixViewSet(BaseModelViewSet):
             {
                 "id": str(matrix.id),
                 "name": matrix.name,
+                "description": matrix.description,
+                "provider": matrix.provider,
+                "locale": matrix.locale,
                 "status": "draft_created_from",
                 "editing_draft": matrix.editing_draft,
             },

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -3183,6 +3183,9 @@ class RiskMatrixViewSet(BaseModelViewSet):
             {
                 "id": str(matrix.id),
                 "name": matrix.name,
+                "description": matrix.description,
+                "provider": matrix.provider,
+                "locale": matrix.locale,
                 "editing_draft": matrix.editing_draft,
                 "status": "imported",
             },

--- a/frontend/src/routes/(app)/(internal)/experimental/matrix-editor/+page.server.ts
+++ b/frontend/src/routes/(app)/(internal)/experimental/matrix-editor/+page.server.ts
@@ -1,5 +1,6 @@
 import { BASE_API_URL } from '$lib/utils/constants';
 import type { PageServerLoad } from './$types';
+import { m } from '$paraglide/messages';
 
 export const load = (async ({ fetch }) => {
 	// Load all risk matrices (published ones for "clone from", ones with editing_draft for "resume")
@@ -11,5 +12,5 @@ export const load = (async ({ fetch }) => {
 	const matrices = allMatrices.filter((m: any) => m.is_enabled);
 	const drafts = allMatrices.filter((m: any) => m.has_editing_draft);
 
-	return { matrices, drafts };
+	return { title: m.matrixEditor(), matrices, drafts };
 }) satisfies PageServerLoad;

--- a/frontend/src/routes/(app)/(internal)/experimental/matrix-editor/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/experimental/matrix-editor/+page.svelte
@@ -301,6 +301,9 @@
 				loadDraft({
 					id: result.id,
 					name: result.name,
+					description: result.description,
+					provider: result.provider,
+					locale: result.locale,
 					editing_draft: result.editing_draft
 				});
 				refreshDrafts();

--- a/frontend/src/routes/(app)/(internal)/experimental/matrix-editor/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/experimental/matrix-editor/+page.svelte
@@ -577,9 +577,12 @@
 
 			const result = await res.json();
 			// Load the newly created clone
-			loadDraft({
+			await loadDraft({
 				id: result.id,
 				name: result.name,
+				description: result.description,
+				provider: result.provider,
+				locale: result.locale,
 				editing_draft: result.editing_draft
 			});
 			refreshDrafts();

--- a/frontend/src/routes/(app)/(internal)/experimental/matrix-editor/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/experimental/matrix-editor/+page.svelte
@@ -8,8 +8,6 @@
 	import { LOCALE_MAP, language } from '$lib/utils/locales';
 	import { onMount } from 'svelte';
 
-	$pageTitle = m.matrixEditor();
-
 	// Warn before leaving with unsaved changes + auto-load latest draft
 	onMount(() => {
 		const handler = (e: BeforeUnloadEvent) => {

--- a/frontend/src/routes/(app)/(internal)/experimental/matrix-editor/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/experimental/matrix-editor/+page.svelte
@@ -298,7 +298,7 @@
 
 				const result = await res.json();
 				// Load the newly created draft
-				loadDraft({
+				await loadDraft({
 					id: result.id,
 					name: result.name,
 					description: result.description,

--- a/frontend/src/routes/(app)/(internal)/experimental/matrix-editor/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/experimental/matrix-editor/+page.svelte
@@ -3,7 +3,6 @@
 	import LevelEditor from '$lib/components/RiskMatrixEditor/LevelEditor.svelte';
 	import GridEditor from '$lib/components/RiskMatrixEditor/GridEditor.svelte';
 	import RiskMatrix from '$lib/components/RiskMatrix/RiskMatrix.svelte';
-	import { pageTitle } from '$lib/utils/stores';
 	import { m } from '$paraglide/messages';
 	import { LOCALE_MAP, language } from '$lib/utils/locales';
 	import { onMount } from 'svelte';


### PR DESCRIPTION
## Return & Process missing Fields in Request for Duplicated Matrix & YAML Matrix Import

The `description`, `provider`, and `locale` fields weren't returned by the backend. This caused a blank description on duplication, but it would reappear after a page refresh.
This would also mess up the default locale if the matrix was in a language other than English.
The missing `provider` field doesn't seem to be a big deal as we apparently can't modify its value in the editor, but it's still important to retrieve it from the backend.

## Fix Page Title
The page title would change to `--` after a few seconds being of the page because it was defined in `+page.svelte` instead of `+page.server.svelte`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Draft metadata is now preserved when cloning or importing a risk matrix — description, provider, and locale are correctly returned and applied to the new draft immediately.

* **Improvements**
  * Matrix editor page now includes a localized page title and ensures newly created drafts load with their provider and locale for consistent editing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/intuitem/ciso-assistant-community/pull/4155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->