### PR TITLE
chore(win-native-dev): convert_library_v2.py launcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,8 @@ cli/db_backup
 /frontend/project.inlang/cache
 
 # Ignore Windows-specific dev script helpers
+# > Backend
 backend.ps1
 backend/.win_native_dev_runserver.py
+# > Tools
+tools/convert_library_v2.bat

--- a/tools/.windows/README.md
+++ b/tools/.windows/README.md
@@ -8,13 +8,16 @@ native Windows development.
 - `backend.ps1`: PowerShell launcher for the backend.
 - `.win_native_dev_runserver.py`: Django `runserver` wrapper that increases the
   development server listen backlog.
+- `convert_library_v2.bat`: Run `convert_library_v2.py` located in `backend` easily.
 
 ## Where to place them?
+
+### > For `backend.ps1` & `.win_native_dev_runserver.py`
 
 Copy the scripts from this folder at these paths from the CISO Assistant
 repository root:
 
-```text
+```sh
 backend.ps1
 backend/.win_native_dev_runserver.py
 ```
@@ -25,7 +28,24 @@ Then start the backend from the repository root:
 .\backend.ps1
 ```
 
+### > For `convert_library_v2.bat`
+
+Copy the script from this folder at this path from the CISO Assistant
+repository root:
+
+```sh
+tools/convert_library_v2.bat
+```
+
+Then start the script when you need it, just as you would with `convert_library_v2.py` (without `python` at the beginning). For example:
+
+```powershell
+.\convert_library_v2.bat .\example_framework.xlsx
+```
+
 ## Why they exist?
+
+### > For `backend.ps1` & `.win_native_dev_runserver.py`
 
 On native Windows, Django's development server can drain bursts of incoming API
 connections more slowly than on Linux. During SvelteKit SSR, the frontend can
@@ -34,6 +54,11 @@ may intermittently return `ECONNREFUSED` before requests reach Django.
 
 The Python wrapper keeps normal `runserver` behavior but raises the backlog with
 `DJANGO_RUNSERVER_BACKLOG` (`512` by default).
+
+
+### > For `convert_library_v2.bat`
+
+We can't use the `tools/convert_library_v2.py` symlink, as symlinks don't work on Windows.
 
 ## About Python Virtual Environment (.venv)
 

--- a/tools/.windows/convert_library_v2.bat
+++ b/tools/.windows/convert_library_v2.bat
@@ -1,0 +1,2 @@
+@echo off
+python "%~dp0../backend/scripts/convert_library_v2.py" %*


### PR DESCRIPTION
## Why?
We can't use the `tools/convert_library_v2.py` symlink, as symlinks don't work on Windows without many workarounds.

## Note
* Updated the Windows Dev Tools `README.md` file.
* The `.gitignore` has been updated to ignore this script in the repo.