### PR TITLE
fix(frontend): avoid unsafe form initialization

### DIFF
--- a/frontend/src/lib/components/Forms/Form.svelte
+++ b/frontend/src/lib/components/Forms/Form.svelte
@@ -47,20 +47,26 @@
 		validationMethod = 'auto',
 		useFocusTrap = true,
 		debug = false,
-		_form = superForm(data, {
-			dataType: dataType,
-			invalidateAll: invalidateAll,
-			applyAction: applyAction,
-			resetForm: resetForm,
-			validators: validators,
-			onUpdated: ({ form }) => handleFormUpdated({ form, closeModal: true }),
-			onSubmit: onSubmit,
-			taintedMessage: taintedMessage,
-			validationMethod
-		}),
+		_form: passedForm = undefined,
 		children,
 		...rest
 	}: Props = $props();
+
+	// Svelte 5.55.6 (PR sveltejs/svelte#18146) made $props() defaults run as deriveds,
+	// so calling superForm() in the default throws state_unsafe_mutation. Build it here instead.
+	const _form =
+		passedForm ??
+		superForm(data, {
+			dataType,
+			invalidateAll,
+			applyAction,
+			resetForm,
+			validators,
+			onUpdated: ({ form }) => handleFormUpdated({ form, closeModal: true }),
+			onSubmit,
+			taintedMessage,
+			validationMethod
+		});
 
 	const { form, message, tainted, delayed, errors, allErrors, enhance } = _form;
 </script>


### PR DESCRIPTION
## Issue

Form initialization can fail after upgrading to Svelte 5.55.6 with a `state_unsafe_mutation` error.

## Root cause

Svelte PR https://github.com/sveltejs/svelte/pull/18146 changed `()` defaults to run as derived values. The form component was calling `superForm()` directly inside a `()` default, which mutates state during derived evaluation.

## Fix

The component now accepts an optional passed form from props, then creates the default `superForm()` outside the `()` destructuring before using it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal component logic for improved maintainability and code organization with no impact on user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/intuitem/ciso-assistant-community/pull/4165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->