### PR TITLE
fix(ebios-rm): use focused feared event in strategic scenario report chain

### DIFF
--- a/backend/ebios_rm/serializers.py
+++ b/backend/ebios_rm/serializers.py
@@ -328,10 +328,8 @@ class StrategicScenarioReadSerializer(BaseModelSerializer):
         """Get feared events from the RoTo couple with their gravity"""
         feared_events_data = []
         for feared_event in obj.ro_to_couple.feared_events.all():
-            # Build display string with name and gravity
             gravity_display = feared_event.get_gravity_display()
             display_str = f"{feared_event.name} ({gravity_display['name']})"
-
             feared_events_data.append(
                 {
                     "id": str(feared_event.id),

--- a/frontend/src/routes/(app)/(internal)/ebios-rm/[id=uuid]/report/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/ebios-rm/[id=uuid]/report/+page.svelte
@@ -632,17 +632,19 @@
 
 						<!-- Attack Path Flow Text -->
 						{#if scenarioAttackPaths.length > 0}
+							{@const chainFearedEventIds = scenario.focused_feared_event
+								? [scenario.focused_feared_event.id]
+								: (scenario.feared_events?.map((sFe) => sFe.id) ?? [])}
+							{@const chainFearedEvents = reportData.feared_events.filter((fe) =>
+								chainFearedEventIds.includes(fe.id)
+							)}
 							<h4 class="text-md font-semibold text-gray-800 mb-3">
 								<i class="fa-solid fa-route mr-2"></i>{m.attackPaths()}
 							</h4>
 							<AttackPathFlowText
 								attackPaths={scenarioAttackPaths}
-								fearedEvents={reportData.feared_events.filter((fe) =>
-									scenario.feared_events?.some((sFe) => sFe.id === fe.id)
-								)}
-								fearedEventsWithAssets={reportData.feared_events.filter((fe) =>
-									scenario.feared_events?.some((sFe) => sFe.id === fe.id)
-								)}
+								fearedEvents={chainFearedEvents}
+								fearedEventsWithAssets={chainFearedEvents}
 							/>
 						{/if}
 					</div>


### PR DESCRIPTION
## Summary
- Le rapport EBIOS RM affichait, dans la chaîne SR → OV → PP → ER → actifs des scénarios stratégiques, **tous** les événements redoutés du couple RoTo associé ou rien quand le RoTo n'en avait aucun, même si un événement redouté spécifique (`focused_feared_event`) était posé sur le scénario.
- La chaîne utilise désormais le `focused_feared_event` quand il est défini, et ne retombe sur la liste du RoTo qu'à défaut (rétrocompat des scénarios créés avant l'introduction du champ).
- Les actifs affichés sous la chaîne sont déduits du même ER ciblé.

## Test plan
- [ ] Créer un scénario stratégique avec un `focused_feared_event` → vérifier que le rapport n'affiche que cet ER (et ses actifs) dans la chaîne.
- [ ] Créer un scénario stratégique sans `focused_feared_event` sur un RoTo ayant plusieurs ER → vérifier que la liste complète du RoTo reste affichée (comportement legacy).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved feared event processing in the Attack Path Flow Text section of the EBIOS-RM report. Feared events are now filtered through a dedicated mechanism to better distinguish between focused threat scenarios and comprehensive threat analysis.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/intuitem/ciso-assistant-community/pull/4172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->