### PR TITLE
fix(pro): mount ChatWidget FAB in app layout

### DIFF
--- a/enterprise/frontend/src/routes/(app)/+layout.svelte
+++ b/enterprise/frontend/src/routes/(app)/+layout.svelte
@@ -2,6 +2,7 @@
 	import { run } from 'svelte/legacy';
 
 	import CommandPalette from '$lib/components/CommandPalette/CommandPalette.svelte';
+	import ChatWidget from '$lib/components/ChatWidget/ChatWidget.svelte';
 	import { safeTranslate } from '$lib/utils/i18n';
 	import { AppBar } from '@skeletonlabs/skeleton-svelte';
 	import '../../app.css';
@@ -229,6 +230,9 @@
 	</div>
 	<!-- Router Slot -->
 	<CommandPalette bind:this={commandPalette} />
+	{#if $page.data.featureflags?.chat_mode}
+		<ChatWidget />
+	{/if}
 	<main
 		class="min-h-screen p-8 bg-linear-to-br from-violet-100 to-slate-200 transition-all duration-300 {classesSidebarOpen(
 			sidebarOpen


### PR DESCRIPTION
The enterprise app layout overlay was missing the ChatWidget mount that exists in the community layout, so when the chat_mode feature flag is enabled the floating chat button never renders in enterprise builds.

Mirror the community pattern: import ChatWidget and conditionally mount it next to CommandPalette in the App Shell.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat widget is now available in the app interface when enabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/intuitem/ciso-assistant-community/pull/4209?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->