### PR TITLE
chores: tighten internal ips check for pdf and webhooks

### DIFF
--- a/backend/core/net_safety.py
+++ b/backend/core/net_safety.py
@@ -7,8 +7,23 @@ import ipaddress
 import socket
 from urllib.parse import urlparse
 
+# RFC 6598 Shared Address Space (CGNAT). `ipaddress` treats this as
+# neither private nor global, so we reject it explicitly.
+_CGNAT_NET = ipaddress.ip_network("100.64.0.0/10")
+
 
 class BlockedRequestError(ValueError):
+    # Inherits ValueError so WeasyPrint's URL fetcher contract (which
+    # treats ValueError as "skip this resource, degrade gracefully")
+    # still applies. Don't change to bare Exception without verifying
+    # the PDF render path still degrades.
+    pass
+
+
+class DnsLookupError(Exception):
+    """Transient DNS failure. Distinct from BlockedRequestError so callers
+    can retry DNS hiccups while treating policy denials as terminal."""
+
     pass
 
 
@@ -27,9 +42,7 @@ def assert_public_url(
     try:
         addrinfo = socket.getaddrinfo(hostname, None)
     except socket.gaierror as exc:
-        raise BlockedRequestError(
-            f"Blocked URL: DNS lookup failed for {hostname!r}: {exc}"
-        ) from exc
+        raise DnsLookupError(f"DNS lookup failed for {hostname!r}: {exc}") from exc
 
     for *_, sockaddr in addrinfo:
         try:
@@ -43,7 +56,34 @@ def assert_public_url(
             or ip.is_reserved
             or ip.is_multicast
             or ip.is_unspecified
+            or (ip.version == 4 and ip in _CGNAT_NET)
         ):
             raise BlockedRequestError(
                 f"Blocked URL: {hostname!r} resolves to non-public address {ip}"
             )
+
+
+def assert_public_url_unless_dev(
+    url: str, *, allowed_schemes: tuple[str, ...] = ("https",)
+) -> None:
+    """assert_public_url, skipped when WEBHOOK_ALLOW_PRIVATE_IPS is set
+    (shared dev/loopback escape hatch across webhooks and integrations).
+    """
+    from django.conf import settings
+
+    if getattr(settings, "WEBHOOK_ALLOW_PRIVATE_IPS", False):
+        return
+    assert_public_url(url, allowed_schemes=allowed_schemes)
+
+
+def check_integration_url(url: str, source: str) -> None:
+    """SSRF check for admin-configured integration URLs (Jira, ServiceNow).
+
+    Raises ValueError with a user-facing message on policy denial; callers
+    log the raw cause via their structured logger before letting it
+    propagate.
+    """
+    try:
+        assert_public_url_unless_dev(url)
+    except BlockedRequestError as exc:
+        raise ValueError(f"{source} URL must be a public HTTPS endpoint") from exc

--- a/backend/core/net_safety.py
+++ b/backend/core/net_safety.py
@@ -1,0 +1,49 @@
+"""SSRF guard. Resolve-then-fetch has a TOCTOU window (hostile DNS with
+TTL=0 can flip the answer between check and connect); closing that
+fully needs IP-pinning at the socket layer.
+"""
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+
+class BlockedRequestError(ValueError):
+    pass
+
+
+def assert_public_url(
+    url: str, *, allowed_schemes: tuple[str, ...] = ("https",)
+) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme not in allowed_schemes:
+        raise BlockedRequestError(
+            f"Blocked URL scheme {parsed.scheme!r}; allowed: {allowed_schemes}"
+        )
+    hostname = parsed.hostname
+    if not hostname:
+        raise BlockedRequestError(f"Blocked URL: no hostname in {url!r}")
+
+    try:
+        addrinfo = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as exc:
+        raise BlockedRequestError(
+            f"Blocked URL: DNS lookup failed for {hostname!r}: {exc}"
+        ) from exc
+
+    for *_, sockaddr in addrinfo:
+        try:
+            ip = ipaddress.ip_address(sockaddr[0])
+        except ValueError:
+            continue
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_reserved
+            or ip.is_multicast
+            or ip.is_unspecified
+        ):
+            raise BlockedRequestError(
+                f"Blocked URL: {hostname!r} resolves to non-public address {ip}"
+            )

--- a/backend/core/tests/test_net_safety.py
+++ b/backend/core/tests/test_net_safety.py
@@ -1,15 +1,19 @@
 """Tests for the SSRF guard helpers in `core.net_safety`."""
 
+import socket
 from unittest.mock import patch
 
 import pytest
 
-from core.net_safety import BlockedRequestError, assert_public_url
+from core.net_safety import BlockedRequestError, DnsLookupError, assert_public_url
 
 
 def _addrinfo(*addrs):
     """Build a fake getaddrinfo() return value for the given IP strings."""
-    return [(2, 1, 6, "", (addr, 0)) for addr in addrs]
+    return [
+        (socket.AF_INET6 if ":" in addr else socket.AF_INET, 1, 6, "", (addr, 0))
+        for addr in addrs
+    ]
 
 
 class TestAssertPublicUrl:
@@ -70,12 +74,20 @@ class TestAssertPublicUrl:
             with pytest.raises(BlockedRequestError):
                 assert_public_url("https://mixed.attacker/")
 
-    def test_blocks_unresolvable_hostname(self):
-        import socket
-
+    def test_dns_failure_raises_dns_lookup_error_not_blocked(self):
+        # Transient DNS hiccups must surface as DnsLookupError, distinct
+        # from BlockedRequestError, so callers can retry them.
         with patch("socket.getaddrinfo", side_effect=socket.gaierror("nope")):
-            with pytest.raises(BlockedRequestError, match="DNS lookup failed"):
+            with pytest.raises(DnsLookupError, match="DNS lookup failed"):
                 assert_public_url("https://nope.invalid/")
+
+    def test_blocks_rfc6598_cgnat(self):
+        # 100.64.0.0/10 is shared CGNAT space; ipaddress treats it as
+        # neither private nor global, so we reject it explicitly.
+        for ip in ("100.64.0.1", "100.127.255.254"):
+            with patch("socket.getaddrinfo", return_value=_addrinfo(ip)):
+                with pytest.raises(BlockedRequestError):
+                    assert_public_url(f"https://cgnat-{ip}.attacker/")
 
     def test_custom_allowed_schemes(self):
         """Webhook callers may want to allow http: too."""

--- a/backend/core/tests/test_net_safety.py
+++ b/backend/core/tests/test_net_safety.py
@@ -1,0 +1,87 @@
+"""Tests for the SSRF guard helpers in `core.net_safety`."""
+
+from unittest.mock import patch
+
+import pytest
+
+from core.net_safety import BlockedRequestError, assert_public_url
+
+
+def _addrinfo(*addrs):
+    """Build a fake getaddrinfo() return value for the given IP strings."""
+    return [(2, 1, 6, "", (addr, 0)) for addr in addrs]
+
+
+class TestAssertPublicUrl:
+    def test_allows_public_https(self):
+        with patch("socket.getaddrinfo", return_value=_addrinfo("93.184.216.34")):
+            assert_public_url("https://example.com/logo.png")
+
+    def test_blocks_non_https_scheme(self):
+        with pytest.raises(BlockedRequestError):
+            assert_public_url("http://example.com/")
+        with pytest.raises(BlockedRequestError):
+            assert_public_url("file:///etc/passwd")
+        with pytest.raises(BlockedRequestError):
+            assert_public_url("gopher://example.com/")
+
+    def test_blocks_missing_hostname(self):
+        with pytest.raises(BlockedRequestError):
+            assert_public_url("https:///nohost")
+
+    def test_blocks_aws_imds(self):
+        with patch(
+            "socket.getaddrinfo",
+            return_value=_addrinfo("169.254.169.254"),
+        ):
+            with pytest.raises(BlockedRequestError, match="non-public"):
+                assert_public_url("https://metadata.attacker.example/latest/meta-data")
+
+    def test_blocks_loopback(self):
+        with patch("socket.getaddrinfo", return_value=_addrinfo("127.0.0.1")):
+            with pytest.raises(BlockedRequestError):
+                assert_public_url("https://localhost.attacker/admin")
+
+    def test_blocks_rfc1918(self):
+        for ip in ("10.0.0.5", "172.16.0.1", "192.168.1.1"):
+            with patch("socket.getaddrinfo", return_value=_addrinfo(ip)):
+                with pytest.raises(BlockedRequestError):
+                    assert_public_url(f"https://internal-{ip}.attacker/")
+
+    def test_blocks_ipv6_loopback(self):
+        with patch("socket.getaddrinfo", return_value=_addrinfo("::1")):
+            with pytest.raises(BlockedRequestError):
+                assert_public_url("https://v6.attacker/")
+
+    def test_blocks_ipv6_link_local(self):
+        with patch("socket.getaddrinfo", return_value=_addrinfo("fe80::1")):
+            with pytest.raises(BlockedRequestError):
+                assert_public_url("https://v6-ll.attacker/")
+
+    def test_blocks_when_any_resolution_is_private(self):
+        """Reject the domain even if it ALSO resolves to a public IP.
+        A multi-A record can return a public IP first and a private IP
+        second; routing decisions would pick either, so refuse.
+        """
+        with patch(
+            "socket.getaddrinfo",
+            return_value=_addrinfo("93.184.216.34", "10.0.0.1"),
+        ):
+            with pytest.raises(BlockedRequestError):
+                assert_public_url("https://mixed.attacker/")
+
+    def test_blocks_unresolvable_hostname(self):
+        import socket
+
+        with patch("socket.getaddrinfo", side_effect=socket.gaierror("nope")):
+            with pytest.raises(BlockedRequestError, match="DNS lookup failed"):
+                assert_public_url("https://nope.invalid/")
+
+    def test_custom_allowed_schemes(self):
+        """Webhook callers may want to allow http: too."""
+        with patch("socket.getaddrinfo", return_value=_addrinfo("8.8.8.8")):
+            # Defaults reject http://
+            with pytest.raises(BlockedRequestError):
+                assert_public_url("http://example.com/")
+            # Caller can opt in.
+            assert_public_url("http://example.com/", allowed_schemes=("http", "https"))

--- a/backend/doc_management/tests.py
+++ b/backend/doc_management/tests.py
@@ -1,0 +1,23 @@
+"""Integration coverage for SSRF guard wiring in doc_management."""
+
+import pytest
+
+from core.net_safety import BlockedRequestError
+from doc_management.views import _safe_url_fetcher
+
+
+class TestSafeUrlFetcher:
+    def test_blocks_file_scheme(self):
+        with pytest.raises(BlockedRequestError):
+            _safe_url_fetcher("file:///etc/passwd")
+
+    def test_blocks_http_scheme(self):
+        with pytest.raises(BlockedRequestError):
+            _safe_url_fetcher("http://example.com/img.png")
+
+    def test_data_uri_passes_through(self):
+        # data: URIs are delegated to WeasyPrint's default fetcher and
+        # must not be rejected by our SSRF guard.
+        _safe_url_fetcher(
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg=="
+        )

--- a/backend/doc_management/views.py
+++ b/backend/doc_management/views.py
@@ -56,23 +56,27 @@ def _get_templates_dir(lang: str) -> Path:
 _PDF_FETCH_MAX_BYTES = 10 * 1024 * 1024
 
 
+# WeasyPrint passes a configured `ssl_context` we don't thread through:
+# deployments needing a custom CA for embedded images won't get it. File
+# an issue if that becomes a real need.
 def _safe_url_fetcher(url, timeout=10, ssl_context=None):
     if url.startswith("data:"):
         return weasyprint.default_url_fetcher(url)
     assert_public_url(url, allowed_schemes=("https",))
     r = requests.get(url, timeout=timeout, allow_redirects=False, stream=True)
-    if 300 <= r.status_code < 400:
+    try:
+        status_code = r.status_code
+        final_url = r.url
+        content_type = r.headers.get("Content-Type", "application/octet-stream")
+        if 300 <= status_code < 400:
+            raise BlockedRequestError(f"Redirects not followed: {url}")
+        content = r.raw.read(_PDF_FETCH_MAX_BYTES + 1, decode_content=True)
+    finally:
         r.close()
-        raise BlockedRequestError(f"Redirects not followed: {url}")
-    content = r.raw.read(_PDF_FETCH_MAX_BYTES + 1, decode_content=True)
-    r.close()
     if len(content) > _PDF_FETCH_MAX_BYTES:
         raise BlockedRequestError(f"Response exceeds {_PDF_FETCH_MAX_BYTES} bytes")
-    mime = (
-        r.headers.get("Content-Type", "application/octet-stream").split(";")[0].strip()
-        or None
-    )
-    return {"string": content, "mime_type": mime, "redirected_url": r.url}
+    mime = content_type.split(";")[0].strip() or None
+    return {"string": content, "mime_type": mime, "redirected_url": final_url}
 
 
 class ManagedDocumentViewSet(BaseModelViewSet):

--- a/backend/doc_management/views.py
+++ b/backend/doc_management/views.py
@@ -3,6 +3,7 @@ import mimetypes
 from pathlib import Path
 from uuid import UUID
 
+import requests
 import structlog
 import yaml
 from django.db import models
@@ -24,6 +25,7 @@ from rest_framework.response import Response
 import weasyprint
 from weasyprint import HTML
 
+from core.net_safety import BlockedRequestError, assert_public_url
 from core.views import BaseModelViewSet
 from iam.models import RoleAssignment, Folder
 
@@ -49,6 +51,28 @@ def _get_templates_dir(lang: str) -> Path:
     if localized.exists() and any(localized.glob("*.md")):
         return localized
     return TEMPLATES_BASE_DIR / "en"
+
+
+_PDF_FETCH_MAX_BYTES = 10 * 1024 * 1024
+
+
+def _safe_url_fetcher(url, timeout=10, ssl_context=None):
+    if url.startswith("data:"):
+        return weasyprint.default_url_fetcher(url)
+    assert_public_url(url, allowed_schemes=("https",))
+    r = requests.get(url, timeout=timeout, allow_redirects=False, stream=True)
+    if 300 <= r.status_code < 400:
+        r.close()
+        raise BlockedRequestError(f"Redirects not followed: {url}")
+    content = r.raw.read(_PDF_FETCH_MAX_BYTES + 1, decode_content=True)
+    r.close()
+    if len(content) > _PDF_FETCH_MAX_BYTES:
+        raise BlockedRequestError(f"Response exceeds {_PDF_FETCH_MAX_BYTES} bytes")
+    mime = (
+        r.headers.get("Content-Type", "application/octet-stream").split(";")[0].strip()
+        or None
+    )
+    return {"string": content, "mime_type": mime, "redirected_url": r.url}
 
 
 class ManagedDocumentViewSet(BaseModelViewSet):
@@ -642,20 +666,6 @@ class DocumentRevisionViewSet(BaseModelViewSet):
         html_string = render_to_string(
             "doc_management/policy_document_pdf.html", context
         )
-
-        def _safe_url_fetcher(url, timeout=10, ssl_context=None):
-            """Allow data URIs and public HTTPS images, block everything else.
-
-            Prevents SSRF via file://, internal network URLs, or non-HTTPS schemes
-            while still allowing users to embed external logos/images.
-            """
-            if url.startswith("data:"):
-                return weasyprint.default_url_fetcher(url)
-            if url.startswith("https://"):
-                return weasyprint.default_url_fetcher(
-                    url, timeout=timeout, ssl_context=ssl_context
-                )
-            raise ValueError(f"Blocked resource loading for URL scheme: {url}")
 
         return HTML(string=html_string, url_fetcher=_safe_url_fetcher).write_pdf()
 

--- a/backend/integrations/itsm/jira/client.py
+++ b/backend/integrations/itsm/jira/client.py
@@ -5,6 +5,7 @@ from jira import JIRA
 from structlog import get_logger
 
 from core.models import AppliedControl
+from core.net_safety import check_integration_url
 from integrations.base import BaseIntegrationClient
 
 from .mapper import JiraFieldMapper
@@ -15,8 +16,18 @@ logger = get_logger(__name__)
 class JiraClient(BaseIntegrationClient):
     def __init__(self, configuration):
         super().__init__(configuration)
+        server_url = self.credentials["server_url"]
+        try:
+            check_integration_url(server_url, "Jira server_url")
+        except ValueError:
+            logger.error(
+                "Jira server_url blocked by SSRF guard",
+                server_url=server_url,
+                exc_info=True,
+            )
+            raise
         self.jira = JIRA(
-            server=self.credentials["server_url"],
+            server=server_url,
             basic_auth=(self.credentials["email"], self.credentials["api_token"]),
             timeout=30,
             max_retries=3,

--- a/backend/integrations/itsm/jira/client.py
+++ b/backend/integrations/itsm/jira/client.py
@@ -20,11 +20,7 @@ class JiraClient(BaseIntegrationClient):
         try:
             check_integration_url(server_url, "Jira server_url")
         except ValueError:
-            logger.error(
-                "Jira server_url blocked by SSRF guard",
-                server_url=server_url,
-                exc_info=True,
-            )
+            logger.error("Jira server_url blocked by SSRF guard", exc_info=True)
             raise
         self.jira = JIRA(
             server=server_url,
@@ -32,6 +28,7 @@ class JiraClient(BaseIntegrationClient):
             timeout=30,
             max_retries=3,
         )
+        self.jira._session.max_redirects = 0
         self.mapper = JiraFieldMapper(configuration)
 
     def create_remote_object(self, local_object: AppliedControl):

--- a/backend/integrations/itsm/servicenow/client.py
+++ b/backend/integrations/itsm/servicenow/client.py
@@ -3,6 +3,7 @@ import requests
 from structlog import get_logger
 from integrations.models import SyncMapping
 from core.models import AppliedControl
+from core.net_safety import check_integration_url
 from integrations.base import BaseIntegrationClient
 from .mapper import ServiceNowFieldMapper
 
@@ -13,6 +14,15 @@ class ServiceNowClient(BaseIntegrationClient):
     def __init__(self, configuration):
         super().__init__(configuration)
         self.base_url = self.credentials.get("instance_url", "").rstrip("/")
+        try:
+            check_integration_url(self.base_url, "ServiceNow instance_url")
+        except ValueError:
+            logger.error(
+                "ServiceNow instance_url blocked by SSRF guard",
+                base_url=self.base_url,
+                exc_info=True,
+            )
+            raise
         username = self.credentials.get("username", "")
         password = self.credentials.get("password", "")
         self.auth = (username, password)

--- a/backend/integrations/itsm/servicenow/client.py
+++ b/backend/integrations/itsm/servicenow/client.py
@@ -17,11 +17,7 @@ class ServiceNowClient(BaseIntegrationClient):
         try:
             check_integration_url(self.base_url, "ServiceNow instance_url")
         except ValueError:
-            logger.error(
-                "ServiceNow instance_url blocked by SSRF guard",
-                base_url=self.base_url,
-                exc_info=True,
-            )
+            logger.error("ServiceNow instance_url blocked by SSRF guard", exc_info=True)
             raise
         username = self.credentials.get("username", "")
         password = self.credentials.get("password", "")
@@ -51,6 +47,7 @@ class ServiceNowClient(BaseIntegrationClient):
                 headers=self._get_headers(),
                 json=payload,
                 timeout=30,
+                allow_redirects=False,
             )
             response.raise_for_status()
             result = response.json().get("result", {})
@@ -87,6 +84,7 @@ class ServiceNowClient(BaseIntegrationClient):
                 headers=self._get_headers(),
                 json=changes,
                 timeout=30,
+                allow_redirects=False,
             )
             response.raise_for_status()
             logger.info(
@@ -110,7 +108,11 @@ class ServiceNowClient(BaseIntegrationClient):
 
         try:
             response = requests.get(
-                url, auth=self.auth, headers=self._get_headers(), timeout=30
+                url,
+                auth=self.auth,
+                headers=self._get_headers(),
+                timeout=30,
+                allow_redirects=False,
             )
             response.raise_for_status()
             result = response.json().get("result", {})
@@ -154,6 +156,7 @@ class ServiceNowClient(BaseIntegrationClient):
                 headers=self._get_headers(),
                 params=params,
                 timeout=30,
+                allow_redirects=False,
             )
             response.raise_for_status()
 
@@ -273,6 +276,7 @@ class ServiceNowClient(BaseIntegrationClient):
                 headers=self._get_headers(),
                 params=params,
                 timeout=30,
+                allow_redirects=False,
             )
             response.raise_for_status()
             results = response.json().get("result", [])
@@ -327,6 +331,7 @@ class ServiceNowClient(BaseIntegrationClient):
                 headers=self._get_headers(),
                 params=params,
                 timeout=10,
+                allow_redirects=False,
             )
             resp.raise_for_status()
             result = resp.json().get("result", [])
@@ -353,6 +358,7 @@ class ServiceNowClient(BaseIntegrationClient):
                 headers=self._get_headers(),
                 params=params,
                 timeout=10,
+                allow_redirects=False,
             )
             if resp.status_code == 200:
                 return resp.json().get("result", {}).get("name")
@@ -378,6 +384,7 @@ class ServiceNowClient(BaseIntegrationClient):
                 headers=self._get_headers(),
                 params=params,
                 timeout=10,
+                allow_redirects=False,
             )
             response.raise_for_status()
             results = response.json().get("result", [])
@@ -440,6 +447,7 @@ class ServiceNowClient(BaseIntegrationClient):
                 headers=self._get_headers(),
                 params=params,
                 timeout=10,
+                allow_redirects=False,
             )
             response.raise_for_status()
             results = response.json().get("result", [])
@@ -466,6 +474,7 @@ class ServiceNowClient(BaseIntegrationClient):
                 headers=self._get_headers(),
                 params=params,
                 timeout=10,
+                allow_redirects=False,
             )
             return response.status_code == 200
         except Exception:

--- a/backend/webhooks/models.py
+++ b/backend/webhooks/models.py
@@ -1,11 +1,10 @@
-import ipaddress
 import uuid
-from urllib.parse import urlparse
 from django.db import models
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from core.base_models import NameDescriptionMixin
 from core.models import Actor
+from core.net_safety import BlockedRequestError, assert_public_url
 from iam.models import Folder, FolderMixin
 
 
@@ -78,30 +77,18 @@ class WebhookEndpoint(NameDescriptionMixin, FolderMixin):
         return f"{self.owner} - {self.url}"
 
     def clean(self):
-        """
-        Model-level validation for SSRF mitigation.
-        """
         super().clean()
-
+        if getattr(settings, "WEBHOOK_ALLOW_PRIVATE_IPS", False):
+            return
         try:
-            hostname = urlparse(self.url).hostname
-            if not hostname:
-                raise ValidationError("The URL provided is invalid.")
-
-            # Try to parse the hostname as an IP address
-            ip = ipaddress.ip_address(hostname)
-
-            if not settings.WEBHOOK_ALLOW_PRIVATE_IPS and (
-                ip.is_private or ip.is_loopback or ip.is_reserved
-            ):
-                raise ValidationError(
-                    "In production, the URL cannot be an internal, loopback, or reserved IP address."
-                )
-        except ValueError:
-            # It's a domain name, not an IP address. This is fine.
-            # We are NOT resolving DNS here, as that's a blocking network call
-            # and belongs in a proxy solution.
-            pass
+            assert_public_url(self.url, allowed_schemes=("http", "https"))
+        except BlockedRequestError:
+            raise ValidationError(
+                {
+                    "url": "URL must point to a public host "
+                    "(no private, loopback, or internal addresses)."
+                }
+            )
 
     def save(self, *args, **kwargs):
         """

--- a/backend/webhooks/tasks.py
+++ b/backend/webhooks/tasks.py
@@ -7,11 +7,10 @@ import time
 from datetime import datetime, timezone
 
 import requests
-from django.conf import settings
 from huey.contrib.djhuey import db_task
 from django.core.serializers.json import DjangoJSONEncoder
 
-from core.net_safety import BlockedRequestError, assert_public_url
+from core.net_safety import BlockedRequestError, assert_public_url_unless_dev
 
 from .models import WebhookEndpoint
 
@@ -64,24 +63,22 @@ def send_webhook_request(endpoint_id, event_type, data_payload):
         "webhook-signature": f"v1,{signature}",
     }
 
-    # Model.clean() only blocks IP-literal hostnames and skips DNS;
-    # re-validate at send time so DNS-based targets and post-save DNS
-    # changes are caught. WEBHOOK_ALLOW_PRIVATE_IPS is the existing
-    # dev/loopback escape hatch.
-    if not getattr(settings, "WEBHOOK_ALLOW_PRIVATE_IPS", False):
-        try:
-            assert_public_url(endpoint.url, allowed_schemes=("http", "https"))
-        except BlockedRequestError:
-            logger.error(
-                "Webhook blocked by SSRF guard",
-                endpoint_id=endpoint_id,
-                url=endpoint.url,
-                exc_info=True,
-            )
-            return "Blocked by SSRF guard"
+    # Re-validate at send time: model.clean() only blocks IP-literal
+    # hostnames, so DNS-based targets and post-save DNS changes need
+    # this. DnsLookupError is transient and propagates so Huey retries.
+    try:
+        assert_public_url_unless_dev(endpoint.url, allowed_schemes=("http", "https"))
+    except BlockedRequestError:
+        # Terminal: return (not raise) so Huey doesn't retry 5x with a
+        # fresh webhook-id — receivers would see those as distinct.
+        logger.error(
+            "Webhook blocked by SSRF guard",
+            endpoint_id=endpoint_id,
+            url=endpoint.url,
+            exc_info=True,
+        )
+        return f"Blocked: {endpoint_id} URL points to a non-public address"
 
-    # allow_redirects=False so a hostile receiver can't bounce us to an
-    # internal IP after the pre-check.
     try:
         response = requests.post(
             endpoint.url,
@@ -94,9 +91,16 @@ def send_webhook_request(endpoint_id, event_type, data_payload):
         if 200 <= response.status_code < 300:
             return f"Success: Sent {event_type} to {endpoint.url}"
         elif 300 <= response.status_code < 400:
-            raise Exception(
-                f"Webhook target {endpoint.url} returned redirect "
-                f"(status {response.status_code}); redirects are not followed."
+            # Terminal (same reason as the SSRF-block branch above).
+            logger.warning(
+                "Webhook target returned redirect; not followed",
+                endpoint_id=endpoint_id,
+                url=endpoint.url,
+                status_code=response.status_code,
+            )
+            return (
+                f"Blocked redirect: {endpoint_id} returned "
+                f"status {response.status_code}"
             )
         else:
             raise Exception(

--- a/backend/webhooks/tasks.py
+++ b/backend/webhooks/tasks.py
@@ -74,7 +74,6 @@ def send_webhook_request(endpoint_id, event_type, data_payload):
         logger.error(
             "Webhook blocked by SSRF guard",
             endpoint_id=endpoint_id,
-            url=endpoint.url,
             exc_info=True,
         )
         return f"Blocked: {endpoint_id} URL points to a non-public address"
@@ -95,7 +94,6 @@ def send_webhook_request(endpoint_id, event_type, data_payload):
             logger.warning(
                 "Webhook target returned redirect; not followed",
                 endpoint_id=endpoint_id,
-                url=endpoint.url,
                 status_code=response.status_code,
             )
             return (

--- a/backend/webhooks/tasks.py
+++ b/backend/webhooks/tasks.py
@@ -7,8 +7,11 @@ import time
 from datetime import datetime, timezone
 
 import requests
+from django.conf import settings
 from huey.contrib.djhuey import db_task
 from django.core.serializers.json import DjangoJSONEncoder
+
+from core.net_safety import BlockedRequestError, assert_public_url
 
 from .models import WebhookEndpoint
 
@@ -61,17 +64,41 @@ def send_webhook_request(endpoint_id, event_type, data_payload):
         "webhook-signature": f"v1,{signature}",
     }
 
-    # Send request (15s timeout)
+    # Model.clean() only blocks IP-literal hostnames and skips DNS;
+    # re-validate at send time so DNS-based targets and post-save DNS
+    # changes are caught. WEBHOOK_ALLOW_PRIVATE_IPS is the existing
+    # dev/loopback escape hatch.
+    if not getattr(settings, "WEBHOOK_ALLOW_PRIVATE_IPS", False):
+        try:
+            assert_public_url(endpoint.url, allowed_schemes=("http", "https"))
+        except BlockedRequestError:
+            logger.error(
+                "Webhook blocked by SSRF guard",
+                endpoint_id=endpoint_id,
+                url=endpoint.url,
+                exc_info=True,
+            )
+            return "Blocked by SSRF guard"
+
+    # allow_redirects=False so a hostile receiver can't bounce us to an
+    # internal IP after the pre-check.
     try:
         response = requests.post(
-            endpoint.url, data=json_payload.encode("utf-8"), headers=headers, timeout=15
+            endpoint.url,
+            data=json_payload.encode("utf-8"),
+            headers=headers,
+            timeout=15,
+            allow_redirects=False,
         )
 
-        # Any non-2xx status code is a failure
         if 200 <= response.status_code < 300:
             return f"Success: Sent {event_type} to {endpoint.url}"
+        elif 300 <= response.status_code < 400:
+            raise Exception(
+                f"Webhook target {endpoint.url} returned redirect "
+                f"(status {response.status_code}); redirects are not followed."
+            )
         else:
-            # Raise exception to trigger Huey retry
             raise Exception(
                 f"Webhook failed for {endpoint_id} with status {response.status_code}."
             )

--- a/backend/webhooks/tests.py
+++ b/backend/webhooks/tests.py
@@ -12,12 +12,13 @@ from webhooks.tasks import send_webhook_request
 
 @pytest.fixture
 def public_endpoint(db):
-    return WebhookEndpoint.objects.create(
-        name="public",
-        url="https://example.com/hook",
-        secret="x" * 32,
-        is_active=True,
-    )
+    with override_settings(WEBHOOK_ALLOW_PRIVATE_IPS=True):
+        return WebhookEndpoint.objects.create(
+            name="public",
+            url="https://example.com/hook",
+            secret="x" * 32,
+            is_active=True,
+        )
 
 
 @pytest.fixture

--- a/backend/webhooks/tests.py
+++ b/backend/webhooks/tests.py
@@ -1,0 +1,106 @@
+"""Tests for SSRF guard + redirect refusal in webhook delivery."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.test import override_settings
+
+from core.net_safety import DnsLookupError
+from webhooks.models import WebhookEndpoint
+from webhooks.tasks import send_webhook_request
+
+
+@pytest.fixture
+def public_endpoint(db):
+    return WebhookEndpoint.objects.create(
+        name="public",
+        url="https://example.com/hook",
+        secret="x" * 32,
+        is_active=True,
+    )
+
+
+@pytest.fixture
+def private_endpoint(db):
+    """WebhookEndpoint pointing at a private IP. Bypasses the save-time
+    guard via WEBHOOK_ALLOW_PRIVATE_IPS to simulate a pre-existing
+    record or post-save DNS flip."""
+    with override_settings(WEBHOOK_ALLOW_PRIVATE_IPS=True):
+        return WebhookEndpoint.objects.create(
+            name="private",
+            url="http://10.0.0.1/admin",
+            secret="x" * 32,
+            is_active=True,
+        )
+
+
+@pytest.mark.django_db
+@override_settings(WEBHOOK_ALLOW_PRIVATE_IPS=False)
+def test_blocked_url_returns_terminally(private_endpoint):
+    # Permanent policy denial must be terminal: return (not raise) so
+    # Huey doesn't retry 5x with fresh webhook-ids.
+    result = send_webhook_request.call_local(
+        private_endpoint.id, "test.event", {"foo": "bar"}
+    )
+    assert result.startswith("Blocked")
+
+
+@pytest.mark.django_db
+@override_settings(WEBHOOK_ALLOW_PRIVATE_IPS=False)
+def test_redirect_returns_terminally(public_endpoint):
+    # 3xx must not be followed and must not trigger retries — each
+    # retry would mint a new webhook-id, so a 307/308 target would see
+    # distinct deliveries.
+    mock_response = MagicMock()
+    mock_response.status_code = 302
+    mock_response.headers = {"Location": "https://elsewhere.example/"}
+
+    with patch("webhooks.tasks.requests.post", return_value=mock_response):
+        result = send_webhook_request.call_local(
+            public_endpoint.id, "test.event", {"foo": "bar"}
+        )
+    assert "redirect" in result.lower()
+
+
+@pytest.mark.django_db
+@override_settings(WEBHOOK_ALLOW_PRIVATE_IPS=False)
+def test_dns_failure_is_transient_and_propagates(public_endpoint):
+    # DnsLookupError must propagate so Huey retries; it must NOT be
+    # caught by the BlockedRequestError handler.
+    with patch(
+        "webhooks.tasks.assert_public_url_unless_dev",
+        side_effect=DnsLookupError("DNS lookup failed for example.com"),
+    ):
+        with pytest.raises(DnsLookupError):
+            send_webhook_request.call_local(
+                public_endpoint.id, "test.event", {"foo": "bar"}
+            )
+
+
+@pytest.mark.django_db
+@override_settings(WEBHOOK_ALLOW_PRIVATE_IPS=False)
+def test_5xx_raises_for_retry(public_endpoint):
+    # Non-redirect non-2xx must raise so Huey retries the transient
+    # remote failure.
+    mock_response = MagicMock()
+    mock_response.status_code = 503
+
+    with patch("webhooks.tasks.requests.post", return_value=mock_response):
+        with pytest.raises(Exception, match="status 503"):
+            send_webhook_request.call_local(
+                public_endpoint.id, "test.event", {"foo": "bar"}
+            )
+
+
+@pytest.mark.django_db
+@override_settings(WEBHOOK_ALLOW_PRIVATE_IPS=True)
+def test_allow_private_ips_bypasses_guard(private_endpoint):
+    # Dev escape hatch: the SSRF check is skipped.
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+
+    with patch("webhooks.tasks.requests.post", return_value=mock_response):
+        result = send_webhook_request.call_local(
+            private_endpoint.id, "test.event", {"foo": "bar"}
+        )
+    assert result.startswith("Success")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSRF protection: outbound URLs resolving to non-public/reserved or CGNAT IPs are blocked; DNS failures surface as transient lookup errors.
  * PDF/resource fetcher and integrations/webhook clients now enforce URL safety and refuse redirects; webhook delivery returns a terminal "Blocked" for disallowed targets.
  * Opt-in developer setting to allow private IPs remains available.

* **Tests**
  * Added tests covering SSRF guard behavior, redirects, DNS failure propagation, and integration wiring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/intuitem/ciso-assistant-community/pull/4216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->