### PR TITLE
chores(ci): scope workflow token permissions to job level

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -12,14 +12,16 @@ concurrency:
 
 # explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
 permissions:
-  actions: write
-  contents: write
-  pull-requests: write
-  statuses: write
+  contents: read
 
 jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+      statuses: write
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'

--- a/.github/workflows/docker-build-and-push-ce-canary.yml
+++ b/.github/workflows/docker-build-and-push-ce-canary.yml
@@ -1,7 +1,6 @@
 name: Build/Push Canary Images - CE
 permissions:
   contents: read
-  packages: write
 on:
   push:
     tags:
@@ -36,6 +35,9 @@ jobs:
   build-frontend:
     needs: prepare
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         include:
@@ -82,6 +84,9 @@ jobs:
   build-backend:
     needs: prepare
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         include:
@@ -141,6 +146,9 @@ jobs:
   merge-manifests:
     needs: [prepare, build-frontend, build-backend]
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/docker-build-and-push-dummy.yml
+++ b/.github/workflows/docker-build-and-push-dummy.yml
@@ -16,9 +16,6 @@ env:
 jobs:
   build-and-push:
     runs-on: ubuntu-24.04-arm
-    permissions:
-      contents: read
-      packages: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6

--- a/.github/workflows/docker-build-and-push-dummy.yml
+++ b/.github/workflows/docker-build-and-push-dummy.yml
@@ -1,7 +1,6 @@
 name: Build and Push Docker Images Dummy
 permissions:
   contents: read
-  packages: write
 on:
   workflow_dispatch:
 
@@ -17,6 +16,9 @@ env:
 jobs:
   build-and-push:
     runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6

--- a/.github/workflows/docker-build-and-push-ee-canary.yml
+++ b/.github/workflows/docker-build-and-push-ee-canary.yml
@@ -1,7 +1,6 @@
 name: Build/Push Canary Images - EE
 permissions:
   contents: read
-  packages: write
 on:
   push:
     tags:
@@ -36,6 +35,9 @@ jobs:
   build-frontend:
     needs: prepare
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         include:
@@ -82,6 +84,9 @@ jobs:
   build-backend:
     needs: prepare
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         include:
@@ -141,6 +146,9 @@ jobs:
   merge-manifests:
     needs: [prepare, build-frontend, build-backend]
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/docker-build-and-push-ee.yml
+++ b/.github/workflows/docker-build-and-push-ee.yml
@@ -1,7 +1,6 @@
 name: Build and Push Docker Images EE
 permissions:
   contents: read
-  packages: write
 
 on:
   push:
@@ -39,6 +38,9 @@ jobs:
   build-frontend:
     needs: prepare
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         include:
@@ -85,6 +87,9 @@ jobs:
   build-backend:
     needs: prepare
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         include:
@@ -144,6 +149,9 @@ jobs:
   merge-manifests:
     needs: [prepare, build-frontend, build-backend]
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -1,7 +1,6 @@
 name: Build and Push Docker Images
 permissions:
   contents: read
-  packages: write
 on:
   push:
     tags:
@@ -38,6 +37,9 @@ jobs:
   build-frontend:
     needs: prepare
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         include:
@@ -84,6 +86,9 @@ jobs:
   build-backend:
     needs: prepare
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         include:
@@ -143,6 +148,9 @@ jobs:
   merge-manifests:
     needs: [prepare, build-frontend, build-backend]
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -1,7 +1,6 @@
 name: Functional Tests
 permissions:
   contents: read
-  actions: write
 
 on:
   pull_request:

--- a/.github/workflows/helm-build-and-push-ce.yml
+++ b/.github/workflows/helm-build-and-push-ce.yml
@@ -1,7 +1,6 @@
 name: Publish Helm Chart - CE
 permissions:
   contents: read
-  packages: write
 on:
   push:
     branches:
@@ -18,6 +17,9 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined CI/CD workflow permission scopes: workflow-level token permissions tightened to read-only, with specific write permissions moved to individual jobs where publishing or PR/status updates occur (including image/manifest publishing and CLA-assistant job). No changes to build steps or runtime behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/intuitem/ciso-assistant-community/pull/4231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->