### PR TITLE
feat: expand comments feature

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -4245,7 +4245,7 @@
 	"noComments": "No comments yet",
 	"deleteCommentConfirmation": "Are you sure you want to delete this comment?",
 	"postComment": "Post",
-	"commentsDescription": "Enable comments on requirement assessments",
+	"commentsDescription": "Enable comments on supported objects",
 	"justNow": "just now",
 	"minutesAgo": "{count}m ago",
 	"hoursAgo": "{count}h ago",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -4163,7 +4163,7 @@
 	"noComments": "Aucun commentaire",
 	"deleteCommentConfirmation": "Êtes-vous sûr de vouloir supprimer ce commentaire ?",
 	"postComment": "Publier",
-	"commentsDescription": "Activer les commentaires sur les évaluations d'exigences",
+	"commentsDescription": "Activer les commentaires sur les objets supportés",
 	"justNow": "à l'instant",
 	"minutesAgo": "il y a {count} min",
 	"hoursAgo": "il y a {count} h",

--- a/frontend/src/lib/components/CommentsPanel/CommentsPanel.svelte
+++ b/frontend/src/lib/components/CommentsPanel/CommentsPanel.svelte
@@ -48,12 +48,14 @@
 	let loading = $state(true);
 	let composerFocused = $state(false);
 	let hideProcessed = $state(false);
+	let expanded = $state(false);
 
 	let visibleComments = $derived(hideProcessed ? comments.filter((c) => c.is_active) : comments);
 	let processedCount = $derived(comments.filter((c) => !c.is_active).length);
 
 	const currentUserId: string = page.data.user?.id ?? '';
 	const isAdmin: boolean = page.data.user?.is_admin ?? false;
+	const authorFallback: string = page.data.clientSettings?.settings?.name?.trim() || '***';
 	const modalStore: ModalStore = getModalStore();
 
 	const avatarColors = [
@@ -79,14 +81,14 @@
 		const first = author.first_name?.[0] ?? '';
 		const last = author.last_name?.[0] ?? '';
 		if (first || last) return (first + last).toUpperCase();
-		return author.email?.[0]?.toUpperCase() ?? '?';
+		return (author.email?.[0] ?? authorFallback[0]).toUpperCase();
 	}
 
 	function getDisplayName(author: CommentAuthor): string {
 		if (author.first_name || author.last_name) {
 			return `${author.first_name ?? ''} ${author.last_name ?? ''}`.trim();
 		}
-		return author.email ?? 'Unknown';
+		return author.email || authorFallback;
 	}
 
 	function timeAgo(dateStr: string): string {
@@ -219,22 +221,32 @@
 
 <div class="comments-panel">
 	<!-- Header -->
-	<div class="flex items-center gap-2.5 mb-4">
-		<div class="flex items-center justify-center w-7 h-7 rounded-md bg-surface-100">
-			<i class="fa-solid fa-comments text-xs text-surface-500"></i>
-		</div>
-		<h4 class="text-sm font-semibold tracking-tight text-surface-700">
-			{m.comments()}
-		</h4>
-		{#if !loading}
-			<span
-				class="inline-flex items-center justify-center min-w-5 h-5 px-1.5 rounded-full
-				text-[11px] font-medium bg-surface-100 text-surface-500"
-			>
-				{comments.length}
-			</span>
-		{/if}
-		{#if processedCount > 0}
+	<div class="flex items-center gap-2.5" class:mb-4={expanded}>
+		<button
+			type="button"
+			class="flex items-center gap-2.5 text-left"
+			onclick={() => (expanded = !expanded)}
+		>
+			<div class="flex items-center justify-center w-7 h-7 rounded-md bg-surface-100">
+				<i class="fa-solid fa-comments text-xs text-surface-500"></i>
+			</div>
+			<h4 class="text-sm font-semibold tracking-tight text-surface-700">
+				{m.comments()}
+			</h4>
+			{#if !loading}
+				<span
+					class="inline-flex items-center justify-center min-w-5 h-5 px-1.5 rounded-full
+					text-[11px] font-medium bg-surface-100 text-surface-500"
+				>
+					{comments.length}
+				</span>
+			{/if}
+			<i
+				class="fa-solid fa-chevron-down text-[10px] text-surface-400 transition-transform duration-200"
+				class:rotate-180={expanded}
+			></i>
+		</button>
+		{#if expanded && processedCount > 0}
 			<button
 				class="ml-auto inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px]
 				transition-all duration-150
@@ -249,188 +261,190 @@
 		{/if}
 	</div>
 
-	<!-- Thread -->
-	{#if loading}
-		<div class="flex items-center justify-center py-8">
-			<div class="loading-dot"></div>
-			<div class="loading-dot" style="animation-delay: 0.15s"></div>
-			<div class="loading-dot" style="animation-delay: 0.3s"></div>
-		</div>
-	{:else if comments.length === 0}
-		<div class="flex flex-col items-center py-6 text-surface-400">
-			<i class="fa-regular fa-comment-dots text-2xl mb-2 opacity-40"></i>
-			<p class="text-xs">{m.noComments()}</p>
-		</div>
-	{:else}
-		<div class="relative">
-			<!-- Timeline connector -->
-			{#if visibleComments.length > 1}
-				<div
-					class="absolute left-[15px] top-4 bottom-4 w-px bg-surface-200"
-					style="z-index: 0;"
-				></div>
-			{/if}
-
-			<div class="space-y-1">
-				{#each visibleComments as comment, i (comment.id)}
+	{#if expanded}
+		<!-- Thread -->
+		{#if loading}
+			<div class="flex items-center justify-center py-8">
+				<div class="loading-dot"></div>
+				<div class="loading-dot" style="animation-delay: 0.15s"></div>
+				<div class="loading-dot" style="animation-delay: 0.3s"></div>
+			</div>
+		{:else if comments.length === 0}
+			<div class="flex flex-col items-center py-6 text-surface-400">
+				<i class="fa-regular fa-comment-dots text-2xl mb-2 opacity-40"></i>
+				<p class="text-xs">{m.noComments()}</p>
+			</div>
+		{:else}
+			<div class="relative">
+				<!-- Timeline connector -->
+				{#if visibleComments.length > 1}
 					<div
-						class="comment-entry group relative"
-						class:comment-processed={!comment.is_active}
-						style="animation-delay: {i * 40}ms"
-					>
-						<!-- Avatar -->
+						class="absolute left-[15px] top-4 bottom-4 w-px bg-surface-200"
+						style="z-index: 0;"
+					></div>
+				{/if}
+
+				<div class="space-y-1">
+					{#each visibleComments as comment, i (comment.id)}
 						<div
-							class="relative z-10 flex-shrink-0 w-8 h-8 rounded-full
+							class="comment-entry group relative"
+							class:comment-processed={!comment.is_active}
+							style="animation-delay: {i * 40}ms"
+						>
+							<!-- Avatar -->
+							<div
+								class="relative z-10 flex-shrink-0 w-8 h-8 rounded-full
 							flex items-center justify-center text-[11px] font-semibold
 							ring-2 ring-white transition-transform duration-200
 							group-hover:scale-105 {getAvatarColor(comment.author?.id ?? '')}"
-						>
-							{getInitials(comment.author)}
-						</div>
-
-						<!-- Content -->
-						<div class="flex-1 min-w-0 pt-0.5">
-							<!-- Meta line -->
-							<div class="flex items-center gap-1.5 flex-wrap">
-								<span class="text-[13px] font-medium text-surface-800">
-									{getDisplayName(comment.author)}
-								</span>
-								<span class="text-[11px] text-surface-400">
-									{timeAgo(comment.created_at)}
-								</span>
-								{#if comment.is_tainted}
-									<span class="text-[10px] text-surface-400 italic">
-										({m.commentEdited()})
-									</span>
-								{/if}
-								{#if !comment.is_active}
-									<span
-										class="inline-flex items-center gap-0.5 px-1.5 py-px rounded-full
-										text-[10px] font-medium bg-emerald-50 text-emerald-600 border border-emerald-200"
-									>
-										<i class="fa-solid fa-check text-[8px]"></i>
-										{m.processed()}
-									</span>
-								{/if}
+							>
+								{getInitials(comment.author)}
 							</div>
 
-							<!-- Body or Edit form -->
-							{#if editingId === comment.id}
-								<div class="mt-2 space-y-2">
-									<textarea
-										class="textarea text-sm w-full rounded-xl border-surface-300
+							<!-- Content -->
+							<div class="flex-1 min-w-0 pt-0.5">
+								<!-- Meta line -->
+								<div class="flex items-center gap-1.5 flex-wrap">
+									<span class="text-[13px] font-medium text-surface-800">
+										{getDisplayName(comment.author)}
+									</span>
+									<span class="text-[11px] text-surface-400">
+										{timeAgo(comment.created_at)}
+									</span>
+									{#if comment.is_tainted}
+										<span class="text-[10px] text-surface-400 italic">
+											({m.commentEdited()})
+										</span>
+									{/if}
+									{#if !comment.is_active}
+										<span
+											class="inline-flex items-center gap-0.5 px-1.5 py-px rounded-full
+										text-[10px] font-medium bg-emerald-50 text-emerald-600 border border-emerald-200"
+										>
+											<i class="fa-solid fa-check text-[8px]"></i>
+											{m.processed()}
+										</span>
+									{/if}
+								</div>
+
+								<!-- Body or Edit form -->
+								{#if editingId === comment.id}
+									<div class="mt-2 space-y-2">
+										<textarea
+											class="textarea text-sm w-full rounded-xl border-surface-300
 										focus:border-primary-400 focus:ring-1 focus:ring-primary-200
 										transition-all duration-200"
-										rows="3"
-										bind:value={editBody}
-									></textarea>
-									<div class="flex gap-2">
-										<button
-											class="btn btn-sm preset-filled-primary-500 text-xs rounded-md"
-											disabled={submitting || !editBody.trim()}
-											onclick={() => saveEdit(comment.id)}
-										>
-											{m.save()}
-										</button>
-										<button
-											class="btn btn-sm text-xs rounded-md text-surface-500
+											rows="3"
+											bind:value={editBody}
+										></textarea>
+										<div class="flex gap-2">
+											<button
+												class="btn btn-sm preset-filled-primary-500 text-xs rounded-md"
+												disabled={submitting || !editBody.trim()}
+												onclick={() => saveEdit(comment.id)}
+											>
+												{m.save()}
+											</button>
+											<button
+												class="btn btn-sm text-xs rounded-md text-surface-500
 											hover:text-surface-700 hover:bg-surface-100 transition-colors duration-150"
-											onclick={cancelEdit}
-										>
-											{m.cancel()}
-										</button>
+												onclick={cancelEdit}
+											>
+												{m.cancel()}
+											</button>
+										</div>
 									</div>
-								</div>
-							{:else}
-								<p
-									class="text-[13px] leading-relaxed mt-0.5 text-surface-600
+								{:else}
+									<p
+										class="text-[13px] leading-relaxed mt-0.5 text-surface-600
 									whitespace-pre-wrap break-words"
-								>
-									{comment.body}
-								</p>
-							{/if}
+									>
+										{comment.body}
+									</p>
+								{/if}
 
-							<!-- Actions (appear on hover) -->
-							{#if editingId !== comment.id && (canEdit(comment) || canDelete(comment))}
-								<div
-									class="flex gap-0.5 mt-1.5 opacity-0 group-hover:opacity-100
+								<!-- Actions (appear on hover) -->
+								{#if editingId !== comment.id && (canEdit(comment) || canDelete(comment))}
+									<div
+										class="flex gap-0.5 mt-1.5 opacity-0 group-hover:opacity-100
 									transition-opacity duration-150"
-								>
-									{#if canEdit(comment)}
-										<button
-											class="comment-action-btn"
-											onclick={() => toggleActive(comment)}
-											title={comment.is_active ? m.markAsProcessed() : m.markAsActive()}
-										>
-											<i
-												class="fa-solid {comment.is_active
-													? 'fa-check'
-													: 'fa-rotate-left'} text-[10px]"
-											></i>
-											<span>
-												{comment.is_active ? m.markAsProcessed() : m.markAsActive()}
-											</span>
-										</button>
-										<button class="comment-action-btn" onclick={() => startEdit(comment)}>
-											<i class="fa-solid fa-pen text-[10px]"></i>
-										</button>
-									{/if}
-									{#if canDelete(comment)}
-										<button
-											class="comment-action-btn comment-action-btn-danger"
-											onclick={() => deleteComment(comment.id)}
-										>
-											<i class="fa-solid fa-trash text-[10px]"></i>
-										</button>
-									{/if}
-								</div>
-							{/if}
+									>
+										{#if canEdit(comment)}
+											<button
+												class="comment-action-btn"
+												onclick={() => toggleActive(comment)}
+												title={comment.is_active ? m.markAsProcessed() : m.markAsActive()}
+											>
+												<i
+													class="fa-solid {comment.is_active
+														? 'fa-check'
+														: 'fa-rotate-left'} text-[10px]"
+												></i>
+												<span>
+													{comment.is_active ? m.markAsProcessed() : m.markAsActive()}
+												</span>
+											</button>
+											<button class="comment-action-btn" onclick={() => startEdit(comment)}>
+												<i class="fa-solid fa-pen text-[10px]"></i>
+											</button>
+										{/if}
+										{#if canDelete(comment)}
+											<button
+												class="comment-action-btn comment-action-btn-danger"
+												onclick={() => deleteComment(comment.id)}
+											>
+												<i class="fa-solid fa-trash text-[10px]"></i>
+											</button>
+										{/if}
+									</div>
+								{/if}
+							</div>
 						</div>
-					</div>
-				{/each}
+					{/each}
+				</div>
+			</div>
+		{/if}
+
+		<!-- Composer -->
+		<div class="mt-4 pt-4 border-t border-surface-200">
+			<div class="composer-box" class:composer-focused={composerFocused}>
+				<textarea
+					class="w-full bg-transparent text-[13px] text-surface-700
+				placeholder:text-surface-400 resize-none outline-none
+				border-none leading-relaxed"
+					rows="2"
+					placeholder={m.commentPlaceholder()}
+					bind:value={newCommentBody}
+					onkeydown={handleKeydown}
+					onfocus={() => (composerFocused = true)}
+					onblur={() => (composerFocused = false)}
+				></textarea>
+				<div class="flex items-center justify-between mt-1">
+					<span class="text-[10px] text-surface-400">
+						{#if composerFocused || newCommentBody.trim()}
+							{m.ctrlEnterToPost()}
+						{/if}
+					</span>
+					<button
+						class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium
+					transition-all duration-200
+					{newCommentBody.trim() && !submitting
+							? 'bg-primary-500 text-white shadow-sm shadow-primary-200 hover:bg-primary-600 hover:shadow-md hover:shadow-primary-200 active:scale-[0.97]'
+							: 'bg-surface-100 text-surface-400 cursor-not-allowed'}"
+						disabled={submitting || !newCommentBody.trim()}
+						onclick={postComment}
+					>
+						{#if submitting}
+							<i class="fa-solid fa-spinner fa-spin text-[10px]"></i>
+						{:else}
+							<i class="fa-solid fa-paper-plane text-[10px]"></i>
+						{/if}
+						{m.postComment()}
+					</button>
+				</div>
 			</div>
 		</div>
 	{/if}
-
-	<!-- Composer -->
-	<div class="mt-4 pt-4 border-t border-surface-200">
-		<div class="composer-box" class:composer-focused={composerFocused}>
-			<textarea
-				class="w-full bg-transparent text-[13px] text-surface-700
-				placeholder:text-surface-400 resize-none outline-none
-				border-none leading-relaxed"
-				rows="2"
-				placeholder={m.commentPlaceholder()}
-				bind:value={newCommentBody}
-				onkeydown={handleKeydown}
-				onfocus={() => (composerFocused = true)}
-				onblur={() => (composerFocused = false)}
-			></textarea>
-			<div class="flex items-center justify-between mt-1">
-				<span class="text-[10px] text-surface-400">
-					{#if composerFocused || newCommentBody.trim()}
-						{m.ctrlEnterToPost()}
-					{/if}
-				</span>
-				<button
-					class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium
-					transition-all duration-200
-					{newCommentBody.trim() && !submitting
-						? 'bg-primary-500 text-white shadow-sm shadow-primary-200 hover:bg-primary-600 hover:shadow-md hover:shadow-primary-200 active:scale-[0.97]'
-						: 'bg-surface-100 text-surface-400 cursor-not-allowed'}"
-					disabled={submitting || !newCommentBody.trim()}
-					onclick={postComment}
-				>
-					{#if submitting}
-						<i class="fa-solid fa-spinner fa-spin text-[10px]"></i>
-					{:else}
-						<i class="fa-solid fa-paper-plane text-[10px]"></i>
-					{/if}
-					{m.postComment()}
-				</button>
-			</div>
-		</div>
-	</div>
 </div>
 
 <style>

--- a/frontend/src/lib/components/CommentsPanel/CommentsPanel.svelte
+++ b/frontend/src/lib/components/CommentsPanel/CommentsPanel.svelte
@@ -248,6 +248,7 @@
 		</button>
 		{#if expanded && processedCount > 0}
 			<button
+				type="button"
 				class="ml-auto inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px]
 				transition-all duration-150
 				{hideProcessed
@@ -339,6 +340,7 @@
 										></textarea>
 										<div class="flex gap-2">
 											<button
+												type="button"
 												class="btn btn-sm preset-filled-primary-500 text-xs rounded-md"
 												disabled={submitting || !editBody.trim()}
 												onclick={() => saveEdit(comment.id)}
@@ -346,6 +348,7 @@
 												{m.save()}
 											</button>
 											<button
+												type="button"
 												class="btn btn-sm text-xs rounded-md text-surface-500
 											hover:text-surface-700 hover:bg-surface-100 transition-colors duration-150"
 												onclick={cancelEdit}
@@ -371,6 +374,7 @@
 									>
 										{#if canEdit(comment)}
 											<button
+												type="button"
 												class="comment-action-btn"
 												onclick={() => toggleActive(comment)}
 												title={comment.is_active ? m.markAsProcessed() : m.markAsActive()}
@@ -384,12 +388,17 @@
 													{comment.is_active ? m.markAsProcessed() : m.markAsActive()}
 												</span>
 											</button>
-											<button class="comment-action-btn" onclick={() => startEdit(comment)}>
+											<button
+												type="button"
+												class="comment-action-btn"
+												onclick={() => startEdit(comment)}
+											>
 												<i class="fa-solid fa-pen text-[10px]"></i>
 											</button>
 										{/if}
 										{#if canDelete(comment)}
 											<button
+												type="button"
 												class="comment-action-btn comment-action-btn-danger"
 												onclick={() => deleteComment(comment.id)}
 											>
@@ -426,6 +435,7 @@
 						{/if}
 					</span>
 					<button
+						type="button"
 						class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium
 					transition-all duration-200
 					{newCommentBody.trim() && !submitting

--- a/frontend/src/routes/(app)/(internal)/[model=urlmodel]/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/[model=urlmodel]/[id=uuid]/+page.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import DetailView from '$lib/components/DetailView/DetailView.svelte';
 	import Anchor from '$lib/components/Anchor/Anchor.svelte';
+	import CommentsPanel from '$lib/components/CommentsPanel/CommentsPanel.svelte';
 	import type { PageData, ActionData } from './$types';
+	import { page } from '$app/state';
 	import { m } from '$paraglide/messages';
 
 	interface Props {
@@ -26,6 +28,12 @@
 {/if}
 
 <DetailView {data} />
+
+{#if data.model.name === 'finding' && page.data?.featureflags?.comments}
+	<div class="mt-4">
+		<CommentsPanel parentType="finding" parentId={data.data.id} />
+	</div>
+{/if}
 
 {#if data.model.name == 'requirementmappingset' && data.data.frameworks_available}
 	<div class="card my-4 p-4 bg-white">

--- a/frontend/src/routes/(app)/(internal)/applied-controls/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/applied-controls/[id=uuid]/+page.svelte
@@ -2,6 +2,7 @@
 	import type { PageData } from './$types';
 	import { safeTranslate } from '$lib/utils/i18n';
 	import DetailView from '$lib/components/DetailView/DetailView.svelte';
+	import CommentsPanel from '$lib/components/CommentsPanel/CommentsPanel.svelte';
 	import { m } from '$paraglide/messages';
 	import { page } from '$app/state';
 	import type { ModalComponent, ModalSettings } from '@skeletonlabs/skeleton-svelte';
@@ -68,3 +69,9 @@
 		{/if}
 	{/snippet}
 </DetailView>
+
+{#if page.data?.featureflags?.comments}
+	<div class="mt-4">
+		<CommentsPanel parentType="applied_control" parentId={data.data.id} />
+	</div>
+{/if}

--- a/frontend/src/routes/(app)/(internal)/risk-scenarios/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/risk-scenarios/[id=uuid]/+page.svelte
@@ -13,6 +13,7 @@
 	import Anchor from '$lib/components/Anchor/Anchor.svelte';
 
 	import MarkdownRenderer from '$lib/components/MarkdownRenderer.svelte';
+	import CommentsPanel from '$lib/components/CommentsPanel/CommentsPanel.svelte';
 
 	import { goto } from '$app/navigation';
 
@@ -548,4 +549,7 @@
 			</div>
 		{/if}
 	</div>
+	{#if page.data?.featureflags?.comments}
+		<CommentsPanel parentType="risk_scenario" parentId={data.scenario.id} />
+	{/if}
 </div>

--- a/frontend/src/routes/(app)/(internal)/risk-scenarios/[id=uuid]/edit/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/risk-scenarios/[id=uuid]/edit/+page.svelte
@@ -13,6 +13,7 @@
 	import type { PageData, ActionData } from './$types';
 	import RiskLevel from './RiskLevel.svelte';
 	import MarkdownField from '$lib/components/Forms/MarkdownField.svelte';
+	import CommentsPanel from '$lib/components/CommentsPanel/CommentsPanel.svelte';
 
 	import { browser } from '$app/environment';
 	import { page } from '$app/state';
@@ -602,6 +603,12 @@
 				/>
 			</div>
 		</div>
+
+		{#if page.data?.featureflags?.comments}
+			<div class="my-3">
+				<CommentsPanel parentType="risk_scenario" parentId={data.scenario.id} />
+			</div>
+		{/if}
 
 		<!-- ── Sticky Footer ── -->
 		<div

--- a/product-docs/SUMMARY.md
+++ b/product-docs/SUMMARY.md
@@ -157,6 +157,7 @@
 * [X-rays](features/x-rays.md)
 * [Scoring Assistant](features/scoring-assistant.md)
 * [Assignments / respondent mode](features/assignments.md)
+* [Comments](features/comments.md)
 * [Domain export/import](features/domain-export-import.md)
 * [Focus mode](features/focus-mode.md)
 * [Sync to actions](features/sync-to-actions.md)

--- a/product-docs/concepts/audits.md
+++ b/product-docs/concepts/audits.md
@@ -115,16 +115,13 @@ Together with the compliance result, the analyst dimension, the extended results
 
 Each requirement assessment can carry a thread of **comments** — short, dated, author-attributed notes used for in-context conversation during the audit. They sit alongside the formal fields and don't change the compliance result or the score; they're where the back-and-forth between the analyst, the reviewer, and the auditee happens (clarifications, follow-up questions, agreed-upon next steps).
 
-Each comment has a body, an author, a creation timestamp, and an **active / processed** toggle so resolved threads can be filtered out of the default view without losing the history. Comments can be edited (the platform records the edited state), preserving who said what and when.
+Each comment has a body, an author, a creation timestamp, and an **active / processed** toggle so resolved threads can be filtered out of the default view without losing the history. Comments can be edited (the platform records the edited state), preserving who said what and when. The panel is collapsed by default and shows the comment count, so it stays out of the way until you open it.
 
-Comments are not exclusive to requirement assessments — the same model is shared across **risk scenarios**, **applied controls**, and **findings**, so the same in-context discussion surface exists wherever it's useful to capture iterative review.
+Comments are not exclusive to requirement assessments — the same thread is available on **risk scenarios**, **applied controls**, and **findings**.
 
-#### Feature flag and visibility
+On audits, **Comments** is governed by two controls: the `comments` [feature flag](../configuration/settings/feature-flags.md) (the platform-wide master switch, default on) and the per-audit [field-visibility editor](../guides/customize-audit.md), which lets you make the thread visible to respondents, auditor-only, or hidden. So you can keep comments enabled everywhere while still hiding the discussion from third-party respondents on a sensitive audit. Authors are also masked for third-party participants who can't see other users.
 
-- The `comments` [feature flag](../configuration/settings/feature-flags.md) is the master switch. When off, the comment panel disappears from every supported surface and the per-audit visibility editor stops exposing the **Comments** field. _Default on._
-- When the flag is on, the [audit field-visibility editor](../guides/customize-audit.md) treats **Comments** like any other field — you can choose whether respondents see them, whether they're auditor-only, or whether they're hidden — per audit.
-
-This dual control means you can keep comments enabled platform-wide while still hiding the discussion thread from third-party respondents on sensitive audits.
+See [Comments](../features/comments.md) for the full feature reference — processed state, edit history, permissions, and author privacy.
 
 ## Evidence
 

--- a/product-docs/features/comments.md
+++ b/product-docs/features/comments.md
@@ -1,0 +1,67 @@
+---
+description: In-context discussion threads on audits, risk scenarios, applied controls, and findings — author-attributed, with a processed toggle and edit history
+---
+
+# Comments
+
+Comments are short, dated, author-attributed notes attached directly to an object. They're the place for the back-and-forth that happens while work is in progress — clarifications, follow-up questions, agreed next steps — without touching the object's formal fields, status, or score.
+
+The panel is **collapsed by default** and shows the comment count next to the **Comments** heading, so it stays out of the way until you open it.
+
+## Where comments appear
+
+A comment is always attached to exactly one object. Comments are supported on:
+
+| Object | Where you find the panel |
+|---|---|
+| **Requirement assessment** | On the requirement detail and the respondent-mode assessment view |
+| **Risk scenario** | On the risk-scenario detail page and its edit form |
+| **Applied control** | On the applied-control detail page |
+| **Finding** | On the finding detail page |
+
+## Anatomy of a comment
+
+Each comment carries:
+
+- a **body** (free text),
+- an **author** (the user who posted it),
+- a **creation timestamp**, shown as relative time ("just now", "5 minutes ago") and as a full date once it ages,
+- an **active / processed** state.
+
+Comments are ordered oldest-first, so a thread reads top to bottom like a conversation. Write in the composer at the bottom and **Post** — or press **Ctrl+Enter**.
+
+## Processed vs. active
+
+Every comment is **active** when posted. Once a thread is resolved, its author can **Mark as processed** (and **Mark as active** to reopen it). Processed comments stay in the history but can be filtered out of the default view: when a thread has processed comments, a **Hide processed** / **Show processed (n)** toggle appears in the panel header.
+
+This keeps long threads readable — settled points collapse away without being deleted.
+
+## Edited comments
+
+Comments can be edited by their author. The first time a comment's body actually changes, it's flagged as **edited**, and that marker stays on the comment from then on — so the thread always reflects when wording was changed after the fact. The original posting is what other participants saw; the **edited** tag tells them it was revised.
+
+## Who can do what
+
+| Action | Who |
+|---|---|
+| Post a comment | Anyone with comment access in the object's [domain](../concepts/domains.md) |
+| Edit a comment | The author only |
+| Delete a comment | The author, or an administrator |
+
+Respondents and auditees can post, edit, and delete their **own** comments on the objects they're assigned, so the discussion is two-way.
+
+## Author privacy in respondent mode
+
+Comments are author-attributed, but a participant only sees an author's name and email if they're allowed to see that user. Third-party respondents and auditees have no access to the user directory, so for any comment they didn't write themselves the author is shown as the **Client name** configured in [branding settings](../configuration/settings/branding.md), falling back to `***` when none is set. Their own comments still appear under their own name — internal reviewers' identities never leak into the third-party view.
+
+## Enabling comments
+
+- The **comments** [feature flag](../configuration/settings/feature-flags.md) is the master switch (default **on**). When off, the panel disappears from every object.
+- On audits, **Comments** is also a [field-visibility](../guides/customize-audit.md) option — per audit you can make the thread visible to respondents, auditor-only, or hidden. This lets you keep comments enabled platform-wide while still hiding the discussion from third-party respondents on a sensitive audit.
+
+## Related
+
+- [Audits](../concepts/audits.md) — comments in the audit workflow
+- [Assignments / respondent mode](assignments.md) — the third-party review flow comments support
+- [Branding](../configuration/settings/branding.md) — sets the **Client name** used as the masked-author label
+- [Feature flags](../configuration/settings/feature-flags.md) — the **comments** switch


### PR DESCRIPTION
- **feat: collapsable comments, fallback for identity**
- **expand to other objects**
- **update doc**

<!--
PR title must follow Conventional Commits (squash-merged → title becomes the commit subject):
  feat | fix | chore | refactor | perf | docs | test | ci | build   (lowercase, scope optional, `!` for breaking)
  e.g. feat(lib): add NIS2 framework   |   fix(api): correct residual risk validation
Full guide: product-docs/contributing/code.md
-->

## What & why

<!-- What does this change do, and why? Link the issue if there is one. -->

Closes #

## Test plan

<!-- What you ran/clicked to verify. Attach screenshots for UI changes. -->

## Checklist

<!-- Keep the sections that apply, delete the rest. Tests and docs are part of "done" — tick them when relevant, or note why they aren't. -->

- [x] PR title follows Conventional Commits (`!` set if this is a breaking change)
- [x] One focused change, branched off `main`


### Backend — if you touched `backend/`
- [x] `ruff format` run, no new linter errors


### Frontend — if you touched `frontend/`
- [x] Svelte 5 syntax; `pnpm run lint` and `pnpm run format` run
- [x] New/changed UI strings added to `frontend/messages/en.json` (keep keys, preserve `{tokens}`)
- [x] Clicked through the change in the dev server; screenshots attached for UI changes


### Tests & documentation — definition of done

- [x] `product-docs/` updated, new pages listed in `SUMMARY.md`, vocabulary terms added *(if relevant)*



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comments feature now available on findings, risk scenarios, and applied controls in addition to requirement assessments.
  * Added expandable/collapsible interface for the comments panel for improved space management.
  * Updated translations for comments functionality in English and French.

* **Documentation**
  * Added comprehensive guide documenting comments feature, usage, and availability across supported object types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->