### PR TITLE
fix: expose metrics for enterprise

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -16,7 +16,7 @@ import os
 import uuid
 import zipfile
 import tempfile
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import Dict, Any, List, Tuple, Final
 import time
 from django.db.models import (
@@ -19205,7 +19205,20 @@ def metrics_view(request):
         nb_risk_acceptances_gauge.set(metrics.get("nb_risk_acceptances", 0))
         nb_seats_gauge.set(metrics.get("nb_seats", 0))
         nb_editors_gauge.set(metrics.get("nb_editors", 0))
-        expiration_gauge.set(metrics.get("expiration", 0))
+        # Prometheus onlyhave float64 gauge, so we convert expiration timestamp to int and use -1 for unset/invalid dates
+        try:
+            expiration_date = date.fromisoformat(str(metrics.get("expiration", "")))
+            expiration_ts = int(
+                datetime(
+                    expiration_date.year,
+                    expiration_date.month,
+                    expiration_date.day,
+                    tzinfo=timezone.utc,
+                ).timestamp()
+            )
+        except (ValueError, AttributeError, TypeError):
+            expiration_ts = -1
+        expiration_gauge.set(expiration_ts)
         created_at_gauge.set(metrics.get("created_at", 0))
         last_login_gauge.set(metrics.get("last_login", 0))
     except Exception as e:

--- a/enterprise/backend/enterprise_core/settings.py
+++ b/enterprise/backend/enterprise_core/settings.py
@@ -146,12 +146,19 @@ ENABLE_INFRA_CONFIG_MANAGEMENT = os.environ.get(
     "yes",
 )
 
+EXPOSE_METRICS = os.environ.get("EXPOSE_METRICS", "False").strip().lower() in (
+    "true",
+    "1",
+    "yes",
+)
+
 LIBRARY_COMPATIBILITY_MODES = [0, 1, 2, 3]
 
 logger.info("DEBUG mode: %s", DEBUG)
 logger.info("ENABLE_SANDBOX: %s", ENABLE_SANDBOX)
 logger.info("ENABLE_CHAT: %s", ENABLE_CHAT)
 logger.info("ENABLE_INFRA_CONFIG_MANAGEMENT: %s", ENABLE_INFRA_CONFIG_MANAGEMENT)
+logger.info("EXPOSE_METRICS: %s", EXPOSE_METRICS)
 logger.info("CISO_ASSISTANT_URL: %s", CISO_ASSISTANT_URL)
 # ALLOWED_HOSTS should contain the backend address
 ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "localhost,127.0.0.1").split(",")


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits (squash-merged → title becomes the commit subject):
  feat | fix | chore | refactor | perf | docs | test | ci | build   (lowercase, scope optional, `!` for breaking)
  e.g. feat(lib): add NIS2 framework   |   fix(api): correct residual risk validation
Full guide: product-docs/contributing/code.md
-->

## What & why

expose metrics for enterprise 
Closes #

## Test plan

Going to run a canary and check directly on kube 
## Checklist

- [x ] PR title follows Conventional Commits (`!` set if this is a breaking change)
- [ x] One focused change, branched off `main`
- [ x] CLA accepted (first contribution only)

### Backend — if you touched `backend/`
- [ x] `ruff format` run, no new linter errors
- [ ] Migrations generated with `makemigrations` and committed (or none needed)
- [ ] New dependencies checked for known vulnerabilities and called out above

### Frontend — if you touched `frontend/`
- [ ] Svelte 5 syntax; `pnpm run lint` and `pnpm run format` run
- [ ] New/changed UI strings added to `frontend/messages/en.json` (keep keys, preserve `{tokens}`)
- [ ] Clicked through the change in the dev server; screenshots attached for UI changes

### Other — libraries, CI, infra
- [ ] Library changes built via the `tools/` script
- [ ] CI / build changes run green

### Tests & documentation — definition of done
- [ ] Tests added or updated and passing locally — backend `poetry run pytest`, frontend `pnpm run test` / `./tests/e2e-tests.sh` *(if relevant)*
- [ ] Regression test added for bug fixes *(if relevant)*
- [ ] `product-docs/` updated, new pages listed in `SUMMARY.md`, vocabulary terms added *(if relevant)*
- [ ] No tests or docs needed for this change — why:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new configuration option to control whether metrics are exposed.

* **Bug Fixes**
  * Metrics exporter now reports expiration as a UTC Unix timestamp (or -1 when missing/invalid) instead of an unparsed value, improving consistency for monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->