### PR TITLE
feat(policies): add control catalogue tab

### DIFF
--- a/backend/app_tests/api/test_api_policies.py
+++ b/backend/app_tests/api/test_api_policies.py
@@ -1,6 +1,14 @@
 import pytest
+from rest_framework import status
 from rest_framework.test import APIClient
-from core.models import Policy
+from core.models import (
+    AppliedControl,
+    ComplianceAssessment,
+    Framework,
+    Policy,
+    RequirementAssessment,
+    RequirementNode,
+)
 from iam.models import Folder
 
 from test_utils import EndpointTestsQueries
@@ -14,6 +22,35 @@ POLICY_EFFORT = ("L", "Large")
 POLICY_EFFORT2 = ("M", "Medium")
 POLICY_LINK = "https://example.com"
 POLICY_ETA = "2024-01-01"
+
+
+def _make_requirement_assessment(folder, suffix):
+    framework = Framework.objects.create(
+        urn=f"urn:test:policy-control-catalogue:{suffix}",
+        name=f"Catalogue framework {suffix}",
+        folder=folder,
+    )
+    requirement = RequirementNode.objects.create(
+        urn=f"urn:test:policy-control-catalogue:{suffix}:requirement",
+        folder=folder,
+        framework=framework,
+        assessable=True,
+    )
+    compliance_assessment = ComplianceAssessment.objects.create(
+        name=f"Catalogue assessment {suffix}",
+        folder=folder,
+        framework=framework,
+    )
+    return RequirementAssessment.objects.create(
+        compliance_assessment=compliance_assessment,
+        requirement=requirement,
+        folder=folder,
+    )
+
+
+def _get_results(response):
+    data = response.json()
+    return data["results"] if isinstance(data, dict) and "results" in data else data
 
 
 @pytest.mark.django_db
@@ -214,3 +251,111 @@ class TestPolicysAuthenticated:
             Policy.Status.choices,
             user_group=test.user_group,
         )
+
+    def test_get_control_catalogue(self, authenticated_client):
+        """returns deduped non-policy controls linked through policy requirements"""
+
+        folder = Folder.objects.create(name="policy-control-catalogue")
+        policy = Policy.objects.create(name="Catalogue Policy", folder=folder)
+        other_policy = Policy.objects.create(name="Other Policy", folder=folder)
+        policy_category_row = AppliedControl.objects.create(
+            name="Policy category row",
+            ref_id="POLICY-CAT",
+            category="policy",
+            folder=folder,
+        )
+        control_a = AppliedControl.objects.create(
+            name="Alpha Control",
+            ref_id="CTRL-A",
+            category="technical",
+            folder=folder,
+        )
+        control_b = AppliedControl.objects.create(
+            name="Beta Control",
+            ref_id="CTRL-B",
+            category="process",
+            folder=folder,
+        )
+        unrelated_control = AppliedControl.objects.create(
+            name="Unrelated Control",
+            ref_id="CTRL-UNRELATED",
+            folder=folder,
+        )
+
+        requirement_assessment_a = _make_requirement_assessment(folder, "a")
+        requirement_assessment_b = _make_requirement_assessment(folder, "b")
+        requirement_assessment_a.applied_controls.add(
+            policy,
+            other_policy,
+            policy_category_row,
+            control_a,
+            control_b,
+        )
+        requirement_assessment_b.applied_controls.add(policy, control_a)
+
+        response = authenticated_client.get(
+            f"/api/policies/{policy.id}/control-catalogue/"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        rows = _get_results(response)
+        row_ids = [row["id"] for row in rows]
+        assert row_ids.count(str(control_a.id)) == 1
+        assert set(row_ids) == {str(control_a.id), str(control_b.id)}
+        assert str(policy.id) not in row_ids
+        assert str(other_policy.id) not in row_ids
+        assert str(policy_category_row.id) not in row_ids
+        assert str(unrelated_control.id) not in row_ids
+
+        row_a = next(row for row in rows if row["id"] == str(control_a.id))
+        assert "linked_models" in row_a
+        assert "requirement_assessments" in row_a["linked_models"]
+        assert row_a["folder"] == {"id": str(folder.id), "str": folder.name}
+
+    def test_control_catalogue_supports_search_ordering_and_pagination(
+        self, authenticated_client
+    ):
+        """supports Applied Control list filtering behavior on the derived queryset"""
+
+        folder = Folder.objects.create(name="policy-control-catalogue-filtering")
+        policy = Policy.objects.create(name="Catalogue Policy", folder=folder)
+        requirement_assessment = _make_requirement_assessment(folder, "filtering")
+        alpha = AppliedControl.objects.create(
+            name="Alpha Control",
+            ref_id="CTRL-A",
+            category="technical",
+            folder=folder,
+        )
+        beta = AppliedControl.objects.create(
+            name="Beta Control",
+            ref_id="CTRL-B",
+            category="technical",
+            folder=folder,
+        )
+        gamma = AppliedControl.objects.create(
+            name="Gamma Control",
+            ref_id="CTRL-C",
+            category="technical",
+            folder=folder,
+        )
+        requirement_assessment.applied_controls.add(policy, alpha, beta, gamma)
+
+        response = authenticated_client.get(
+            f"/api/policies/{policy.id}/control-catalogue/",
+            {"search": "Control", "ordering": "-ref_id", "limit": 2, "offset": 1},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        rows = data["results"]
+        assert data["count"] == 3
+        assert [row["id"] for row in rows] == [str(beta.id), str(alpha.id)]
+
+        response = authenticated_client.get(
+            f"/api/policies/{policy.id}/control-catalogue/",
+            {"search": "Beta"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        rows = _get_results(response)
+        assert [row["id"] for row in rows] == [str(beta.id)]

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -5151,22 +5151,11 @@ class AppliedControlViewSet(ExportMixin, BaseModelViewSet):
         "prefetch_related": ["owner", "filtering_labels"],
     }
 
-    def get_queryset(self):
-        """Optimize queries by prefetching related objects used in the table view and serializer"""
+    @staticmethod
+    def _with_linked_model_annotations(qs):
+        """Annotate AppliedControl rows with linked model flags used by the list serializer."""
         from crq.models import QuantitativeRiskHypothesis
 
-        qs = (
-            super()
-            .get_queryset()
-            .select_related(
-                "folder",
-                "folder__parent_folder",  # For get_folder_full_path() optimization
-            )
-        )
-        if self.action == "autocomplete":
-            return qs
-
-        # Annotate with Exists() for each reverse relation to power linked_models
         m2m_through_fields = {
             "has_requirement_assessments": RequirementAssessment.applied_controls.through,
             "has_risk_scenarios": RiskScenario.applied_controls.through,
@@ -5187,21 +5176,39 @@ class AppliedControlViewSet(ExportMixin, BaseModelViewSet):
             alias: Exists(through.objects.filter(appliedcontrol_id=OuterRef("pk")))
             for alias, through in m2m_through_fields.items()
         }
-        # Comment uses a ForeignKey, not M2M
         annotations["has_comments"] = Exists(
             Comment.objects.filter(applied_control_id=OuterRef("pk"))
         )
 
-        qs = qs.select_related("reference_control").annotate(**annotations)
+        return qs.select_related("reference_control").annotate(**annotations)
+
+    @staticmethod
+    def _with_list_prefetches(qs):
+        return qs.prefetch_related(
+            "owner",
+            "filtering_labels__folder",
+            "assets",
+        )
+
+    def get_queryset(self):
+        """Optimize queries by prefetching related objects used in the table view and serializer"""
+        qs = (
+            super()
+            .get_queryset()
+            .select_related(
+                "folder",
+                "folder__parent_folder",  # For get_folder_full_path() optimization
+            )
+        )
+        if self.action == "autocomplete":
+            return qs
+
+        qs = self._with_linked_model_annotations(qs)
 
         # The list serializer doesn't render findings/evidences/objectives/
         # security_exceptions, so skip those prefetches on the list path.
         if self.action == "list":
-            return qs.prefetch_related(
-                "owner",
-                "filtering_labels__folder",
-                "assets",
-            )
+            return self._with_list_prefetches(qs)
 
         return qs.prefetch_related(
             "owner",
@@ -6639,6 +6646,44 @@ class PolicyViewSet(AppliedControlViewSet):
     @action(detail=False, name="Get csf_function choices")
     def csf_function(self, request):
         return Response(dict(AppliedControl.CSF_FUNCTION))
+
+    @action(detail=True, methods=["get"], url_path="control-catalogue")
+    def control_catalogue(self, request, pk=None):
+        policy = get_object_or_404(Policy.objects.all(), pk=pk)
+        if not RoleAssignment.is_object_readable(request.user, Policy, policy.id):
+            raise PermissionDenied()
+
+        requirement_assessments = policy.requirement_assessments.all()
+        qs = (
+            AppliedControl.objects.filter(
+                requirement_assessments__in=requirement_assessments,
+            )
+            .exclude(Q(id=policy.id) | Q(category="policy"))
+            .distinct()
+            .select_related("folder", "folder__parent_folder")
+        )
+
+        viewable_controls, _, _ = RoleAssignment.get_accessible_object_ids(
+            Folder.get_root_folder(),
+            request.user,
+            AppliedControl,
+        )
+        qs = AppliedControlViewSet._with_list_prefetches(
+            AppliedControlViewSet._with_linked_model_annotations(qs)
+        )
+        qs = self.filter_queryset(qs.filter(id__in=viewable_controls))
+
+        from core.serializers import AppliedControlListSerializer
+
+        page = self.paginate_queryset(qs)
+        objects = page if page is not None else qs
+        serializer = AppliedControlListSerializer(
+            objects, many=True, context=self.get_serializer_context()
+        )
+
+        if page is not None:
+            return self.get_paginated_response(serializer.data)
+        return Response(serializer.data)
 
 
 class RiskScenarioFilter(GenericFilterSet):

--- a/cli/README.md
+++ b/cli/README.md
@@ -309,6 +309,7 @@ CLICA includes Model Context Protocol (MCP) integration for use with Claude Desk
 
 - `get_risk_scenarios()`: Retrieve risk scenarios from CISO Assistant
 - `get_applied_controls()`: Retrieve applied controls/action plan
+- `get_policy_control_catalogue(policy)`: Retrieve the derived Applied Control catalogue for a policy
 - `get_audits_progress()`: Retrieve compliance assessment progress
 
 ## Examples

--- a/cli/ca_mcp/resolvers.py
+++ b/cli/ca_mcp/resolvers.py
@@ -1,6 +1,6 @@
 """Helper functions to resolve names to UUIDs"""
 
-from .client import make_get_request, get_paginated_results
+from .client import make_get_request, get_paginated_results, fetch_all_results
 
 
 def resolve_folder_id(folder_name_or_id: str) -> str:
@@ -294,6 +294,46 @@ def resolve_applied_control_id(control_name_or_id: str, folder_id: str = None) -
         )
 
     return controls[0]["id"]
+
+
+def resolve_policy_id(policy_name_or_ref_or_id: str) -> str:
+    """Resolve a policy UUID, ref_id, or name to a UUID."""
+    if "-" in policy_name_or_ref_or_id and len(policy_name_or_ref_or_id) == 36:
+        return policy_name_or_ref_or_id
+
+    policies, error = fetch_all_results(
+        "/policies/", params={"search": policy_name_or_ref_or_id}
+    )
+
+    if error:
+        raise ValueError(f"Policy '{policy_name_or_ref_or_id}' API error: {error}")
+
+    if not policies:
+        raise ValueError(f"Policy '{policy_name_or_ref_or_id}' not found")
+
+    exact_matches = [
+        policy
+        for policy in policies
+        if policy.get("name") == policy_name_or_ref_or_id
+        or policy.get("ref_id") == policy_name_or_ref_or_id
+    ]
+
+    if len(exact_matches) == 1:
+        return str(exact_matches[0]["id"])
+
+    if len(exact_matches) > 1:
+        policy_names = [p.get("name", "N/A") for p in exact_matches[:3]]
+        raise ValueError(
+            f"Ambiguous policy '{policy_name_or_ref_or_id}', found {len(exact_matches)} exact matches: {policy_names}"
+        )
+
+    if len(policies) == 1:
+        return str(policies[0]["id"])
+
+    policy_names = [p.get("name", "N/A") for p in policies[:3]]
+    raise ValueError(
+        f"Ambiguous policy '{policy_name_or_ref_or_id}', found {len(policies)}: {policy_names}. Use the policy UUID or ref_id."
+    )
 
 
 def resolve_requirement_assessment_id(requirement_assessment_id: str) -> str:

--- a/cli/ca_mcp/server.py
+++ b/cli/ca_mcp/server.py
@@ -10,6 +10,7 @@ from .tools.read_tools import (
     get_risk_scenarios,
     get_risk_scenario,
     get_applied_controls,
+    get_policy_control_catalogue,
     get_audits_progress,
     get_folders,
     get_perimeters,
@@ -138,6 +139,7 @@ from .tools.ebios_rm_tools import (
 mcp.tool()(get_risk_scenarios)
 mcp.tool()(get_risk_scenario)
 mcp.tool()(get_applied_controls)
+mcp.tool()(get_policy_control_catalogue)
 mcp.tool()(get_audits_progress)
 mcp.tool()(get_folders)
 mcp.tool()(get_perimeters)

--- a/cli/ca_mcp/tools/read_tools.py
+++ b/cli/ca_mcp/tools/read_tools.py
@@ -3,7 +3,7 @@
 import json
 import sys
 from rich import print as rprint
-from ..client import make_get_request, get_paginated_results
+from ..client import make_get_request, get_paginated_results, fetch_all_results
 from ..utils.response_formatter import (
     success_response,
     error_response,
@@ -216,6 +216,108 @@ async def get_applied_controls(folder: str = None):
             result,
             "get_applied_controls",
             "Use this table to answer the user's question about applied controls",
+        )
+    except Exception as e:
+        return error_response(
+            "Internal Error",
+            str(e),
+            "Report this error to the user",
+            retry_allowed=False,
+        )
+
+
+def _markdown_cell(value):
+    return (
+        str(value if value not in (None, "") else "--")
+        .replace("\n", " ")
+        .replace("|", "\\|")
+    )
+
+
+def _markdown_list(value):
+    if not value:
+        return "--"
+    if not isinstance(value, list):
+        return _markdown_cell(value)
+    return ", ".join(
+        _markdown_cell(item.get("str", item) if isinstance(item, dict) else item)
+        for item in value
+    )
+
+
+async def get_policy_control_catalogue(
+    policy: str,
+    search: str = None,
+    ordering: str = None,
+    limit: int = 100,
+):
+    """List the derived Control Catalogue for a policy.
+
+    Args:
+        policy: Policy UUID, ref_id, or name
+        search: Optional search term for catalogue rows
+        ordering: Optional ordering field, e.g. ref_id or -ref_id
+        limit: Maximum rows to display in the MCP response
+    """
+    try:
+        from ..resolvers import resolve_policy_id
+
+        policy_id = resolve_policy_id(policy)
+        display_limit = max(1, min(int(limit or 100), 500))
+        params = {"limit": display_limit}
+        filters = {"policy": policy}
+
+        if search:
+            params["search"] = search
+            filters["search"] = search
+
+        if ordering:
+            params["ordering"] = ordering
+            filters["ordering"] = ordering
+
+        res = make_get_request(
+            f"/policies/{policy_id}/control-catalogue/", params=params
+        )
+
+        if res.status_code != 200:
+            return http_error_response(res.status_code, res.text)
+
+        data = res.json()
+        controls = get_paginated_results(data)
+
+        if not controls:
+            return empty_response("policy control catalogue rows", filters)
+
+        total_count = (
+            data.get("count", len(controls)) if isinstance(data, dict) else len(controls)
+        )
+
+        result = f"Found {total_count} policy control catalogue rows"
+        if filters:
+            result += f" ({', '.join(f'{k}={v}' for k, v in filters.items())})"
+        if total_count > len(controls):
+            result += f"; showing first {len(controls)}"
+        result += "\n\n"
+        result += "|UUID|Ref|Name|Status|Category|CSF Function|Owner|Domain|ETA|\n"
+        result += "|---|---|---|---|---|---|---|---|---|\n"
+
+        for control in controls:
+            result += (
+                f"|{_markdown_cell(control.get('id'))}"
+                f"|{_markdown_cell(control.get('ref_id'))}"
+                f"|{_markdown_cell(control.get('name'))}"
+                f"|{_markdown_cell(control.get('status'))}"
+                f"|{_markdown_cell(control.get('category'))}"
+                f"|{_markdown_cell(control.get('csf_function'))}"
+                f"|{_markdown_list(control.get('owner'))}"
+                f"|{_markdown_cell((control.get('folder') or {}).get('str'))}"
+                f"|{_markdown_cell(control.get('eta'))}|\n"
+            )
+
+        return success_response(
+            result,
+            "get_policy_control_catalogue",
+            "Use this table to answer questions about the policy-level Control Catalogue. Use update_applied_control only if the user explicitly asks to edit a listed control.",
         )
     except Exception as e:
         return error_response(

--- a/cli/tests/test_mcp.py
+++ b/cli/tests/test_mcp.py
@@ -277,3 +277,168 @@ class TestMCPErrorHandling:
             mock_rprint.assert_called_once()
             args, kwargs = mock_rprint.call_args
             assert "check credentials" in str(args[0])
+
+
+class _MockResponse:
+    def __init__(self, payload, status_code=200, text="OK"):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+class TestPolicyControlCatalogueMCP:
+    def test_resolve_policy_id_returns_uuid_without_api_lookup(self):
+        from ca_mcp.resolvers import resolve_policy_id
+
+        policy_id = "11111111-1111-1111-1111-111111111111"
+
+        assert resolve_policy_id(policy_id) == policy_id
+
+    def test_resolve_policy_id_exact_ref_id_and_name(self, monkeypatch):
+        from ca_mcp import resolvers
+
+        policies = [
+            {"id": "policy-a", "name": "Policy A", "ref_id": "POL-A"},
+            {"id": "policy-b", "name": "Policy B", "ref_id": "POL-B"},
+        ]
+
+        def fake_fetch_all_results(endpoint, params=None):
+            assert endpoint == "/policies/"
+            assert params == {"search": "POL-A"}
+            return policies, None
+
+        monkeypatch.setattr(resolvers, "fetch_all_results", fake_fetch_all_results)
+
+        assert resolvers.resolve_policy_id("POL-A") == "policy-a"
+
+        def fake_fetch_all_results_by_name(endpoint, params=None):
+            assert endpoint == "/policies/"
+            assert params == {"search": "Policy B"}
+            return policies, None
+
+        monkeypatch.setattr(
+            resolvers, "fetch_all_results", fake_fetch_all_results_by_name
+        )
+
+        assert resolvers.resolve_policy_id("Policy B") == "policy-b"
+
+    def test_resolve_policy_id_rejects_ambiguity(self, monkeypatch):
+        from ca_mcp import resolvers
+
+        def fake_fetch_all_results(endpoint, params=None):
+            return [
+                {"id": "policy-a", "name": "Policy", "ref_id": "POL"},
+                {"id": "policy-b", "name": "Policy", "ref_id": "POL"},
+            ], None
+
+        monkeypatch.setattr(resolvers, "fetch_all_results", fake_fetch_all_results)
+
+        with pytest.raises(ValueError, match="Ambiguous policy"):
+            resolvers.resolve_policy_id("POL")
+
+    @pytest.mark.asyncio
+    async def test_get_policy_control_catalogue_passes_bounded_request_params(
+        self, monkeypatch
+    ):
+        from ca_mcp import resolvers
+        from ca_mcp.tools import read_tools
+
+        calls = []
+
+        monkeypatch.setattr(resolvers, "resolve_policy_id", lambda policy: "policy-id")
+        monkeypatch.setattr(
+            read_tools,
+            "fetch_all_results",
+            lambda *args, **kwargs: pytest.fail("should not fetch all pages"),
+        )
+
+        def fake_make_get_request(endpoint, params=None):
+            calls.append((endpoint, params))
+            return _MockResponse(
+                {
+                    "count": 10,
+                    "next": (
+                        "https://example.test/api/policies/policy-id/"
+                        "control-catalogue/?offset=2"
+                    ),
+                    "results": [
+                        {
+                            "id": "ctrl-a",
+                            "ref_id": "CTRL-A",
+                            "name": "Alpha Control",
+                            "status": "active",
+                            "category": "Technical",
+                            "csf_function": "Identify",
+                            "owner": [{"str": "Owner A"}],
+                            "folder": {"str": "Domain A"},
+                            "eta": "2026-01-01",
+                        },
+                        {
+                            "id": "ctrl-b",
+                            "ref_id": "CTRL-B",
+                            "name": "Beta Control",
+                            "status": "to_do",
+                            "category": "Process",
+                            "csf_function": "Protect",
+                            "owner": [],
+                            "folder": {"str": "Domain A"},
+                            "eta": None,
+                        },
+                    ],
+                }
+            )
+
+        monkeypatch.setattr(read_tools, "make_get_request", fake_make_get_request)
+
+        result = await read_tools.get_policy_control_catalogue(
+            "POL-A", search="control", ordering="-ref_id", limit=2
+        )
+
+        assert calls == [
+            (
+                "/policies/policy-id/control-catalogue/",
+                {"limit": 2, "search": "control", "ordering": "-ref_id"},
+            )
+        ]
+        assert (
+            "|UUID|Ref|Name|Status|Category|CSF Function|Owner|Domain|ETA|"
+            in result
+        )
+        assert "CTRL-A" in result
+        assert "CTRL-B" in result
+        assert "Found 10 policy control catalogue rows" in result
+        assert "showing first 2" in result
+
+    @pytest.mark.asyncio
+    async def test_get_policy_control_catalogue_caps_limit(self, monkeypatch):
+        from ca_mcp import resolvers
+        from ca_mcp.tools import read_tools
+
+        calls = []
+
+        monkeypatch.setattr(resolvers, "resolve_policy_id", lambda policy: "policy-id")
+
+        def fake_make_get_request(endpoint, params=None):
+            calls.append((endpoint, params))
+            return _MockResponse(
+                {
+                    "count": 1,
+                    "results": [
+                        {
+                            "id": "ctrl-a",
+                            "ref_id": "CTRL-A",
+                            "name": "Alpha Control",
+                            "folder": {"str": "Domain A"},
+                        }
+                    ],
+                }
+            )
+
+        monkeypatch.setattr(read_tools, "make_get_request", fake_make_get_request)
+
+        await read_tools.get_policy_control_catalogue("POL-A", limit=999)
+
+        assert calls == [("/policies/policy-id/control-catalogue/", {"limit": 500})]

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1541,6 +1541,7 @@
 	"advancedAnalyticsLockedTooltip": "Advanced Analytics is disabled. Enable it in Settings > Feature Flags.",
 	"complianceBySection": "Compliance by Section",
 	"controlsCoverage": "Controls Coverage",
+	"controlCatalogue": "Control catalogue",
 	"requirementsWithControls": "With controls",
 	"requirementsWithoutControls": "Without controls",
 	"coveragePercent": "Coverage",

--- a/frontend/src/lib/components/DetailView/DetailView.svelte
+++ b/frontend/src/lib/components/DetailView/DetailView.svelte
@@ -10,7 +10,11 @@
 	import ModelTable from '$lib/components/ModelTable/ModelTable.svelte';
 	import { booleanDisplay } from '$lib/utils/boolean-display';
 	import { ISO_8601_REGEX } from '$lib/utils/constants';
-	import { type ModelMapEntry, type ReverseForeignKeyField } from '$lib/utils/crud';
+	import {
+		getReverseForeignKeyFieldKey,
+		type ModelMapEntry,
+		type ReverseForeignKeyField
+	} from '$lib/utils/crud';
 	import { getModelInfo } from '$lib/utils/crud.js';
 	import { formatDate, formatDateOrDateTime } from '$lib/utils/datetime';
 	import { isURL } from '$lib/utils/helpers';
@@ -87,9 +91,16 @@
 
 	exclude = [...exclude, ...defaultExcludes];
 
-	const getRelatedModelIndex = (model: ModelMapEntry, relatedModel: Record<string, string>) => {
+	const getRelatedModelIndex = (
+		model: ModelMapEntry,
+		relatedModel: { relationKey?: string; urlModel: string }
+	) => {
 		if (!model.reverseForeignKeyFields) return -1;
-		return model.reverseForeignKeyFields.findIndex((o) => o.urlModel === relatedModel.urlModel);
+		return model.reverseForeignKeyFields.findIndex(
+			(o) =>
+				getReverseForeignKeyFieldKey(o, model.reverseForeignKeyFields) ===
+				(relatedModel.relationKey ?? relatedModel.urlModel)
+		);
 	};
 
 	let filteredData = $derived(
@@ -867,15 +878,18 @@
 			class="w-full"
 		>
 			<Tabs.List class="shrink-0 gap-3">
-				{#each relatedModels as [urlmodel, model]}
+				{#each relatedModels as [relationKey, model]}
+					{@const field = model.field}
 					<Tabs.Trigger
-						value={urlmodel}
+						value={relationKey}
 						class="justify-between w-full rounded-md px-3 py-2 transition-colors
 			       aria-[selected=true]:!bg-gray-200
 			       "
 						data-testid="tabs-control"
 					>
-						{safeTranslate(model.info.localNamePlural)}
+						{field.tabLabel
+							? safeTranslate(field.tabLabel)
+							: safeTranslate(model.info.localNamePlural)}
 						{#if model.count !== undefined && model.count > 0}
 							<span
 								class="ml-2 rounded-full px-2 py-0.5 text-xs
@@ -887,23 +901,22 @@
 					</Tabs.Trigger>
 				{/each}
 			</Tabs.List>
-			{#each relatedModels as [urlmodel, model]}
-				<Tabs.Content value={urlmodel} class="flex-1 min-w-0">
-					{#key urlmodel}
-						{@const field = data.model.reverseForeignKeyFields.find(
-							(item) => item.urlModel === urlmodel
-						)}
+			{#each relatedModels as [relationKey, model]}
+				<Tabs.Content value={relationKey} class="flex-1 min-w-0">
+					{#key relationKey}
+						{@const field = model.field}
 						{@const fieldsToUse =
-							field?.tableFields ||
+							field.tableFields ||
 							getListViewFields({
-								key: urlmodel,
+								key: model.urlModel,
 								featureFlags: page.data?.featureflags
 							}).body.filter((v) => v !== field.field)}
+						{@const fieldHeadings = field.tableHeadings || fieldsToUse}
 						{#if model.table}
 							<ModelTable
 								baseEndpoint={getReverseForeignKeyEndpoint({
 									parentModel: data.model,
-									targetUrlModel: urlmodel,
+									targetUrlModel: model.urlModel,
 									field: field.field,
 									id: data.data.id,
 									endpointUrl: field.endpointUrl
@@ -913,9 +926,10 @@
 								disableEdit={disableEdit || model.disableEdit}
 								disableDelete={disableDelete || model.disableDelete}
 								deleteForm={model.deleteForm}
-								URLModel={urlmodel}
-								expectedCount={getExpectedCount(urlmodel, field)}
+								URLModel={model.urlModel}
+								expectedCount={getExpectedCount(model.urlModel, field)}
 								fields={fieldsToUse}
+								{fieldHeadings}
 								defaultFilters={field.defaultFilters || {}}
 							>
 								{#snippet addButton()}

--- a/frontend/src/lib/components/ModelTable/ModelTable.svelte
+++ b/frontend/src/lib/components/ModelTable/ModelTable.svelte
@@ -91,6 +91,7 @@
 		detailQueryParameter?: string;
 		fields?: string[];
 		columnSelector?: boolean;
+		fieldHeadings?: string[];
 		canSelectObject?: boolean;
 		overrideFilters?: { [key: string]: any[] };
 		defaultFilters?: { [key: string]: any[] };
@@ -145,6 +146,7 @@
 		detailQueryParameter = $bindable(),
 		fields = [],
 		columnSelector = undefined,
+		fieldHeadings = [],
 		canSelectObject = false,
 		overrideFilters = {},
 		defaultFilters = {},
@@ -321,7 +323,7 @@
 			endpoint: baseEndpoint,
 			fields:
 				fields.length > 0
-					? { head: fields, body: fields }
+					? { head: fieldHeadings.length > 0 ? fieldHeadings : fields, body: fields }
 					: {
 							head:
 								typeof tableSource.head[0] === 'string'
@@ -481,21 +483,22 @@
 			: false
 	);
 	let contextMenuCanEditObject = $derived(
-		(model
-			? page.params.id
-				? canPerformAction({
-						user,
-						action: 'change',
-						model: model.name,
-						domain:
-							model.name === 'folder'
-								? contextMenuOpenRow?.meta.id
-								: (contextMenuOpenRow?.meta.folder?.id ??
-									contextMenuOpenRow?.meta.folder ??
-									user.root_folder_id)
-					})
-				: Object.hasOwn(user.permissions, `change_${model.name}`)
-			: false) &&
+		!disableEdit &&
+			(model
+				? page.params.id
+					? canPerformAction({
+							user,
+							action: 'change',
+							model: model.name,
+							domain:
+								model.name === 'folder'
+									? contextMenuOpenRow?.meta.id
+									: (contextMenuOpenRow?.meta.folder?.id ??
+										contextMenuOpenRow?.meta.folder ??
+										user.root_folder_id)
+						})
+					: Object.hasOwn(user.permissions, `change_${model.name}`)
+				: false) &&
 			(!(contextMenuOpenRow?.meta.builtin || contextMenuOpenRow?.meta.urn) ||
 				URLModel === 'terminologies' ||
 				URLModel === 'entities')
@@ -508,7 +511,8 @@
 	);
 
 	let contextMenuCanDeleteObject = $derived(
-		!preventDelete(contextMenuOpenRow ?? { head: [], body: [], meta: [] }) &&
+		!disableDelete &&
+			!preventDelete(contextMenuOpenRow ?? { head: [], body: [], meta: [] }) &&
 			(model
 				? page.params.id
 					? canPerformAction({
@@ -1158,29 +1162,33 @@
 						<ContextMenu.Separator class="-mx-1 my-1 block h-px bg-surface-100" />
 					{/if}
 					{#if !(contextMenuOpenRow?.meta.builtin || contextMenuOpenRow?.meta.urn) || URLModel === 'terminologies' || URLModel === 'entities'}
-						<ContextMenu.Item
-							class="flex h-10 w-full select-none items-center rounded-xs py-3 pl-3 pr-1.5 text-sm font-medium cursor-pointer data-highlighted:bg-surface-50"
-							onclick={() => {
-								goto(
-									`/${actionsURLModel}/${contextMenuOpenRow?.meta[identifierField]}/edit?next=${encodeURIComponent(page.url.pathname + page.url.search)}`,
-									{
+						{#if contextMenuDisplayEdit}
+							<ContextMenu.Item
+								class="flex h-10 w-full select-none items-center rounded-xs py-3 pl-3 pr-1.5 text-sm font-medium cursor-pointer data-highlighted:bg-surface-50"
+								onclick={() => {
+									goto(
+										`/${actionsURLModel}/${contextMenuOpenRow?.meta[identifierField]}/edit?next=${encodeURIComponent(page.url.pathname + page.url.search)}`,
+										{
+											breadcrumbAction: 'push'
+										}
+									);
+								}}
+							>
+								{m.edit()}
+							</ContextMenu.Item>
+						{/if}
+						{#if !disableView}
+							<ContextMenu.Item
+								class="flex h-10 w-full select-none items-center rounded-xs py-3 pl-3 pr-1.5 text-sm font-medium cursor-pointer data-highlighted:bg-surface-50"
+								onclick={() => {
+									goto(`/${actionsURLModel}/${contextMenuOpenRow?.meta[identifierField]}/`, {
 										breadcrumbAction: 'push'
-									}
-								);
-							}}
-						>
-							{m.edit()}
-						</ContextMenu.Item>
-						<ContextMenu.Item
-							class="flex h-10 w-full select-none items-center rounded-xs py-3 pl-3 pr-1.5 text-sm font-medium cursor-pointer data-highlighted:bg-surface-50"
-							onclick={() => {
-								goto(`/${actionsURLModel}/${contextMenuOpenRow?.meta[identifierField]}/`, {
-									breadcrumbAction: 'push'
-								});
-							}}
-						>
-							{m.view()}
-						</ContextMenu.Item>
+									});
+								}}
+							>
+								{m.view()}
+							</ContextMenu.Item>
+						{/if}
 					{/if}
 					{#if contextMenuDisplayDelete}
 						<ContextMenu.Separator class="-mx-1 my-1 block h-px bg-surface-100" />

--- a/frontend/src/lib/utils/crud.ts
+++ b/frontend/src/lib/utils/crud.ts
@@ -102,6 +102,7 @@ export interface ForeignKeyField {
 	endpointUrl?: string;
 	urlParams?: string;
 	tableFields?: string[];
+	tableHeadings?: string[];
 }
 
 export interface ReverseForeignKeyField extends ForeignKeyField {
@@ -110,6 +111,7 @@ export interface ReverseForeignKeyField extends ForeignKeyField {
 	disableCreate?: boolean;
 	disableDelete?: boolean;
 	disableEdit?: boolean;
+	tabLabel?: string;
 	folderPermsNeeded?: { action: 'add' | 'view' | 'change' | 'delete'; model: string }[]; // Permissions needed on the folder to display this reverse foreign key field
 	defaultFilters?: { [key: string]: any[] }; // Default filters to initialize the table with (user can change/remove them)
 	expectedCountField?: string; // Field on parent payload that holds related items (for masked count)
@@ -128,6 +130,18 @@ export interface ReverseForeignKeyField extends ForeignKeyField {
 		label?: string; // i18n key for button title (defaults to 'batchCreate')
 	};
 }
+
+export const getReverseForeignKeyFieldKey = (
+	field: Pick<ReverseForeignKeyField, 'urlModel' | 'field' | 'endpointUrl'>,
+	fields: Pick<ReverseForeignKeyField, 'urlModel' | 'field' | 'endpointUrl'>[] = []
+) => {
+	const hasDuplicateTargetModel =
+		fields.filter((item) => item.urlModel === field.urlModel).length > 1;
+
+	return hasDuplicateTargetModel
+		? `${field.urlModel}:${field.field}:${field.endpointUrl ?? ''}`
+		: field.urlModel;
+};
 
 interface Field {
 	keyNameOverride?: string;
@@ -534,6 +548,34 @@ export const URL_MODEL_MAP: ModelMap = {
 			{
 				field: 'applied_controls',
 				urlModel: 'requirement-assessments',
+				disableCreate: true,
+				disableDelete: true
+			},
+			{
+				field: 'requirement_assessments',
+				urlModel: 'applied-controls',
+				endpointUrl: './control-catalogue/',
+				tabLabel: 'controlCatalogue',
+				tableFields: [
+					'ref_id',
+					'name',
+					'category',
+					'csf_function',
+					'status',
+					'owner',
+					'eta',
+					'folder'
+				],
+				tableHeadings: [
+					'ID',
+					'name',
+					'category',
+					'csfFunction',
+					'status',
+					'owner',
+					'eta',
+					'domain'
+				],
 				disableCreate: true,
 				disableDelete: true
 			},

--- a/frontend/src/lib/utils/load.ts
+++ b/frontend/src/lib/utils/load.ts
@@ -1,10 +1,12 @@
 import { BASE_API_URL, UUID_REGEX } from '$lib/utils/constants';
 import {
 	getModelInfo,
+	getReverseForeignKeyFieldKey,
 	urlParamModelVerboseName,
 	type ModelMapEntry,
 	type SelectField,
-	type SelectFieldData
+	type SelectFieldData,
+	type ReverseForeignKeyField
 } from '$lib/utils/crud';
 import { type TableSource } from '@skeletonlabs/skeleton-svelte';
 
@@ -128,7 +130,9 @@ export const loadDetail = async ({ event, model, id }) => {
 	const data = await res.json();
 
 	type RelatedModel = {
+		relationKey: string;
 		urlModel: urlModel;
+		field: ReverseForeignKeyField;
 		info: ModelMapEntry;
 		table: TableSource;
 		deleteForm: SuperValidated<FormDataShape>;
@@ -138,9 +142,7 @@ export const loadDetail = async ({ event, model, id }) => {
 		count?: number;
 	};
 
-	type RelatedModels = {
-		[K in urlModel]: RelatedModel;
-	};
+	type RelatedModels = Record<string, RelatedModel>;
 
 	const form = await superValidate(zod(z.object({ id: z.string().uuid() })));
 
@@ -164,7 +166,10 @@ export const loadDetail = async ({ event, model, id }) => {
 						})
 				)
 				.map(async (e) => {
-					const tableFieldsRef = listViewFields[e.urlModel];
+					const relationKey = getReverseForeignKeyFieldKey(e, model.reverseForeignKeyFields ?? []);
+					const tableFieldsRef = e.tableFields
+						? { head: e.tableHeadings ?? e.tableFields, body: e.tableFields }
+						: listViewFields[e.urlModel];
 					const tableFields = {
 						head: [...tableFieldsRef.head],
 						body: [...tableFieldsRef.body]
@@ -259,8 +264,10 @@ export const loadDetail = async ({ event, model, id }) => {
 							})
 						);
 					}
-					relatedModels[e.urlModel] = {
+					relatedModels[relationKey] = {
+						relationKey,
 						urlModel,
+						field: e,
 						info,
 						table,
 						deleteForm,
@@ -278,8 +285,12 @@ export const loadDetail = async ({ event, model, id }) => {
 	if (model.reverseForeignKeyFields) {
 		await Promise.all(
 			model.reverseForeignKeyFields
-				.filter((e) => relatedModels[e.urlModel])
+				.filter((e) => {
+					const relationKey = getReverseForeignKeyFieldKey(e, model.reverseForeignKeyFields ?? []);
+					return relatedModels[relationKey];
+				})
 				.map(async (e) => {
+					const relationKey = getReverseForeignKeyFieldKey(e, model.reverseForeignKeyFields ?? []);
 					try {
 						let countUrl: string;
 						if (e.endpointUrl?.startsWith('./')) {
@@ -294,7 +305,7 @@ export const loadDetail = async ({ event, model, id }) => {
 						if (countRes.ok) {
 							const countData = await countRes.json();
 							if (typeof countData.count === 'number') {
-								relatedModels[e.urlModel].count = countData.count;
+								relatedModels[relationKey].count = countData.count;
 							}
 						}
 					} catch {

--- a/frontend/src/routes/(app)/(internal)/policies/[id=uuid]/control-catalogue/+server.ts
+++ b/frontend/src/routes/(app)/(internal)/policies/[id=uuid]/control-catalogue/+server.ts
@@ -1,0 +1,20 @@
+import { BASE_API_URL } from '$lib/utils/constants';
+import { error, json, type NumericRange } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+async function fetchJson(fetch: typeof globalThis.fetch, endpoint: URL) {
+	const res = await fetch(endpoint);
+	if (!res.ok) {
+		error(res.status as NumericRange<400, 599>, await res.json());
+	}
+	return res.json();
+}
+
+export const GET: RequestHandler = async ({ fetch, params, url }) => {
+	const catalogueUrl = new URL(`${BASE_API_URL}/policies/${params.id}/control-catalogue/`);
+	for (const [key, value] of url.searchParams.entries()) {
+		catalogueUrl.searchParams.append(key, value);
+	}
+
+	return json(await fetchJson(fetch, catalogueUrl));
+};


### PR DESCRIPTION

## What & why

This PR adds a policy-level **Control catalogue** tab that lists Applied Controls linked through the policy's requirement assessments.

The business problem is policy review and governance traceability. When a policy is backed by assessed requirements, reviewers often need to answer: **which implemented controls support this policy?** Today that answer is not visible from the policy detail page, even though the relationship already exists in the data model.

Without this change, users have to leave the policy, inspect its requirement assessments, then manually pivot to Applied Controls or recreate equivalent filters in the action plan. That workflow is slow, easy to get wrong, and awkward during management review, audit preparation, or evidence collection because the reviewer loses policy context while chasing related controls.

This PR exposes the existing relationship directly from the policy page. It does not create duplicate controls or introduce a new control-writing workflow; it provides a derived view over Applied Controls that are already linked through the policy's requirement assessments.

Related to #2946. This does not fully close #2946 because it does not add a generic "source" column/filter to the global Applied Controls list; it improves source/context visibility for controls when reviewing a policy.

## Implementation notes

- Adds `GET /api/policies/{id}/control-catalogue/`.
- Returns Applied Controls linked through the policy's requirement assessments, deduplicated across multiple requirement links.
- Excludes the current policy and all `category="policy"` rows from the derived catalogue.
- Reuses Applied Control list annotations/prefetches so fields such as `linked_models`, owners, folder, assets, and labels serialize consistently with the main Applied Controls list.
- Reuses existing Applied Control filtering, search, ordering, pagination, and object-level access checks for catalogue rows.
- Adds a derived `Control catalogue` tab on policy detail pages.
- Uses stable reverse-related tab keys so multiple tabs can target the same model without overwriting each other.
- Keeps create/delete disabled for the derived catalogue view; edit/view continue through existing Applied Control pages and permissions.
- Fixes the table context menu so disabled view/edit/delete flags are respected there too.
- Adds a read-only MCP tool, `get_policy_control_catalogue(policy)`, with `search`, `ordering`, and bounded `limit` passthrough.
- Updates the CLI README MCP tool list. No separate product docs are needed for this small discoverable policy-detail tab; the MCP tool is self-described and registered through the server.

## How tested

- [x] `python3 -m py_compile backend/core/views.py cli/ca_mcp/server.py cli/ca_mcp/resolvers.py cli/ca_mcp/tools/read_tools.py`
- [x] `docker exec ciso-backend-local sh -lc 'cd /src && /code/.venv/bin/python -m pytest app_tests/api/test_api_policies.py -k control_catalogue'`
  - Result: `2 passed, 102 deselected`
- [x] `cd cli && uv run --with pytest --with pytest-asyncio pytest tests/test_mcp.py -k "policy_control_catalogue or resolve_policy_id"`
  - Result: `5 passed, 11 deselected`
- [x] `pnpm --dir frontend check`
  - Result: `svelte-check found 0 errors and 0 warnings`
- [x] `pnpm --dir frontend exec prettier --check src/lib/utils/crud.ts src/lib/utils/load.ts src/lib/components/DetailView/DetailView.svelte 'src/routes/(app)/(internal)/policies/[id=uuid]/control-catalogue/+server.ts'`
  - Result: `All matched files use Prettier code style`
- [x] `git diff --check`
- [x] Browser QA against a local development instance
  - Result: policy detail page shows the `Control catalogue` tab selected, generic Applied Control columns visible, and no create/delete controls in the derived tab.

<img width="1269" height="720" alt="image" src="https://github.com/user-attachments/assets/7e6c46bb-2794-4e1a-9043-47ec23fcf8d0" />


## Checklist

- [x] PR title follows Conventional Commits: `feat(policies): add control catalogue tab`
- [x] One focused public contribution, branched off `main`
- [x] No migrations needed
- [x] No new dependencies
- [x] Backend API regression tests added
- [x] MCP resolver/tool regression tests added
- [x] Frontend type check passes
- [x] Targeted frontend formatting check passes
- [x] CLA accepted, if this is the contributor's first upstream contribution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Control Catalogue view showing applied controls derived from a policy’s requirement assessments — accessible in the policy detail view, via a new API endpoint, and as a CLI tool (with search, ordering, and pagination).

* **Improvements**
  * Detail view related-model tabs and tables support custom headings and labels for clearer displays.
  * Table actions now respect edit/delete/view disable flags.

* **Documentation**
  * CLI README updated with the new control catalogue tool.

* **Localization**
  * Added "Control catalogue" English UI label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->