### PR TITLE
fix: framework builder nodes unusably narrow at deep nesting levels

### DIFF
--- a/frontend/src/lib/components/FrameworkBuilder/FrameworkBuilder.svelte
+++ b/frontend/src/lib/components/FrameworkBuilder/FrameworkBuilder.svelte
@@ -313,7 +313,7 @@
 		<BuilderToC />
 
 		<div class="flex-1 min-w-0">
-			<div class="{$activeLanguageStore ? 'max-w-5xl' : 'max-w-3xl'} mx-auto px-6 py-8 space-y-8">
+			<div class="max-w-5xl mx-auto px-6 py-8 space-y-8">
 				<!-- Framework metadata -->
 				<div class="space-y-2" data-framework-metadata>
 					{#if $activeLanguageStore}

--- a/frontend/src/lib/components/FrameworkBuilder/NodeBlock.svelte
+++ b/frontend/src/lib/components/FrameworkBuilder/NodeBlock.svelte
@@ -262,7 +262,7 @@
 </script>
 
 <div
-	style="margin-left: {Math.min(node.depth, 3) * 16}px"
+	style="margin-left: {node.depth > 0 && node.depth <= 3 ? 16 : 0}px"
 	class="scroll-mt-32 outline-none"
 	data-section-id={node.node.id}
 	data-builder-node

--- a/frontend/src/lib/components/FrameworkBuilder/NodeBlock.svelte
+++ b/frontend/src/lib/components/FrameworkBuilder/NodeBlock.svelte
@@ -262,7 +262,7 @@
 </script>
 
 <div
-	style="margin-left: {node.depth > 0 && node.depth <= 3 ? 16 : 0}px"
+	style="margin-left: {node.depth > 0 && node.depth <= 6 ? 16 : 0}px"
 	class="scroll-mt-32 outline-none"
 	data-section-id={node.node.id}
 	data-builder-node


### PR DESCRIPTION
## What & why

Builder node cards shrank by ~48px per nesting level: the per-node `margin-left` formula assumed a flat list, but cards nest in the DOM, so margins compounded. Deep nodes ended up a few characters wide. The canvas was also capped at `max-w-3xl`, leaving most of the screen unused.

- Indent is now a constant 16px per level, applied up to depth 6 (96px total); deeper nodes stay aligned, depth remains visible via the colored left border and the "nested under" breadcrumb
- Canvas widened to `max-w-5xl`, matching translation mode

## Test plan

Open a draft framework with 10+ nesting levels: deep nodes keep full-width cards instead of collapsing to a few characters.

## Checklist

- [x] PR title follows Conventional Commits (`!` set if this is a breaking change)
- [x] One focused change, branched off `main`

### Frontend — if you touched `frontend/`
- [x] Svelte 5 syntax; `pnpm run lint` and `pnpm run format` run
- [x] Clicked through the change in the dev server; screenshots attached for UI changes

- Before
<img width="1699" height="1057" alt="image" src="https://github.com/user-attachments/assets/b35e0760-625b-42d9-b347-8d24bdf63be8" />
- After
<img width="1448" height="1056" alt="image" src="https://github.com/user-attachments/assets/014a7dae-f32a-4007-bc09-359656c85005" />

### Tests & documentation — definition of done
- [x] No tests or docs needed for this change — why: CSS-only layout fix
