### PR TITLE
fix: respondent field visibility for third-party users in audits

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -6875,6 +6875,17 @@ class ComplianceAssessment(Assessment):
     # per-role pairs ({role: 'edit'|'read'|'hidden'}); the legacy booleans read
     # the auditor axis (the field exists at all if auditor isn't 'hidden').
 
+    @property
+    def effective_field_visibility(self):
+        """Fully-resolved per-role visibility map served to clients.
+
+        Single source of truth: callers read this instead of reconstructing the
+        DEFAULT_VISIBILITY cascade themselves.
+        """
+        from core.utils import build_effective_field_visibility
+
+        return build_effective_field_visibility(self)
+
     def _auditor_visible(self, field):
         from core.utils import resolve_field_visibility
 

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -2740,11 +2740,12 @@ class ComplianceAssessmentWriteSerializer(BaseModelSerializer):
 
         # Always merge the caller's partial field_visibility with code defaults
         # + framework template so the new CA is stored as a complete snapshot.
-        from core.utils import build_initial_field_visibility
+        # Merge per role so a partial pair doesn't erase a default/framework role.
+        from core.utils import build_initial_field_visibility, merge_field_visibility
 
         defaults = build_initial_field_visibility(validated_data.get("framework"))
         provided = validated_data.get("field_visibility") or {}
-        validated_data["field_visibility"] = {**defaults, **provided}
+        validated_data["field_visibility"] = merge_field_visibility(defaults, provided)
 
         assessment = super().create(validated_data)
 
@@ -2787,11 +2788,16 @@ class ComplianceAssessmentWriteSerializer(BaseModelSerializer):
 
         # PATCH semantics for field_visibility: merge incoming partial map onto
         # the existing one so a request that only sets a few keys doesn't wipe
-        # the rest of the snapshot.
+        # the rest of the snapshot. Merge per role too, so a partial pair updates
+        # only the given roles instead of dropping the others.
         if "field_visibility" in validated_data:
+            from core.utils import merge_field_visibility
+
             existing = instance.field_visibility or {}
             provided = validated_data["field_visibility"] or {}
-            validated_data["field_visibility"] = {**existing, **provided}
+            validated_data["field_visibility"] = merge_field_visibility(
+                existing, provided
+            )
 
         old_scoring_enabled = instance.scoring_enabled
 

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -2084,7 +2084,7 @@ class FrameworkReadSerializer(ReferentialSerializer):
     has_compliance_assessments = serializers.SerializerMethodField()
     scores_definition = serializers.SerializerMethodField()
     # The complete per-role visibility map a new CA created from this framework
-    # would inherit: DEFAULT_VISIBILITY ⊕ framework.field_visibility. The
+    # would inherit: DEFAULT_VISIBILITY + framework.field_visibility. The
     # CA-creation form's editor reads this so its pills always reflect what
     # the backend will actually save.
     effective_field_visibility = serializers.SerializerMethodField()
@@ -2591,6 +2591,10 @@ class ComplianceAssessmentReadSerializer(AssessmentReadSerializer):
             return sd["scale"]
         return sd
 
+    # Fully-resolved visibility map (DEFAULT_VISIBILITY + stored overrides).
+    # Clients read this instead of reconstructing the cascade locally.
+    effective_field_visibility = serializers.JSONField(read_only=True)
+
     # Derived booleans, kept in the API for backwards compatibility. The actual
     # storage is `field_visibility`; clients that want to change these should
     # PATCH `field_visibility` directly.
@@ -2952,6 +2956,7 @@ class RequirementAssessmentReadSerializer(BaseModelSerializer):
             "progress_status_enabled",
             "extended_result_enabled",
             "field_visibility",
+            "effective_field_visibility",
             {"framework": ["implementation_groups_definition", "field_visibility"]},
         ]
     )
@@ -2996,10 +3001,21 @@ class RequirementAssessmentReadSerializer(BaseModelSerializer):
     def to_representation(self, instance):
         data = super().to_representation(instance)
 
-        viewer_role = self.context.get("viewer_role", "auditor")
         ca = getattr(instance, "compliance_assessment", None)
         if ca is None:
             return data
+
+        # Endpoints that scope to a single CA pass an explicit viewer_role.
+        # Generic list/detail routes instead pass the caller's respondent folder
+        # set, so the role is derived per-instance from the RA's CA folder.
+        viewer_role = self.context.get("viewer_role")
+        if viewer_role is None:
+            respondent_folders = self.context.get("respondent_folders")
+            viewer_role = (
+                "respondent"
+                if respondent_folders and ca.folder_id in respondent_folders
+                else "auditor"
+            )
 
         # Strip fields the viewer is not allowed to read. Resolve through the
         # cascade (CA overrides → DEFAULT_VISIBILITY → EVERYONE_EDIT) so that

--- a/backend/core/utils.py
+++ b/backend/core/utils.py
@@ -1485,3 +1485,19 @@ def build_initial_field_visibility(framework):
         merged.setdefault(key, dict(EVERYONE_EDIT))
         merged[key].update(pair)
     return merged
+
+
+def build_effective_field_visibility(compliance_assessment):
+    """Return a CA's fully-resolved per-role visibility map.
+
+    The result spans every field that has a non-edit default (the
+    DEFAULT_VISIBILITY keys) plus any field explicitly overridden on the CA,
+    each resolved through the cascade (override → DEFAULT_VISIBILITY). Fields
+    absent from the result legitimately resolve to all-roles-edit, so a client
+    can treat a missing key as everyone-edit without shipping its own copy of
+    DEFAULT_VISIBILITY. This is the single source of truth handed to the
+    frontend.
+    """
+    overrides = getattr(compliance_assessment, "field_visibility", None) or {}
+    keys = set(DEFAULT_VISIBILITY) | set(overrides)
+    return {key: resolve_visibility_from_overrides(overrides, key) for key in keys}

--- a/backend/core/utils.py
+++ b/backend/core/utils.py
@@ -1487,6 +1487,28 @@ def build_initial_field_visibility(framework):
     return merged
 
 
+def merge_field_visibility(base, overrides):
+    """Deep-merge a partial `field_visibility` map onto a base, per field and
+    per role.
+
+    A shallow ``{**base, **overrides}`` would let a partial pair like
+    {"status": {"auditor": "read"}} replace the whole stored pair and drop the
+    other role's value, which the resolver would then only backfill from the
+    *code* default (not the previous/framework value). Merging per role keeps
+    roles the caller didn't touch.
+    """
+    merged = {
+        key: (dict(pair) if isinstance(pair, dict) else pair)
+        for key, pair in (base or {}).items()
+    }
+    for key, pair in (overrides or {}).items():
+        if isinstance(pair, dict) and isinstance(merged.get(key), dict):
+            merged[key].update(pair)
+        else:
+            merged[key] = dict(pair) if isinstance(pair, dict) else pair
+    return merged
+
+
 def build_effective_field_visibility(compliance_assessment):
     """Return a CA's fully-resolved per-role visibility map.
 

--- a/backend/core/utils.py
+++ b/backend/core/utils.py
@@ -1424,26 +1424,26 @@ DEFAULT_VISIBILITY = {
 
 
 def resolve_visibility_from_overrides(overrides, field_name):
-    """Resolve a field's visibility pair from a raw `field_visibility` dict.
+    """Resolve a field's complete per-role visibility pair from a raw
+    `field_visibility` dict.
 
     Shape: {role: 'edit'|'read'|'hidden'}.
 
-    Lookup order:
-      1. Explicit override in `overrides`.
-      2. DEFAULT_VISIBILITY (backstop in case a new field was added in code
-         without a migration to backfill existing CAs).
-      3. EVERYONE_EDIT (truly unknown field).
+    The override is merged on top of a base pair, per role, so the result always
+    carries every known role. The base is DEFAULT_VISIBILITY for the field (or
+    EVERYONE_EDIT for fields with no default), and the override wins per role.
+    This means a partial stored override like {"status": {"auditor": "edit"}}
+    still resolves `respondent` from the default (hidden) rather than silently
+    falling back to edit, which would reopen a respondent leak.
 
     Use this when you have a raw dict (e.g. from a queryset `.values()` call).
     For a model instance, prefer `resolve_field_visibility(ca, field)`.
     """
+    base = dict(DEFAULT_VISIBILITY.get(field_name) or EVERYONE_EDIT)
     pair = (overrides or {}).get(field_name)
     if isinstance(pair, dict):
-        return pair
-    fallback = DEFAULT_VISIBILITY.get(field_name)
-    if isinstance(fallback, dict):
-        return dict(fallback)
-    return dict(EVERYONE_EDIT)
+        base.update(pair)
+    return base
 
 
 def resolve_field_visibility(compliance_assessment, field_name):

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -161,6 +161,7 @@ from core.utils import (
     build_answers_dict,
     compare_schema_versions,
     get_auditee_filtered_folder_ids,
+    get_respondent_filtered_folder_ids,
     is_field_visible_to,
     rewrite_child_urns,
     _generate_occurrences,
@@ -8659,13 +8660,14 @@ class FrameworkViewSet(BaseModelViewSet):
 
         cas = [ca for ca in all_visible_cas if ca.status in LIVE_STATUSES]
 
-        # Per-CA viewer role: respondent if the user is an auditee on the CA's
-        # folder, auditor otherwise. Computed once per CA.
-        auditee_folders = get_auditee_filtered_folder_ids(request.user)
+        # Per-CA viewer role: respondent if the user is a respondent (auditee or
+        # third-party respondent) on the CA's folder, auditor otherwise. Computed
+        # once per CA.
+        respondent_folders = get_respondent_filtered_folder_ids(request.user)
         ca_viewer_roles = {
             ca.id: (
                 "respondent"
-                if (auditee_folders and ca.folder_id in auditee_folders)
+                if (respondent_folders and ca.folder_id in respondent_folders)
                 else "auditor"
             )
             for ca in cas
@@ -13975,12 +13977,12 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
                 parent = nodes_by_urn.get(req.parent_urn)
                 if parent:
                     req._parent_requirement_obj = parent
-        # Determine viewer role based on auditee status
-        auditee_folders = get_auditee_filtered_folder_ids(request.user)
-        is_auditee = bool(
-            auditee_folders and compliance_assessment.folder_id in auditee_folders
+        # Determine viewer role based on respondent status (auditee or third-party)
+        respondent_folders = get_respondent_filtered_folder_ids(request.user)
+        is_respondent = bool(
+            respondent_folders and compliance_assessment.folder_id in respondent_folders
         )
-        viewer_role = "respondent" if is_auditee else "auditor"
+        viewer_role = "respondent" if is_respondent else "auditor"
 
         requirement_assessments = RequirementAssessmentReadSerializer(
             requirement_assessments_objects,
@@ -15349,6 +15351,17 @@ class RequirementAssessmentViewSet(BaseModelViewSet):
                 | Q(assignments__actor__in=user_actors)
             ).distinct()
         return qs
+
+    def get_serializer_context(self):
+        # Mirror the per-CA viewer_role logic of the requirements_list endpoints
+        # so a single RA read also strips fields hidden from respondents (auditee
+        # or third-party). Without this the serializer defaults to "auditor" and
+        # leaks fields like score/status to respondents hitting the detail route.
+        context = super().get_serializer_context()
+        respondent_folders = get_respondent_filtered_folder_ids(self.request.user)
+        if respondent_folders:
+            context.setdefault("respondent_folders", respondent_folders)
+        return context
 
     def update(self, request, *args, **kwargs):
         return super().update(request, *args, **kwargs)
@@ -18744,12 +18757,21 @@ class RequirementAssignmentViewSet(BaseModelViewSet):
         assignment = self.get_object()
         compliance_assessment = assignment.compliance_assessment
 
-        # Determine viewer role: respondent if user is an assigned actor, auditor otherwise
+        # Determine viewer role: respondent if the user is an assigned actor OR
+        # a respondent (auditee / third-party respondent) on the CA's folder,
+        # auditor otherwise. The folder check mirrors the other requirements_list
+        # endpoints so a third-party respondent who isn't the literal assigned
+        # actor still gets respondent-scoped field visibility.
         user_actors = Actor.get_all_for_user(request.user)
         is_assigned_actor = assignment.actor.filter(
             id__in=[a.id for a in user_actors]
         ).exists()
-        viewer_role = "respondent" if is_assigned_actor else "auditor"
+        respondent_folders = get_respondent_filtered_folder_ids(request.user)
+        is_respondent = is_assigned_actor or (
+            bool(respondent_folders)
+            and compliance_assessment.folder_id in respondent_folders
+        )
+        viewer_role = "respondent" if is_respondent else "auditor"
 
         assigned_ra_ids = set(
             assignment.requirement_assessments.values_list("id", flat=True)

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -13926,9 +13926,12 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
                 include_non_assessable=not assessable
             )
         )
-        # Auditee filtering: scope to assigned requirements only
-        auditee_folders = get_auditee_filtered_folder_ids(request.user)
-        if auditee_folders and compliance_assessment.folder_id in auditee_folders:
+        # Respondent filtering: scope to assigned requirements only (auditee or third-party)
+        respondent_folders = get_respondent_filtered_folder_ids(request.user)
+        is_respondent = bool(
+            respondent_folders and compliance_assessment.folder_id in respondent_folders
+        )
+        if is_respondent:
             user_actors = Actor.get_all_for_user(request.user)
             ra_ids = set(
                 RequirementAssignment.objects.filter(
@@ -13978,10 +13981,6 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
                 if parent:
                     req._parent_requirement_obj = parent
         # Determine viewer role based on respondent status (auditee or third-party)
-        respondent_folders = get_respondent_filtered_folder_ids(request.user)
-        is_respondent = bool(
-            respondent_folders and compliance_assessment.folder_id in respondent_folders
-        )
         viewer_role = "respondent" if is_respondent else "auditor"
 
         requirement_assessments = RequirementAssessmentReadSerializer(
@@ -15343,11 +15342,11 @@ class RequirementAssessmentViewSet(BaseModelViewSet):
                 "requirement__questions__choices",  # Needed by get_questions_translated
             )
         )
-        auditee_folders = get_auditee_filtered_folder_ids(self.request.user)
-        if auditee_folders:
+        respondent_folders = get_respondent_filtered_folder_ids(self.request.user)
+        if respondent_folders:
             user_actors = Actor.get_all_for_user(self.request.user)
             qs = qs.filter(
-                ~Q(folder_id__in=auditee_folders)
+                ~Q(folder_id__in=respondent_folders)
                 | Q(assignments__actor__in=user_actors)
             ).distinct()
         return qs
@@ -18600,11 +18599,11 @@ class RequirementAssignmentViewSet(BaseModelViewSet):
                 ),
             )
         )
-        auditee_folders = get_auditee_filtered_folder_ids(self.request.user)
-        if auditee_folders:
+        respondent_folders = get_respondent_filtered_folder_ids(self.request.user)
+        if respondent_folders:
             user_actors = Actor.get_all_for_user(self.request.user)
             qs = qs.filter(
-                ~Q(folder_id__in=auditee_folders) | Q(actor__in=user_actors)
+                ~Q(folder_id__in=respondent_folders) | Q(actor__in=user_actors)
             ).distinct()
         return qs
 
@@ -18638,7 +18637,7 @@ class RequirementAssignmentViewSet(BaseModelViewSet):
         return super().destroy(request, *args, **kwargs)
 
     # Valid transitions: (from_status, to_status) → config
-    # reviewer_only: auditee-only users are forbidden
+    # reviewer_only: respondents (auditee or third-party) are forbidden
     # actor_only: only assigned actors can perform this transition
     # check_completion: all assessable requirements must be assessed
     # observation: "clear" removes it, "optional" keeps if provided, "required" must be provided
@@ -18691,15 +18690,15 @@ class RequirementAssignmentViewSet(BaseModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        # Reviewer-only check: auditee-only users are forbidden
+        # Reviewer-only check: respondents (auditee or third-party) are forbidden
         if config.get("reviewer_only"):
-            auditee_folders = get_auditee_filtered_folder_ids(request.user)
+            respondent_folders = get_respondent_filtered_folder_ids(request.user)
             if (
-                auditee_folders
-                and assignment.compliance_assessment.folder_id in auditee_folders
+                respondent_folders
+                and assignment.compliance_assessment.folder_id in respondent_folders
             ):
                 return Response(
-                    {"error": "Auditee users cannot perform this action."},
+                    {"error": "Respondent users cannot perform this action."},
                     status=status.HTTP_403_FORBIDDEN,
                 )
 

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -18750,8 +18750,8 @@ class RequirementAssignmentViewSet(BaseModelViewSet):
     def requirements_list(self, request, pk=None):
         """Returns the scoped requirements list for this assignment.
 
-        Authorization is enforced by get_queryset() which filters
-        auditee-only users to their own assignments.
+        Authorization is enforced by get_queryset() which filters respondents
+        (auditee or third-party) to their own assignments.
         """
         assignment = self.get_object()
         compliance_assessment = assignment.compliance_assessment

--- a/frontend/src/lib/components/ComplianceAssessment/VisibilityEditor.svelte
+++ b/frontend/src/lib/components/ComplianceAssessment/VisibilityEditor.svelte
@@ -11,7 +11,7 @@
 		onChange: (next: VisibilityMap) => void;
 		disabled?: boolean;
 		// Framework's effective_field_visibility — the complete map a new CA
-		// would inherit from this framework (DEFAULT_VISIBILITY ⊕ framework's
+		// would inherit from this framework (DEFAULT_VISIBILITY + framework's
 		// own overrides, computed on the backend). Used as fallback for missing
 		// keys in `value`, so pills on a fresh create form display what the
 		// API will actually save.

--- a/frontend/src/lib/utils/helpers.ts
+++ b/frontend/src/lib/utils/helpers.ts
@@ -395,12 +395,23 @@ export type VisibilityPair = { auditor: RoleAccess; respondent: RoleAccess };
 
 const EDIT_PAIR: VisibilityPair = { auditor: 'edit', respondent: 'edit' };
 
-/** Return the per-role visibility pair for a field. Missing → all roles edit. */
+/**
+ * Return the per-role visibility pair for a field.
+ *
+ * The backend is the single source of truth: it serves `effective_field_visibility`,
+ * the fully-resolved map (DEFAULT_VISIBILITY + stored overrides), so every field
+ * with a non-edit default is already present. This resolver therefore stays dumb
+ * — read the explicit pair, treat a missing field as all-roles-edit. The raw
+ * `field_visibility` is kept only as a fallback for objects that predate the
+ * resolved field.
+ */
 export function resolveFieldVisibility(
 	complianceAssessment: Record<string, any> | null | undefined,
 	fieldName: string
 ): VisibilityPair {
-	const raw = complianceAssessment?.field_visibility?.[fieldName];
+	const map =
+		complianceAssessment?.effective_field_visibility ?? complianceAssessment?.field_visibility;
+	const raw = map?.[fieldName];
 	if (!raw || typeof raw !== 'object') return { ...EDIT_PAIR };
 	return {
 		auditor: (raw.auditor as RoleAccess) ?? 'edit',


### PR DESCRIPTION
## What & why

Third-party respondents (TPRM) were treated like auditors in audits/questionnaires: they saw auditor-only fields and could reach rows that weren't theirs. It worked for auditees but not third-party respondents.

Two distinct gaps, both rooted in `viewer_role`/scoping being derived from the auditee-only `get_auditee_filtered_folder_ids`:

- **Field visibility.** The read serializer fell back to `auditor` for third-party respondents, and the frontend reconstructed the `DEFAULT_VISIBILITY` cascade itself, so default-hidden fields (`status`, `extended_result`, `score`) leaked after a refresh. Backend now serves a fully-resolved `effective_field_visibility` map as the single source of truth; the frontend reads it instead of re-deriving defaults.
- **Row scoping + transitions.** `requirements_list`, `RequirementAssessmentViewSet`/`RequirementAssignmentViewSet` querysets, and the `set_status` `reviewer_only` guard all scoped on auditees only. A third-party respondent could list every RA/assignment in the CA folder and perform reviewer-only status transitions. All four now use `get_respondent_filtered_folder_ids` (a superset that still excludes higher-privilege roles), so respondents are scoped to their own assignments and blocked from reviewer transitions, exactly like auditees. No change for auditees or higher roles.

Also hardened partial role pairs: `resolve_visibility_from_overrides` now merges a stored override onto the field's default per role, and CA create/update deep-merge `field_visibility` per role, so a partial pair (e.g. `{"status": {"auditor": "read"}}`) can no longer drop the other role and silently revert it to a code default.

The row-scoping gap predates this branch (introduced with respondent mode in #3783); the field-visibility work surfaced it.

## Test plan

- As a third-party respondent: open an audit via table-mode, the auditee-assessments page, and a single requirement-assessment edit, then refresh. Confirm `status`/`extended_result`/`score` stay hidden and only assigned requirements are listed.
- Confirm a third-party respondent gets 403 on a reviewer-only transition (e.g. `submitted → closed`), and can still submit their own assignment.
- As an auditor on the same audit: confirm all fields and all rows remain visible, and reviewer transitions still work.
- Direct API `GET` on an RA detail as a third-party respondent strips the hidden fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backend now exposes a single, pre-resolved per-role field visibility map for clients to consume.

* **Improvements**
  * Read endpoints include the resolved visibility so frontends no longer must reconstruct it.
  * Write/update behavior now merges partial visibility updates without losing other-role defaults.
  * Viewer-role determination and scoping tightened so respondent/auditor visibility is applied consistently.

* **Documentation**
  * Clarified explanatory text in the visibility editor and resolver comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->