### PR TITLE
fix: prevent fragments in openai api base

### DIFF
--- a/backend/global_settings/serializers.py
+++ b/backend/global_settings/serializers.py
@@ -146,6 +146,8 @@ class GeneralSettingsSerializer(serializers.ModelSerializer):
             if key not in GENERAL_SETTINGS_KEYS:
                 raise serializers.ValidationError(f"Invalid key: {key}")
             if key in ("ollama_base_url", "openai_api_base") and value:
+                if not isinstance(value, str):
+                    raise serializers.ValidationError({key: "URL must be a string."})
                 parsed = urlparse(value)
                 if parsed.scheme not in ("http", "https"):
                     raise serializers.ValidationError(

--- a/backend/global_settings/serializers.py
+++ b/backend/global_settings/serializers.py
@@ -5,6 +5,8 @@ from django.conf import settings as django_settings
 from django.core.exceptions import ValidationError as DjangoValidationError
 from rest_framework import serializers
 
+from urllib.parse import urlparse
+
 from .models import GlobalSettings
 
 
@@ -143,6 +145,16 @@ class GeneralSettingsSerializer(serializers.ModelSerializer):
         for key, value in validated_data["value"].items():
             if key not in GENERAL_SETTINGS_KEYS:
                 raise serializers.ValidationError(f"Invalid key: {key}")
+            if key in ("ollama_base_url", "openai_api_base") and value:
+                parsed = urlparse(value)
+                if parsed.scheme not in ("http", "https"):
+                    raise serializers.ValidationError(
+                        {key: "URL must use http or https scheme."}
+                    )
+                if "#" in value:
+                    raise serializers.ValidationError(
+                        {key: "URL must not contain a fragment (#)."}
+                    )
             # Validate builtin_metrics_retention_days minimum value
             if key == "builtin_metrics_retention_days":
                 if not isinstance(value, int) or value < 1:


### PR DESCRIPTION
## What & why

**defense-in-depth hardening**

LLM provider base URLs (`ollama_base_url`, `openai_api_base`) stored in
`GlobalSettings` were not validated before being persisted. Two issues:

1. **URL fragment bypass** — a URL like `http://attacker.internal/api/tags#`
   causes `httpx` to send a request to `http://attacker.internal/api/tags`
   because the fragment (`#...`) is never transmitted over the wire (RFC 3986
   §3.5). This silently drops any path suffix the code appends after the stored
   URL, potentially redirecting requests to unintended hosts.

2. **Unrestricted scheme** — no check prevented non-HTTP/HTTPS schemes from
   being stored.

Fixes by rejecting any URL that contains a `#` character or uses a scheme
other than `http`/`https` at the serializer level, before the value is
persisted.

Local and private IP addresses are intentionally **allowed** — Ollama and
LM Studio legitimately run on `localhost` or LAN addresses in standard
self-hosted deployments.

## Checklist

- [x] PR title follows Conventional Commits
- [x] One focused change, branched off `main`
- [x] CLA accepted (first contribution only)

### Backend — if you touched `backend/`

- [x] `ruff format` run, no new linter errors
- [x] Migrations generated with `makemigrations` and committed (or none needed)
- [x] New dependencies checked for known vulnerabilities and called out above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened URL validation for API base URL settings: values must be strings, require http/https schemes, and URLs containing fragments (#) are rejected. Validation errors are reported per setting to help users correct misconfigured API endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->