### PR TITLE
fix(docs): correct uv usage in enterprise backend README

### DIFF
--- a/enterprise/backend/README.md
+++ b/enterprise/backend/README.md
@@ -15,5 +15,5 @@ uv sync
 3. Start the development server with the enterprise settings file
 
 ```bash
-uv run manage.sh runserver
+uv run ./manage.sh runserver
 ```


### PR DESCRIPTION
Quick edit to add `./` to the `manage.sh` uv command, otherwise it fails to find the script