### PR TITLE
fix: restore applied controls columns in current/residual risk tables

### DIFF
--- a/frontend/src/routes/(app)/(internal)/risk-scenarios/[id=uuid]/+page.server.ts
+++ b/frontend/src/routes/(app)/(internal)/risk-scenarios/[id=uuid]/+page.server.ts
@@ -56,7 +56,7 @@ export const load = (async ({ fetch, params, cookies, locals }) => {
 	await Promise.all(
 		['risk_scenarios', 'risk_scenarios_e'].map(async (key) => {
 			const table: TableSource = {
-				head: ['name', 'owner', 'status', 'eta'],
+				head: headData('applied-controls'),
 				body: [],
 				meta: []
 			};


### PR DESCRIPTION
## What & why

Applied controls in the **Current risk** and **Residual risk** sections of a risk scenario page were displaying `-` for all fields (name, owner, status, eta) instead of actual values.

The `head` of the two applied-controls tables (`risk_scenarios` / `risk_scenarios_e`) was hardcoded as a plain string array `['name', 'owner', 'status', 'eta']` instead of using `headData('applied-controls')`. `ModelTable` needs an object mapping `{ fieldName: 'Label' }` to resolve cell values — without it, every lookup fails and falls back to `-`.

Regression introduced when table column customization was added; all other embedded tables in the codebase already used `headData()`.

## Test plan

1. Open a risk scenario that has applied controls linked (Current risk and Residual risk sections)
2. **Before**: all applied controls rows show `-` for every column
3. **After**: name, owner, status, eta display correctly

## Checklist

- [x] PR title follows Conventional Commits (`!` set if this is a breaking change)
- [x] One focused change, branched off `main`

### Frontend — if you touched `frontend/`

- [x] Svelte 5 syntax; `pnpm run lint` and `pnpm run format` run
- [x] No new/changed UI strings
- [x] Clicked through the change in the dev server; screenshots attached for UI changes

### Tests & documentation — definition of done

- [x] No tests or docs needed — one-line regression fix restoring existing behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the risk scenarios table column initialization to use dynamic header configuration, improving flexibility for future enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->