### PR TITLE
fix: missing permissions on /experimental/ecosystem page

### DIFF
--- a/backend/ebios_rm/views.py
+++ b/backend/ebios_rm/views.py
@@ -958,7 +958,7 @@ class StakeholderViewSet(BaseModelViewSet):
 
     @action(detail=False, name="Get chart data")
     def chart_data(self, request):
-        return Response(ecosystem_radar_chart_data(Stakeholder.objects.all()))
+        return Response(ecosystem_radar_chart_data(self.get_queryset()))
 
 
 class StrategicScenarioViewSet(BaseModelViewSet):


### PR DESCRIPTION
## What & why

`GET /api/ebios-rm/stakeholders/chart_data/` used `Stakeholder.objects.all()` with no IAM scoping, exposing aggregated ecosystem radar chart data (entity names, dependency, penetration, maturity, trust, criticality scores) from **all** tenants to any authenticated user.

## Checklist

- [x] PR title follows Conventional Commits
- [x] One focused change, branched off `main`
- [x] CLA accepted (first contribution only)

### Backend — if you touched `backend/`

- [x] `ruff format` run, no new linter errors
- [x] Migrations generated with `makemigrations` and committed (or none needed — no model changes)
- [x] New dependencies checked for known vulnerabilities and called out above — none added

### Tests & documentation — definition of done

- [x] Tests added or updated and passing locally — `uv run pytest`
- [x] No docs update needed — internal security hardening, no API contract change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the ecosystem radar chart to properly respect filters and permissions. The chart now displays only stakeholders relevant to your current view, improving data accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->