### PR TITLE
fix: idor in ecosystem chart data

### DIFF
--- a/backend/ebios_rm/views.py
+++ b/backend/ebios_rm/views.py
@@ -110,16 +110,20 @@ class EbiosRMStudyViewSet(BaseModelViewSet):
 
     @action(detail=True, name="Get ecosystem radar chart data")
     def ecosystem_chart_data(self, request, pk):
+        study = self.get_object()
         return Response(
-            ecosystem_radar_chart_data(Stakeholder.objects.filter(ebios_rm_study=pk))
+            ecosystem_radar_chart_data(Stakeholder.objects.filter(ebios_rm_study=study))
         )
 
     @action(detail=True, name="Get ecosystem circular chart data")
     def ecosystem_circular_chart_data(self, request, pk):
         from .helpers import ecosystem_circular_chart_data
 
+        study = self.get_object()
         return Response(
-            ecosystem_circular_chart_data(Stakeholder.objects.filter(ebios_rm_study=pk))
+            ecosystem_circular_chart_data(
+                Stakeholder.objects.filter(ebios_rm_study=study)
+            )
         )
 
     @action(detail=True, name="Get EBIOS RM  study visual analysis")


### PR DESCRIPTION
## What & why

Three endpoints in `EbiosRMStudyViewSet` and `StakeholderViewSet` returned
data without verifying the requesting user had access to the underlying study
or its stakeholders, exposing cross-tenant EBIOS RM data to any authenticated
user.

**`StakeholderViewSet.chart_data`** (`ebios_rm/views.py:960`)
Called `Stakeholder.objects.all()` with no IAM filter. Any authenticated user
(Reader or above in any folder) could call
`GET /api/ebios-rm/stakeholders/chart_data/` and receive aggregated ecosystem
radar data (entity names, dependency, penetration, maturity, trust, criticality)
for stakeholders belonging to all organisations in the database.
Fix: replaced with `self.get_queryset()` which applies the standard
`RoleAssignment`-based folder scope already used by every other list endpoint.

**`EbiosRMStudyViewSet.ecosystem_chart_data` and `ecosystem_circular_chart_data`**
(`ebios_rm/views.py:111–123`)
Both `detail=True` actions used the raw `pk` from the URL to filter
`Stakeholder.objects.filter(ebios_rm_study=pk)` without calling
`self.get_object()`. An authenticated user who knew or guessed the UUID of an
EBIOS RM study in a folder they cannot access could retrieve its full
stakeholder ecosystem chart data.
Fix: replaced raw `pk` usage with `study = self.get_object()`, which calls
`check_object_permissions()` and raises HTTP 404 if the study is outside the
user's accessible scope.

## Test plan

1. `GET /api/ebios-rm/stakeholders/chart_data/` as a Reader scoped to org A
   → returns only stakeholders from org A's accessible folders (was: all orgs)

2. `GET /api/ebios-rm/studies/<uuid-org-B>/ecosystem_chart_data/` as a user
   with no access to org B's folder → **404** (was: 200 with full chart data)

3. `GET /api/ebios-rm/studies/<uuid-org-B>/ecosystem_circular_chart_data/`
   same user → **404** (was: 200)

4. Both chart endpoints still return correct data when called with a study UUID
   the user has access to → **200** 

## Checklist

- [x] PR title follows Conventional Commits
- [x] One focused change, branched off `main`
- [x] CLA accepted (first contribution only)

### Backend — if you touched `backend/`

- [x] `ruff format` run, no new linter errors
- [x] Migrations generated with `makemigrations` and committed — none needed (no model changes)
- [x] New dependencies checked for known vulnerabilities — none added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ecosystem chart data endpoints to correctly filter and display stakeholder information across chart views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->