### PR TITLE
chores(doc): recover missing doc for framework reporting nuances

### DIFF
--- a/product-docs/configuration/settings/feature-flags.md
+++ b/product-docs/configuration/settings/feature-flags.md
@@ -34,6 +34,7 @@ Flags affect what's visible in the sidebar, what appears in CRUD pages, and whic
 - **compliance** — compliance assessments (audits). Effectively master switch for the entire compliance pillar.
 - **auditee_mode** — the read-only auditee surface for external assessors. _Default off._
 - **campaigns** — bulk-orchestration of audits across many perimeters. _PRO._
+- **audit_tree_inheritance** — combine an audit's results with parent-domain audits on the same framework. Reveals the **Domain inheritance strategy** [general setting](general.md#domain-tree-audit-inheritance) and the **Combined view** on the [Framework report](../../features/framework-report.md#combined-view-domain-tree-inheritance). _Default off._
 
 ## Resilience
 

--- a/product-docs/configuration/settings/general.md
+++ b/product-docs/configuration/settings/general.md
@@ -50,3 +50,9 @@ These settings drive the optional AI features (chat mode, agentic workflows, RAG
 ## Analytics
 
 - **Default custom analytics dashboard** — UUID of the dashboard shown by default on the analytics page.
+
+## Domain-tree audit inheritance
+
+Shown only when the **Domain-tree audit inheritance** feature flag is on (under the **Compliance assessments** group).
+
+- **Domain inheritance strategy** — when the same framework is audited at several levels of the domain tree, decides how a child audit combines results with its parent audits. Options: _No inheritance_ (default), _Parent always wins_, _Child always wins_, _Best case (optimistic)_, _Worst case (prudent)_. Scores from a different scale are normalised to the top parent's scale. This one org-wide setting drives the **Combined view** on the [Framework report](../../features/framework-report.md#combined-view-domain-tree-inheritance) and the inheritance panel in [Advanced Analytics](../../features/audit-analytics.md). Leaving it on _No inheritance_ keeps the feature dormant even with the flag enabled.

--- a/product-docs/features/framework-report.md
+++ b/product-docs/features/framework-report.md
@@ -4,7 +4,7 @@ description: Cross-audit aggregate for one framework — compliance %, average i
 
 # Framework report
 
-The **Framework report** is the answer to _"how is this framework doing across our organisation?"_ Pick any framework loaded into the platform, and the report rolls up every audit using it into a single view: compliance percentage, average implementation score, sections breakdown, and the full list of audits in scope.
+The **Framework report** is the answer to _"how is this framework doing across our organisation?"_ Pick any framework loaded into the platform, and the report rolls up every audit using it into a single view: compliance percentage, average implementation score, sections breakdown, and the full list of audits in scope. You can read it as a **Requirements tree** or pivot it **Per domain**, and — when domain-tree inheritance is enabled — fold parent-domain results into a single **Combined view**.
 
 It's the framework-level layer of the platform's advanced analytics — sandwiched between the [per-audit Advanced Analytics](audit-analytics.md) dashboard and the [estate-wide Insights](insights.md) menu.
 
@@ -32,7 +32,14 @@ It's the framework-level layer of the platform's advanced analytics — sandwich
 | **In-scope audits** | The count of audits the report rolled up |
 | **Detected audits drawer** | Per-audit list with status, folder path, and `counted vs excluded` marker — so you can see what the live-status filter left out |
 | **Per-section breakdown** | Requirement rows grouped by their immediate parent section |
-| **Implementation-group filter** | Narrow the report to a single IG via query param |
+| **Implementation-group filter** | Narrow the report to a single IG via the **Implementation group** dropdown |
+
+## Two ways to read it
+
+The **View** toggle in the filter bar switches the body of the report between two lenses on the same numbers:
+
+- **Requirements tree** — the default. Sections roll up their requirements; click a section to expand it, then click a requirement row to drill into its **Per-assessment breakdown** (one row per audit, with domain, result, score, controls and evidence counts, and a link straight to that requirement assessment). **Expand all** / **Collapse all** act on every section at once.
+- **Per domain** — pivots the same rows by the domain (Folder) they live in. **Group by domain depth** controls how far down the tree the grouping cuts (`root` … `leaf domain`), and **Sort by** orders the rows by domain name (alphabetical), compliance %, or average score, ascending or descending.
 
 ## What gets counted
 
@@ -43,6 +50,39 @@ Only **live** audits roll into the numbers. "Live" means the audit's status is o
 - `done`
 
 Audits in `planned` or `deprecated` status are visible in the drawer (so you can see them) but **excluded** from the aggregates. The `deprecated` filter exists for a specific reason — when you cut a new audit cycle on the same domain, you mark the previous one deprecated so it doesn't double-count its requirements alongside the new live audit. The page surfaces this rule inline: _"Only assessments with status {statuses} are counted — mark audits as {deprecated} to exclude them."_
+
+## Combined view: domain-tree inheritance
+
+When the same framework is audited at several levels of a domain hierarchy — say an org-wide audit on the root domain, a business-unit audit below it, and a system audit below that — a lower audit can **inherit** results and scores for requirements an ancestor audit already covers. This is useful when common controls are assessed once high up and you don't want every child audit to re-prove them.
+
+This only appears when your administrator has enabled **Domain-tree audit inheritance** and chosen a strategy other than _No inheritance_ — see [the inheritance setting](../configuration/settings/general.md#domain-tree-audit-inheritance). When it's active and at least one requirement on this framework actually inherits something, a **Combined view** control shows up in the filter bar with an **Apply domain inheritance** checkbox (on by default).
+
+Inheritance is **non-destructive**. Each audit's own stored results are never changed; the report computes an _effective_ result and score on top of them and remembers where each came from. Toggling **Apply domain inheritance** off returns every figure — KPIs, distributions, and the detail cells — to each audit's own values.
+
+### How a source is chosen
+
+For a requirement, the platform looks up the domain tree from the audit (nearest ancestor first, including the root domain). In each ancestor domain it considers only **live** audits on the same framework (`in_progress` / `in_review` / `done`) and picks the **most recently updated** one. The configured strategy then decides which value along that chain wins:
+
+| Strategy | Effective result |
+|---|---|
+| **No inheritance** | Inheritance off — each audit stands alone |
+| **Parent always wins** | The nearest ancestor that has a verdict overrides the child |
+| **Child always wins** | The child's own verdict stands; ancestors only fill gaps it left unassessed |
+| **Best case (optimistic)** | The strongest verdict anywhere in the chain (`compliant` > `partially compliant` > `non-compliant`) |
+| **Worst case (prudent)** | The weakest verdict anywhere in the chain |
+
+A requirement marked `not assessed` carries no opinion, so it never wins a comparison — it's the gap that ancestors fill. The score follows the same audit that won the result (a score is only meaningful paired with the verdict it was given for), and when audits use different scoring scales every score is normalised onto the **top-most ancestor's scale** before it's shown.
+
+{% hint style="info" %}
+The same `not assessed` and live-status rules power both this report and the per-audit [Advanced Analytics](audit-analytics.md) inheritance panel, so the two always agree.
+{% endhint %}
+
+### Reading an inherited row
+
+Drill into a requirement (Requirements tree → expand a section → click the row) and the **Per-assessment breakdown** marks each inherited row:
+
+- A **branch icon** next to the result links to the source audit it was inherited from; hovering it shows the full inheritance path (`domain · audit: result`, nearest first).
+- An **info icon** next to the score appears when the audit's own result differs from the effective one — hover it to see the original _own result_ and score before inheritance was applied.
 
 ## Permissions and visibility
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added feature flag documentation for domain-tree audit inheritance
  * New general settings section for configuring domain inheritance strategy across organizations
  * Enhanced framework report documentation explaining combined view calculations when domain-tree inheritance is enabled, including inheritance source selection, score normalization, and UI indicators

<!-- end of auto-generated comment: release notes by coderabbit.ai -->