### PR TITLE
fix: table-mode with hidden select fields

### DIFF
--- a/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/table-mode/+page.server.ts
+++ b/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/table-mode/+page.server.ts
@@ -187,7 +187,7 @@ export const actions: Actions = {
 			'observation',
 			'answers',
 			'evidences',
-			'applied_controls',
+			'applied_controls'
 		];
 		for (const key of visibilityControlled) {
 			if (!(key in currentRa)) {

--- a/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/table-mode/+page.server.ts
+++ b/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/table-mode/+page.server.ts
@@ -180,6 +180,7 @@ export const actions: Actions = {
 
 		const visibilityControlled = [
 			'result',
+			'extended_result',
 			'status',
 			'score',
 			'is_scored',

--- a/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/table-mode/+page.server.ts
+++ b/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/table-mode/+page.server.ts
@@ -156,6 +156,10 @@ export const actions: Actions = {
 		const URLModel = 'requirement-assessments';
 		const schema = modelSchema(URLModel);
 		const id = event.url.searchParams.get('id');
+		if (!id) {
+			console.error('Missing id parameter in update action');
+			return fail(400, { form: await superValidate(event.request, zod(schema)) });
+		}
 		const endpoint = `${BASE_API_URL}/${URLModel}/${id}/`;
 		const form = await superValidate(event.request, zod(schema));
 

--- a/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/table-mode/+page.server.ts
+++ b/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/table-mode/+page.server.ts
@@ -149,10 +149,13 @@ export const actions: Actions = {
 		return nestedWriteFormAction({ event, action: 'create' });
 	},
 	update: async (event) => {
-		// Custom update for requirement-assessments that strips fields hidden by
-		// field_visibility before PATCHing. The generic nestedWriteFormAction
-		// would send empty values for fields the viewer never saw, which the
-		// backend rejects (e.g. `status: ""` is not a valid enum choice).
+		// Custom update for requirement-assessments. When a select field is hidden
+		// by field_visibility the viewer never sets it, so zod defaults it to "",
+		// which DRF rejects (e.g. `status: ""` is not a valid enum choice). The
+		// requirements_list endpoint that feeds this form already strips fields the
+		// viewer can't see (with the correct viewer_role), and the backend re-strips
+		// non-editable fields for respondents, so all that's left here is to drop
+		// the empty enum defaults before PATCHing.
 		const URLModel = 'requirement-assessments';
 		const schema = modelSchema(URLModel);
 		const id = event.url.searchParams.get('id');
@@ -170,45 +173,6 @@ export const actions: Actions = {
 
 		const formData: Record<string, any> = { ...form.data };
 
-		let currentRa: Record<string, any>;
-		try {
-			const currentRaResponse = await event.fetch(endpoint);
-			if (!currentRaResponse.ok) {
-				return handleErrorResponse({ event, response: currentRaResponse, form });
-			}
-			currentRa = await currentRaResponse.json();
-		} catch (error) {
-			console.error('Failed to fetch requirement assessment before update', error);
-			return fail(502, { form });
-		}
-
-		const visibilityControlled = [
-			'result',
-			'extended_result',
-			'status',
-			'score',
-			'is_scored',
-			'documentation_score',
-			'observation',
-			'answers',
-			'evidences',
-			'applied_controls'
-		];
-		for (const key of visibilityControlled) {
-			if (!(key in currentRa)) {
-				delete formData[key];
-			}
-		}
-		// extended_result is a qualifier on result; strip it alongside a hidden result.
-		if (!('result' in currentRa)) {
-			delete formData.extended_result;
-		}
-
-		// The detail GET above does not honor viewer_role and returns the
-		// auditor view regardless of caller, so visibility-driven stripping
-		// alone misses fields the respondent never saw but that zod defaulted
-		// to "". Drop empty enum values to avoid DRF "is not a valid choice"
-		// errors on PATCH (e.g. status: "").
 		for (const key of ['status', 'result', 'extended_result', 'respondent_alignment']) {
 			if (formData[key] === '' || formData[key] === null) {
 				delete formData[key];

--- a/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/table-mode/+page.server.ts
+++ b/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/table-mode/+page.server.ts
@@ -1,9 +1,11 @@
-import { nestedWriteFormAction } from '$lib/utils/actions';
+import { handleErrorResponse, nestedWriteFormAction } from '$lib/utils/actions';
 import { BASE_API_URL } from '$lib/utils/constants';
 import { getModelInfo } from '$lib/utils/crud';
 import { modelSchema } from '$lib/utils/schemas';
 import { m } from '$paraglide/messages';
-import type { Actions } from '@sveltejs/kit';
+import { safeTranslate } from '$lib/utils/i18n';
+import { fail, type Actions } from '@sveltejs/kit';
+import { setFlash } from 'sveltekit-flash-message/server';
 import { superValidate } from 'sveltekit-superforms';
 import { zod4 as zod } from 'sveltekit-superforms/adapters';
 import { z } from 'zod';
@@ -147,6 +149,84 @@ export const actions: Actions = {
 		return nestedWriteFormAction({ event, action: 'create' });
 	},
 	update: async (event) => {
-		return nestedWriteFormAction({ event, action: 'edit' });
+		// Custom update for requirement-assessments that strips fields hidden by
+		// field_visibility before PATCHing. The generic nestedWriteFormAction
+		// would send empty values for fields the viewer never saw, which the
+		// backend rejects (e.g. `status: ""` is not a valid enum choice).
+		const URLModel = 'requirement-assessments';
+		const schema = modelSchema(URLModel);
+		const id = event.url.searchParams.get('id');
+		const endpoint = `${BASE_API_URL}/${URLModel}/${id}/`;
+		const form = await superValidate(event.request, zod(schema));
+
+		if (!form.valid) {
+			console.error(form.errors);
+			return fail(400, { form });
+		}
+
+		const formData: Record<string, any> = { ...form.data };
+
+		let currentRa: Record<string, any>;
+		try {
+			const currentRaResponse = await event.fetch(endpoint);
+			if (!currentRaResponse.ok) {
+				return handleErrorResponse({ event, response: currentRaResponse, form });
+			}
+			currentRa = await currentRaResponse.json();
+		} catch (error) {
+			console.error('Failed to fetch requirement assessment before update', error);
+			return fail(502, { form });
+		}
+
+		const visibilityControlled = [
+			'result',
+			'status',
+			'score',
+			'is_scored',
+			'documentation_score',
+			'observation',
+			'answers',
+			'evidences',
+			'applied_controls',
+		];
+		for (const key of visibilityControlled) {
+			if (!(key in currentRa)) {
+				delete formData[key];
+			}
+		}
+		// extended_result is a qualifier on result; strip it alongside a hidden result.
+		if (!('result' in currentRa)) {
+			delete formData.extended_result;
+		}
+
+		// The detail GET above does not honor viewer_role and returns the
+		// auditor view regardless of caller, so visibility-driven stripping
+		// alone misses fields the respondent never saw but that zod defaulted
+		// to "". Drop empty enum values to avoid DRF "is not a valid choice"
+		// errors on PATCH (e.g. status: "").
+		for (const key of ['status', 'result', 'extended_result', 'respondent_alignment']) {
+			if (formData[key] === '' || formData[key] === null) {
+				delete formData[key];
+			}
+		}
+
+		const response = await event.fetch(endpoint, {
+			method: 'PATCH',
+			body: JSON.stringify(formData)
+		});
+
+		if (!response.ok) return handleErrorResponse({ event, response, form });
+
+		const object = await response.json();
+		setFlash(
+			{
+				type: 'success',
+				message: m.successfullySavedObject({
+					object: safeTranslate('requirementAssessment').toLowerCase()
+				})
+			},
+			event
+		);
+		return { form, object };
 	}
 };

--- a/frontend/tests/functional/detailed/visibility-effects.test.ts
+++ b/frontend/tests/functional/detailed/visibility-effects.test.ts
@@ -42,6 +42,7 @@ test('field visibility effects: each flag toggles the corresponding donut', asyn
 	logedPage,
 	pages,
 	complianceAssessmentsPage,
+	evidencesPage,
 	page
 }) => {
 	test.slow();
@@ -61,6 +62,18 @@ test('field visibility effects: each flag toggles the corresponding donut', asyn
 		await requiredPage.hasUrl();
 	}
 
+	const hiddenStatusEvidenceName = `${vars.evidenceName} hidden status`;
+	await evidencesPage.goto();
+	await evidencesPage.hasUrl();
+	await evidencesPage.createItem({
+		name: hiddenStatusEvidenceName,
+		description: vars.description,
+		folder: vars.folderName,
+		link: 'https://intuitem.com/'
+	});
+
+	await complianceAssessmentsPage.goto();
+	await complianceAssessmentsPage.hasUrl();
 	await complianceAssessmentsPage.viewItemDetail(
 		testObjectsData.complianceAssessmentsPage.build.name
 	);
@@ -107,6 +120,29 @@ test('field visibility effects: each flag toggles the corresponding donut', asyn
 		await setVisibility(check.field, EVERYONE);
 		await expect(page.locator(check.selector)).toHaveCount(1);
 	}
+
+	await setVisibility('status', HIDDEN);
+	await page.goto(`${auditDetailUrl}/table-mode`);
+
+	const firstRequirementAssessment = page.locator('.table-mode-form').first();
+	await firstRequirementAssessment.getByText(m.evidence()).click();
+	await firstRequirementAssessment.getByTestId('select-evidence-button').click();
+
+	await expect(page.getByTestId('modal-title')).toBeVisible();
+	const evidenceField = page.getByTestId('form-input-evidences');
+	await evidenceField.click();
+	const evidenceOption = evidenceField
+		.getByRole('option', { name: hiddenStatusEvidenceName })
+		.first();
+	if (!(await evidenceOption.isVisible())) {
+		await evidenceField.getByRole('textbox').fill(hiddenStatusEvidenceName);
+	}
+	await expect(evidenceOption).toBeVisible();
+	await evidenceOption.click();
+	await page.getByTestId('save-button').click();
+
+	await expect(page.getByTestId('modal-title')).not.toBeVisible();
+	await expect(firstRequirementAssessment.getByText(hiddenStatusEvidenceName)).toBeVisible();
 });
 
 test.afterAll('cleanup', async ({ browser }) => {

--- a/frontend/tests/functional/detailed/visibility-effects.test.ts
+++ b/frontend/tests/functional/detailed/visibility-effects.test.ts
@@ -125,18 +125,19 @@ test('field visibility effects: each flag toggles the corresponding donut', asyn
 	await page.goto(`${auditDetailUrl}/table-mode`);
 
 	const firstRequirementAssessment = page.locator('.table-mode-form').first();
-	await firstRequirementAssessment.getByText(m.evidence()).click();
+	await firstRequirementAssessment
+		.locator('[data-scope="accordion"][data-part="item-trigger"]')
+		.filter({ hasText: m.evidence() })
+		.click();
 	await firstRequirementAssessment.getByTestId('select-evidence-button').click();
 
 	await expect(page.getByTestId('modal-title')).toBeVisible();
 	const evidenceField = page.getByTestId('form-input-evidences');
 	await evidenceField.click();
+	await evidenceField.getByRole('textbox').fill(hiddenStatusEvidenceName);
 	const evidenceOption = evidenceField
 		.getByRole('option', { name: hiddenStatusEvidenceName })
 		.first();
-	if (!(await evidenceOption.isVisible())) {
-		await evidenceField.getByRole('textbox').fill(hiddenStatusEvidenceName);
-	}
 	await expect(evidenceOption).toBeVisible();
 	await evidenceOption.click();
 	await page.getByTestId('save-button').click();


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits (squash-merged → title becomes the commit subject):
  feat | fix | chore | refactor | perf | docs | test | ci | build   (lowercase, scope optional, `!` for breaking)
  e.g. feat(lib): add NIS2 framework   |   fix(api): correct residual risk validation
Full guide: product-docs/contributing/code.md
-->

## What & why

Fixes table-mode requirement updates when some visibility-controlled select fields are hidden.

Hidden fields were visually removed from the table, but still included in the update payload with empty string values. Those empty strings are invalid enum choices for the backend, causing the PATCH request to fail.

This change strips hidden visibility-controlled fields before sending the update request, and also drops empty enum values that can be produced by form defaults.

## Test plan

- Hide one of the select fields (e.g status, result, extended_result), and update a requirement assessment

## Checklist

- [x] PR title follows Conventional Commits (`fix(frontend): strip hidden table-mode fields before update`)
- [x] One focused change, branched off `main`

### Frontend — if you touched `frontend/`

- [x] `pnpm run lint` and `pnpm run format` run
- [x] Clicked through the change in the dev server; screenshots attached for UI changes

### Tests & documentation — definition of done

- [x] Regression test added for bug fixes
- [x] No tests or docs needed for this change — why: no documentation change; fix is limited to sanitizing the table-mode update payload before PATCH.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of compliance assessment updates with more consistent error handling and stricter request validation.
  * Improved handling of optional/empty fields to prevent update failures.
  * Fixed audit “table-mode” visibility behavior so evidence selection and saving work correctly when fields are hidden.
* **New Features**
  * Success notifications now appear in your preferred language after saving compliance assessment changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->