### PR TITLE
fix(pro): read audit log actor and folder from native columns

### DIFF
--- a/backend/core/tests/test_audit_log_actor.py
+++ b/backend/core/tests/test_audit_log_actor.py
@@ -1,0 +1,64 @@
+"""Regression tests for the audit-log actor/folder data contract.
+
+LogEntry rows are produced in the community backend: auditlog.register(...) in
+core.models, the AuditlogMiddleware (actor/actor_email native columns), and
+AbstractBaseModel.get_additional_data() (folder_id). The enterprise audit-log
+serializer only exposes them.
+
+The audit-trail refactor (#4312/#4333) moved actor capture from an
+additional_data["user_email"] blob to the native actor/actor_email columns, and
+folder from additional_data["folder"] (a path string) to
+additional_data["folder_id"]. These tests pin that contract so a producer-side
+change can't silently blank the actor again.
+"""
+
+import pytest
+from auditlog.context import set_actor
+from auditlog.models import LogEntry
+
+from core.models import Asset
+from iam.models import Folder, User
+
+
+@pytest.mark.django_db
+class TestAuditLogActorContract:
+    def _domain_folder(self):
+        root = Folder.objects.get(content_type=Folder.ContentType.ROOT)
+        return Folder.objects.create(
+            name="Domain A",
+            content_type=Folder.ContentType.DOMAIN,
+            parent_folder=root,
+            create_iam_groups=False,
+        )
+
+    def test_create_populates_native_actor_and_folder_id(self):
+        user = User.objects.create_user(email="auditor@test.com")
+        folder = self._domain_folder()
+
+        with set_actor(actor=user):
+            asset = Asset.objects.create(name="A-audited", folder=folder)
+
+        entry = LogEntry.objects.get(
+            object_pk=str(asset.pk), action=LogEntry.Action.CREATE
+        )
+
+        # Actor lands in the native columns the serializer reads.
+        assert entry.actor_id == user.pk
+        assert entry.actor_email == user.email
+
+        # Folder is captured as folder_id; the old enrichment keys are gone.
+        assert entry.additional_data.get("folder_id") == str(folder.id)
+        assert "user_email" not in entry.additional_data
+        assert "folder" not in entry.additional_data
+
+    def test_create_without_actor_leaves_actor_empty_but_keeps_folder(self):
+        folder = self._domain_folder()
+        asset = Asset.objects.create(name="A-no-actor", folder=folder)
+
+        entry = LogEntry.objects.get(
+            object_pk=str(asset.pk), action=LogEntry.Action.CREATE
+        )
+
+        assert entry.actor_id is None
+        assert entry.actor_email is None
+        assert entry.additional_data.get("folder_id") == str(folder.id)

--- a/enterprise/backend/enterprise_core/serializers.py
+++ b/enterprise/backend/enterprise_core/serializers.py
@@ -8,6 +8,8 @@ from core.serializers import (
 )
 from core.serializer_fields import FieldsRelatedField
 from iam.models import Folder, User, Role
+from iam.cache_builders import get_folder_path, CacheNotReadyError
+import uuid
 
 from global_settings.models import GlobalSettings
 from global_settings.serializers import (
@@ -145,13 +147,28 @@ class LogEntrySerializer(serializers.ModelSerializer):
     actor = serializers.SerializerMethodField(method_name="get_actor")
     action = serializers.SerializerMethodField(method_name="get_action_display")
     content_type = serializers.SerializerMethodField(method_name="get_content_type")
-    folder = serializers.CharField(source="additional_data.folder", read_only=True)
+    folder = serializers.SerializerMethodField(method_name="get_folder")
 
     def get_action_display(self, obj):
         return LogEntryAction(obj.action).to_string()
 
     def get_actor(self, obj):
-        return obj.additional_data.get("user_email") if obj.additional_data else None
+        # actor/actor_email are native LogEntry columns populated by the auditlog
+        # middleware. They replaced the additional_data["user_email"] blob that the
+        # old post_save enrichment used to fill (removed in the audit-trail refactor).
+        return obj.actor_email or (obj.actor.email if obj.actor_id else None)
+
+    def get_folder(self, obj):
+        # additional_data now carries folder_id (the old enrichment stored a "folder"
+        # path string). Resolve it to the full path via the in-memory folders cache.
+        folder_id = (obj.additional_data or {}).get("folder_id")
+        if not folder_id:
+            return None
+        try:
+            path = get_folder_path(uuid.UUID(str(folder_id)))
+        except (ValueError, KeyError, CacheNotReadyError):
+            return None
+        return "/".join(f.name for f in path) or None
 
     def get_content_type(self, obj):
         return obj.content_type.name

--- a/enterprise/backend/enterprise_core/serializers.py
+++ b/enterprise/backend/enterprise_core/serializers.py
@@ -166,7 +166,7 @@ class LogEntrySerializer(serializers.ModelSerializer):
             return None
         try:
             path = get_folder_path(uuid.UUID(str(folder_id)))
-        except (ValueError, KeyError, CacheNotReadyError):
+        except ValueError, KeyError, CacheNotReadyError:
             return None
         return "/".join(f.name for f in path) or None
 

--- a/enterprise/backend/enterprise_core/views.py
+++ b/enterprise/backend/enterprise_core/views.py
@@ -463,9 +463,7 @@ class NumberInFilter(df.BaseInFilter, df.NumberFilter):
 
 class LogEntryFilterSet(GenericFilterSet):
     actor = df.CharFilter(field_name="actor__email", lookup_expr="icontains")
-    folder = df.CharFilter(
-        field_name="additional_data__folder", lookup_expr="icontains"
-    )
+    folder = df.CharFilter(method="filter_folder")
     action = NumberInFilter(field_name="action", lookup_expr="in")
     content_type = df.CharFilter(method="filter_content_type_model")
 
@@ -482,6 +480,25 @@ class LogEntryFilterSet(GenericFilterSet):
             return queryset
         normalized = value.replace(" ", "").lower()
         return queryset.filter(content_type__model__icontains=normalized)
+
+    def filter_folder(self, queryset, name, value):
+        # additional_data stores folder_id, not the path string the old enrichment
+        # used. Resolve folders whose full path matches the query, then match their
+        # ids. Path resolution hits the in-memory folders cache, not the DB.
+        if not value:
+            return queryset
+        needle = value.lower()
+        matching_ids = [
+            str(folder.id)
+            for folder in Folder.objects.only("id")
+            if needle in folder.get_folder_full_path_string().lower()
+        ]
+        if not matching_ids:
+            return queryset.none()
+        q = models.Q()
+        for folder_id in matching_ids:
+            q |= models.Q(additional_data__folder_id=folder_id)
+        return queryset.filter(q)
 
 
 class LogEntryViewSet(
@@ -501,7 +518,6 @@ class LogEntryViewSet(
         "actor__first_name",
         "actor__last_name",
         "changes",  # allows to search for last_login (for example)
-        "additional_data__folder",
     ]
     filterset_class = LogEntryFilterSet
 
@@ -515,12 +531,14 @@ class LogEntryViewSet(
             folder=Folder.get_root_folder(),
         ):
             return LogEntry.objects.none()
+        # Annotate folder_id (display resolution to a path happens in the serializer
+        # via the folders cache). Keeps `folder` orderable without a per-row join.
         return LogEntry.objects.all().annotate(
             folder=Lower(
                 Case(
                     When(additional_data__isnull=True, then=Value("")),
-                    When(additional_data__folder=None, then=Value("")),
-                    default=Cast("additional_data__folder", CharField()),
+                    When(additional_data__folder_id=None, then=Value("")),
+                    default=Cast("additional_data__folder_id", CharField()),
                     output_field=CharField(),
                 )
             ),


### PR DESCRIPTION
## What & why

Audit log entries created after the audit-trail refactor show no actor (and no folder). Older entries are unaffected.

Root cause: the audit-trail refactor moved actor capture to django-auditlog's native `actor` / `actor_email` columns and folder capture to `additional_data["folder_id"]`. The enrichment `post_save` signal that used to fill `additional_data["user_email"]` / `["folder"]` was removed in #4333. But the enterprise `LogEntrySerializer` still read those now-absent keys, so `get_actor` always returned `None`. The actor data was never lost, the serializer just read the wrong field.

Fix:
- `get_actor` reads the native `actor_email` / `actor` columns.
- `folder` resolves `additional_data["folder_id"]` to a path via the in-memory folders cache.
- The folder filter resolves names to ids, the dead `additional_data__folder` search field is dropped, and the ordering annotation points at `folder_id`.

## Test plan

- `uv run pytest backend/core/tests/test_audit_log_actor.py` (2 passed)
- Verified the contract the serializer depends on: creating an Asset within an actor context populates native `actor`/`actor_email` and `additional_data["folder_id"]`, with no stale `user_email`/`folder` keys.

## Checklist

- [x] PR title follows Conventional Commits (`!` set if this is a breaking change)
- [x] One focused change, branched off `main`

### Backend — if you touched `backend/`

- [x] `ruff format` run, no new linter errors
- [x] Migrations generated with `makemigrations` and committed (or none needed)

### Tests & documentation — definition of done

- [x] Tests added or updated and passing locally — backend `uv run pytest`
- [x] Regression test added for bug fixes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression tests for audit log actor and folder data tracking to ensure accurate data capture

* **Bug Fixes**
  * Improved accuracy of actor information in audit logs with proper user identification
  * Enhanced folder tracking and resolution in audit logs for better visibility
  * Updated audit log filtering to better handle folder-based queries with improved path resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->