### PR TITLE
fix: translation for back label in kanban and flash mode

### DIFF
--- a/frontend/src/routes/(app)/(internal)/applied-controls/flash-mode/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/applied-controls/flash-mode/+page.svelte
@@ -194,7 +194,7 @@
 						class="flex items-center space-x-2 text-primary-800-300 hover:text-primary-600-400"
 					>
 						<i class="fa-solid fa-arrow-left"></i>
-						<p class="">{data.backLabel}</p>
+						<p class="">{safeTranslate(data.backLabel)}</p>
 					</a>
 				</div>
 				<div class="relative">

--- a/frontend/src/routes/(app)/(internal)/applied-controls/kanban-mode/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/applied-controls/kanban-mode/+page.svelte
@@ -2,6 +2,7 @@
 	import { m } from '$paraglide/messages';
 	import { getLocale } from '$paraglide/runtime';
 	import { formatDateOrDateTime } from '$lib/utils/datetime';
+	import { safeTranslate } from '$lib/utils/i18n';
 	import type { PageData } from './$types';
 
 	interface Props {
@@ -317,7 +318,7 @@
 			class="flex items-center space-x-2 text-primary-800-300 hover:text-primary-600-400"
 		>
 			<i class="fa-solid fa-arrow-left"></i>
-			<span>{data.backLabel}</span>
+			<span>{safeTranslate(data.backLabel)}</span>
 		</a>
 		<div class="flex items-center space-x-4">
 			<span class="text-sm text-surface-600-400">


### PR DESCRIPTION
## What & why

Closes #4357

## Test plan

In Applied Controls > Kanban Mode and Applied Controls > Flash Mode, the return button must be translated.

<img width="241" height="67" alt="image" src="https://github.com/user-attachments/assets/8dd0fdb7-8243-406b-a26a-744cea6f9ac8" />


## Checklist

- [X] PR title follows Conventional Commits (`!` set if this is a breaking change)
- [X] One focused change, branched off `main`

### Frontend — if you touched `frontend/`

- [X] Svelte 5 syntax; `pnpm run lint` and `pnpm run format` run
- [X] Clicked through the change in the dev server; screenshots attached for UI changes

### Tests & documentation — definition of done

- [X] No tests or docs needed for this change — why: only translation related change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed navigation back-button labels to display correctly in different languages across applied controls sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->