### PR TITLE
Fix Python 3 syntax error in convert_library_v2.py exception handlers

### DIFF
--- a/backend/scripts/convert_library_v2.py
+++ b/backend/scripts/convert_library_v2.py
@@ -856,7 +856,7 @@ def _handle_framework(obj, library, object_blocks, prefix_to_urn, compat_mode, v
                             try:
                                 score_to_add = int(val)
                                 choices[i]["add_score"] = score_to_add
-                            except TypeError, ValueError:
+                            except (TypeError, ValueError):
                                 raise ValueError(
                                     f"(answers_definition) Invalid add_score value '{val}' "
                                     f"for answer ID '{answer_id}', choice #{i + 1}. Must be an integer"
@@ -1135,7 +1135,7 @@ def _handle_framework(obj, library, object_blocks, prefix_to_urn, compat_mode, v
                     if (w := int(data["weight"])) <= 0:
                         raise ValueError
                     node["weight"] = w
-                except TypeError, ValueError:
+                except (TypeError, ValueError):
                     raise ValueError(
                         f"(framework) Invalid weight at row #{row[0].row}: {data['weight']}. Must be a strictly positive integer."
                     )
@@ -1150,7 +1150,7 @@ def _handle_framework(obj, library, object_blocks, prefix_to_urn, compat_mode, v
                 ):
                     try:
                         node[int_field] = int(data[int_field])
-                    except TypeError, ValueError:
+                    except (TypeError, ValueError):
                         raise ValueError(
                             f"(framework) Invalid {int_field} at row #{row[0].row}: "
                             f"{data[int_field]}. Must be an integer."
@@ -1291,7 +1291,7 @@ def _handle_metric_definitions(obj, library, compat_mode, verbose):
         if "default_target" in data and data["default_target"] is not None:
             try:
                 entry["default_target"] = float(data["default_target"])
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 raise ValueError(
                     f"(metric_definitions) Invalid default_target '{data['default_target']}' at row #{row[0].row}. Must be a number."
                 )


### PR DESCRIPTION
## Fix Python 3 syntax error in `convert_library_v2.py`

The library converter (`backend/scripts/convert_library_v2.py`, also exposed via the `tools/convert_library_v2.py` symlink) uses the **Python 2** exception syntax `except TypeError, ValueError:` in four places. Under Python 3 this is a hard `SyntaxError`, so the module fails to even import:

```
$ python3 backend/scripts/convert_library_v2.py library.xlsx
  File "backend/scripts/convert_library_v2.py", line 859
    except TypeError, ValueError:
           ^^^^^^^^^^^^^^^^^^^^^
SyntaxError: multiple exception types must be parenthesized
```

Because it is a parse-time error, the converter cannot run at all once execution reaches code that exercises these handlers — answer scoring (`add_score`), framework `weight` / integer fields, and metric `default_target`. In practice this breaks conversion for any library that uses implementation groups or scoring.

### Fix
Wrap the exception tuples so they are valid Python 3:

```python
except (TypeError, ValueError):
```

Four occurrences (lines 859, 1138, 1153, 1294). No behavior change otherwise.

### Verification
- `python3 -c "import ast; ast.parse(open('backend/scripts/convert_library_v2.py').read())"` now parses cleanly (previously raised `SyntaxError`).
- Ran the converter end to end on a library that uses implementation groups; it completes and writes valid YAML where it previously aborted at import.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated data conversion script syntax for improved code consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->