### PR TITLE
Fix Python 3 syntax errors: parenthesize multi-type except clauses (backend does not import on Py3)

### DIFF
--- a/backend/chat/management/commands/prune_index.py
+++ b/backend/chat/management/commands/prune_index.py
@@ -76,7 +76,7 @@ class Command(BaseCommand):
             try:
                 app_label, model_name = model_path.split(".")
                 model_class = apps.get_model(app_label, model_name)
-            except LookupError, ValueError:
+            except (LookupError, ValueError):
                 continue
             object_type = _normalize_model_name(model_name)
             try:

--- a/backend/chat/memory.py
+++ b/backend/chat/memory.py
@@ -197,7 +197,7 @@ def inject_tool_replays(
             args = obs.get("args", {})
             try:
                 args_str = json.dumps(args, ensure_ascii=False, default=str)
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 args_str = str(args)
             result_text = truncate_to_tokens(
                 obs.get("result_text", "") or "", TOOL_REPLAY_TOKENS

--- a/backend/chat/orm_query.py
+++ b/backend/chat/orm_query.py
@@ -124,7 +124,7 @@ def execute_tool_query(
     if priority is not None and hasattr(model_class, "priority"):
         try:
             priority = int(priority)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             priority = None
         if priority is not None:
             qs = qs.filter(priority=priority)
@@ -147,7 +147,7 @@ def execute_tool_query(
     if severity is not None and hasattr(model_class, "severity"):
         try:
             severity = int(severity)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             severity = None
         if severity is not None:
             qs = qs.filter(severity=severity)
@@ -200,7 +200,7 @@ def execute_tool_query(
     total_count = qs.count()
     try:
         page = int(arguments.get("page", 1) or 1)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         page = 1
 
     # Pagination — always applied

--- a/backend/chat/providers.py
+++ b/backend/chat/providers.py
@@ -468,7 +468,7 @@ class OpenAICompatibleLLM:
                         yield ("thinking", reasoning)
                     if content := delta.get("content"):
                         yield ("raw", content)
-                except json.JSONDecodeError, KeyError, IndexError:
+                except (json.JSONDecodeError, KeyError, IndexError):
                     continue
 
     def stream(

--- a/backend/chat/questionnaire.py
+++ b/backend/chat/questionnaire.py
@@ -945,7 +945,7 @@ def refresh_folder_index(folder_id: str) -> dict:
         try:
             app_label, model_name = model_path.split(".")
             model_class = apps.get_model(app_label, model_name)
-        except LookupError, ValueError:
+        except (LookupError, ValueError):
             continue
         try:
             qs = model_class.objects.filter(folder_id=folder_id_str)
@@ -1910,7 +1910,7 @@ def _critique(
     parsed = _parse_json_response(raw) or {}
     try:
         score = float(parsed.get("score", 0.0))
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         score = 0.0
     score = max(0.0, min(1.0, score))
     issue = (parsed.get("issue") or "").strip()

--- a/backend/chat/tools.py
+++ b/backend/chat/tools.py
@@ -179,7 +179,7 @@ def _get_field_choices(
         field = model._meta.get_field(field_name)
         if field.choices:
             return [choice[0] for choice in field.choices if choice[0]]
-    except LookupError, Exception:
+    except (LookupError, Exception):
         pass
     return None
 

--- a/backend/chat/views.py
+++ b/backend/chat/views.py
@@ -908,7 +908,7 @@ class QuestionnaireRunViewSet(BaseModelViewSet):
 
         try:
             folder = Folder.objects.get(id=folder_id)
-        except Folder.DoesNotExist, ValueError:
+        except (Folder.DoesNotExist, ValueError):
             return Response(
                 {"detail": "Folder not found."}, status=status.HTTP_404_NOT_FOUND
             )

--- a/backend/core/focus_middleware.py
+++ b/backend/core/focus_middleware.py
@@ -53,7 +53,7 @@ def _validate_uuid(value: str) -> UUID | None:
         return None
     try:
         return UUID(value.strip())
-    except ValueError, AttributeError:
+    except (ValueError, AttributeError):
         return None
 
 

--- a/backend/core/mappings/engine.py
+++ b/backend/core/mappings/engine.py
@@ -103,7 +103,7 @@ class MappingEngine:
                 local_framework_mappings,
                 local_direct_mappings,
             ) = self.load_rms_data()
-        except ProgrammingError, OperationalError:
+        except (ProgrammingError, OperationalError):
             # Tables might not exist during migrations. Preserve whatever
             # cache state already exists and let the next access retry.
             return

--- a/backend/core/migrations/0096_appliedcontrol_cost_to_json.py
+++ b/backend/core/migrations/0096_appliedcontrol_cost_to_json.py
@@ -26,7 +26,7 @@ def convert_cost_to_json(apps, schema_editor):
             }
             control.save(update_fields=["cost_temp"])
 
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             # Set to default structure for invalid values
             control.cost_temp = {
                 "currency": "€",
@@ -50,7 +50,7 @@ def reverse_cost_conversion(apps, schema_editor):
             else:
                 control.cost = 0.0
             control.save(update_fields=["cost"])
-        except ValueError, TypeError, KeyError:
+        except (ValueError, TypeError, KeyError):
             control.cost = 0.0
             control.save(update_fields=["cost"])
 

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -9631,7 +9631,7 @@ class ValidationFlow(AbstractBaseModel, FolderMixin, FilteringLabelMixin):
             return "VAL.000001"
         try:
             suffix = int(last.ref_id.split(".")[1])
-        except IndexError, ValueError:
+        except (IndexError, ValueError):
             # Fallback if existing data is malformed
             suffix = 0
         return f"VAL.{suffix + 1:06d}"

--- a/backend/core/preset_editor.py
+++ b/backend/core/preset_editor.py
@@ -333,5 +333,5 @@ def _is_uuid(value: Any) -> bool:
     try:
         uuid.UUID(value)
         return True
-    except ValueError, AttributeError:
+    except (ValueError, AttributeError):
         return False

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -58,7 +58,7 @@ class SerializerFactory:
                 serializer_module = importlib.import_module(module_name)
                 serializer_class = getattr(serializer_module, serializer_name)
                 return serializer_class
-            except ModuleNotFoundError, AttributeError:
+            except (ModuleNotFoundError, AttributeError):
                 continue
 
         raise ValueError(
@@ -153,7 +153,7 @@ class BaseModelSerializer(serializers.ModelSerializer):
                         root_folder, user, related_model
                     )[0]
                     accessible_cache[related_model] = {str(i) for i in ids}
-                except NotImplementedError, Permission.DoesNotExist:
+                except (NotImplementedError, Permission.DoesNotExist):
                     accessible_cache[related_model] = None
             accessible_ids = accessible_cache[related_model]
             if accessible_ids is None:
@@ -351,7 +351,7 @@ class VulnerabilityReadSerializer(BaseModelSerializer):
         severity_label = obj.get_severity_display()
         try:
             sla_days = int(sla_policy.get(severity_label, 0)) or None
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             sla_days = None
         if sla_days is not None:
             remaining = (obj.due_date - today).days

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -365,11 +365,11 @@ def get_mapping_max_depth():
         raw = gs.value.get("mapping_max_depth", MAPPING_MAX_DEPTH)
         try:
             val = int(raw)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             return MAPPING_MAX_DEPTH
         # Clamp to UI constraints
         return max(2, min(5, val))
-    except OperationalError, ProgrammingError:
+    except (OperationalError, ProgrammingError):
         # DB not ready (e.g., migrate, makemigrations)
         return MAPPING_MAX_DEPTH
 
@@ -1015,7 +1015,7 @@ class BaseModelViewSet(viewsets.ModelViewSet):
                 ids = RoleAssignment.get_accessible_object_ids(
                     root_folder, self.request.user, model
                 )[0]
-            except NotImplementedError, Permission.DoesNotExist:
+            except (NotImplementedError, Permission.DoesNotExist):
                 # Model does not support IAM scoping; skip filtering
                 allowed[model] = None
                 continue
@@ -2523,7 +2523,7 @@ class AssetViewSet(ExportMixin, BaseModelViewSet):
 
             try:
                 folder = Folder.objects.get(id=uuid.UUID(str(folder_id)))
-            except ValueError, AttributeError, Folder.DoesNotExist:
+            except (ValueError, AttributeError, Folder.DoesNotExist):
                 return Response(
                     {"error": "Folder not found"},
                     status=status.HTTP_404_NOT_FOUND,
@@ -3467,7 +3467,7 @@ class VulnerabilityViewSet(BaseModelViewSet):
                 continue
             try:
                 delta = timedelta(days=int(days))
-            except ValueError, TypeError:
+            except (ValueError, TypeError):
                 continue
             qs = accessible.filter(
                 severity=severity_int,
@@ -4523,7 +4523,7 @@ class RiskAssessmentViewSet(BaseModelViewSet):
                     {"detail": "loss_threshold must be greater than 0"},
                     status=status.HTTP_400_BAD_REQUEST,
                 )
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             return Response(
                 {"detail": "loss_threshold must be a valid number"},
                 status=status.HTTP_400_BAD_REQUEST,
@@ -4860,7 +4860,7 @@ class RiskAssessmentViewSet(BaseModelViewSet):
                     risk_level_colors[level.get("name", "")] = level.get(
                         "hexcolor", "#6b7280"
                     )
-            except KeyError, TypeError, AttributeError:
+            except (KeyError, TypeError, AttributeError):
                 pass
 
         samples = (
@@ -6273,7 +6273,7 @@ class ActionPlanBudgetOverview:
         """Coerce a JSON-sourced value to float, returning default on failure."""
         try:
             return float(value)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             return default
 
     @staticmethod
@@ -9870,7 +9870,7 @@ class FrameworkViewSet(BaseModelViewSet):
                     )
                 try:
                     parsed = uuid.UUID(str(record.get("id")))
-                except TypeError, ValueError:
+                except (TypeError, ValueError):
                     raise DraftValidationError(
                         f"{kind.capitalize()} '{_label(record)}' has a missing or "
                         "invalid id. Discard the draft and start editing again."
@@ -9890,7 +9890,7 @@ class FrameworkViewSet(BaseModelViewSet):
         for q in draft_questions:
             try:
                 parent_id = uuid.UUID(str(q.get("requirement_node_id")))
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 parent_id = None
             if parent_id not in parsed_ids_by_kind["requirement"]:
                 raise DraftValidationError(
@@ -9899,7 +9899,7 @@ class FrameworkViewSet(BaseModelViewSet):
         for c in draft_choices:
             try:
                 parent_id = uuid.UUID(str(c.get("question_id")))
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 parent_id = None
             if parent_id not in parsed_ids_by_kind["question"]:
                 raise DraftValidationError(
@@ -11667,7 +11667,7 @@ class EvidenceViewSet(BaseModelViewSet):
             )
         try:
             folder = Folder.objects.get(id=uuid.UUID(str(folder_id)))
-        except ValueError, TypeError, Folder.DoesNotExist:
+        except (ValueError, TypeError, Folder.DoesNotExist):
             return Response(
                 {"error": "Folder not found"},
                 status=status.HTTP_404_NOT_FOUND,
@@ -11677,7 +11677,7 @@ class EvidenceViewSet(BaseModelViewSet):
             manifest = json.loads(request.data.get("manifest") or "[]")
             if not isinstance(manifest, list):
                 raise ValueError("manifest must be a list")
-        except ValueError, json.JSONDecodeError:
+        except (ValueError, json.JSONDecodeError):
             logger.exception("Invalid manifest JSON received in batch upload")
             return Response(
                 {"error": "Invalid manifest JSON"},
@@ -12515,7 +12515,7 @@ class JourneyViewSet(BaseModelViewSet):
                         round(assessed_ra / total_ra * 100) if total_ra > 0 else 0
                     ),
                 }
-            except ComplianceAssessment.DoesNotExist, ValueError:
+            except (ComplianceAssessment.DoesNotExist, ValueError):
                 continue
         stats["compliance"] = compliance_stats
         return stats
@@ -12840,7 +12840,7 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
                 target_audit = ComplianceAssessment.objects.select_related(
                     "framework"
                 ).get(id=has_mapping_path_to)
-            except ComplianceAssessment.DoesNotExist, ValueError:
+            except (ComplianceAssessment.DoesNotExist, ValueError):
                 return qs.none()
             from core.mappings.engine import engine
 
@@ -13765,7 +13765,7 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
             if score is not None:
                 try:
                     score = int(score)
-                except ValueError, TypeError:
+                except (ValueError, TypeError):
                     return Response(
                         {"error": "Score must be a valid integer"},
                         status=status.HTTP_400_BAD_REQUEST,
@@ -16404,7 +16404,7 @@ class RequirementMappingSetViewSet(BaseModelViewSet):
                     "value": display_value,
                     "pk": lib.pk,
                 }
-            except KeyError, TypeError:
+            except (KeyError, TypeError):
                 # Skip this library if content is malformed
                 continue
 
@@ -20107,7 +20107,7 @@ def metrics_view(request):
                     tzinfo=timezone.utc,
                 ).timestamp()
             )
-        except ValueError, AttributeError, TypeError:
+        except (ValueError, AttributeError, TypeError):
             expiration_ts = -1
         expiration_gauge.set(expiration_ts)
         created_at_gauge.set(metrics.get("created_at", 0))

--- a/backend/custom_fields/models.py
+++ b/backend/custom_fields/models.py
@@ -52,7 +52,7 @@ def coerce_value(field_type: str, raw):
     if field_type == FieldType.NUMBER:
         try:
             return Decimal(str(raw))
-        except InvalidOperation, ValueError, TypeError:
+        except (InvalidOperation, ValueError, TypeError):
             raise ValueError(f"'{raw}' is not a valid number")
 
     if field_type == FieldType.DATE:

--- a/backend/custom_fields/serializers.py
+++ b/backend/custom_fields/serializers.py
@@ -20,7 +20,7 @@ def _resolve_content_type(model: str) -> ContentType:
     try:
         app_label, model_name = model.lower().split(".")
         return ContentType.objects.get(app_label=app_label, model=model_name)
-    except ValueError, ContentType.DoesNotExist:
+    except (ValueError, ContentType.DoesNotExist):
         raise serializers.ValidationError(
             {"model": f"'{model}' is not a valid app_label.model"}
         )

--- a/backend/custom_fields/views.py
+++ b/backend/custom_fields/views.py
@@ -45,7 +45,7 @@ class CustomFieldDefinitionViewSet(BaseModelViewSet):
         if for_folder:
             try:
                 folder = Folder.objects.filter(pk=for_folder).first()
-            except ValueError, ValidationError:
+            except (ValueError, ValidationError):
                 return queryset.none()
             folder_ids = {Folder.get_root_folder_id()}
             if folder is not None:

--- a/backend/data_wizard/arm_helpers.py
+++ b/backend/data_wizard/arm_helpers.py
@@ -368,7 +368,7 @@ def build_gravity_scale_mapping(workbook) -> dict[str, int]:
         if gravity_name and niveau is not None:
             try:
                 mapping[gravity_name.lower().strip()] = int(niveau) - 1
-            except ValueError, TypeError:
+            except (ValueError, TypeError):
                 logger.warning(f"Invalid Niveau value: {niveau}")
     return mapping
 

--- a/backend/data_wizard/views.py
+++ b/backend/data_wizard/views.py
@@ -227,7 +227,7 @@ def _reverse_scale_value(display_val: str, scale: list) -> int | None:
         for idx, sv in enumerate(scale):
             if isinstance(sv, (int, float)) and int(sv) == numeric:
                 return idx
-    except ValueError, TypeError:
+    except (ValueError, TypeError):
         pass
 
     # Fall back to case-insensitive string comparison (e.g. FIPS-199)
@@ -2048,7 +2048,7 @@ class BusinessImpactAnalysisRecordConsumer(RecordConsumer):
                 perimeter = Perimeter.objects.filter(id=perimeter_uuid).first()
                 if perimeter:
                     return perimeter, None
-            except ValueError, TypeError:
+            except (ValueError, TypeError):
                 pass
 
             perimeter = Perimeter.objects.filter(ref_id=perimeter_value).first()
@@ -2102,7 +2102,7 @@ class BusinessImpactAnalysisRecordConsumer(RecordConsumer):
                 risk_matrix = RiskMatrix.objects.filter(id=matrix_uuid).first()
                 if risk_matrix:
                     return risk_matrix, None
-            except ValueError, TypeError:
+            except (ValueError, TypeError):
                 pass
 
             risk_matrix = RiskMatrix.objects.filter(ref_id=matrix_value).first()
@@ -2206,7 +2206,7 @@ class AssetAssessmentRecordConsumer(RecordConsumer):
             bia = BusinessImpactAnalysis.objects.filter(id=bia_uuid).first()
             if bia:
                 return bia, None
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             pass
 
         bia = BusinessImpactAnalysis.objects.filter(name__iexact=bia_value).first()
@@ -2231,7 +2231,7 @@ class AssetAssessmentRecordConsumer(RecordConsumer):
             asset = Asset.objects.filter(id=asset_uuid).first()
             if asset:
                 return asset, None
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             pass
 
         asset = Asset.objects.filter(ref_id=asset_value).first()
@@ -2268,7 +2268,7 @@ class AssetAssessmentRecordConsumer(RecordConsumer):
             try:
                 control_uuid = UUID(str(item))
                 control = AppliedControl.objects.filter(id=control_uuid).first()
-            except ValueError, TypeError:
+            except (ValueError, TypeError):
                 control = None
 
             if control is None:
@@ -2294,7 +2294,7 @@ class AssetAssessmentRecordConsumer(RecordConsumer):
             try:
                 evidence_uuid = UUID(str(item))
                 evidence = Evidence.objects.filter(id=evidence_uuid).first()
-            except ValueError, TypeError:
+            except (ValueError, TypeError):
                 evidence = None
 
             if evidence is None:
@@ -2383,7 +2383,7 @@ class EscalationThresholdRecordConsumer(RecordConsumer):
             bia = BusinessImpactAnalysis.objects.filter(id=bia_uuid).first()
             if bia:
                 return bia, None
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             pass
 
         bia = BusinessImpactAnalysis.objects.filter(name__iexact=bia_value).first()
@@ -2408,7 +2408,7 @@ class EscalationThresholdRecordConsumer(RecordConsumer):
             asset = Asset.objects.filter(id=asset_uuid).first()
             if asset:
                 return asset, None
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             pass
 
         asset = Asset.objects.filter(ref_id=asset_value).first()
@@ -2431,7 +2431,7 @@ class EscalationThresholdRecordConsumer(RecordConsumer):
                 assessment = AssetAssessment.objects.filter(id=assessment_uuid).first()
                 if assessment:
                     return assessment, None
-            except ValueError, TypeError:
+            except (ValueError, TypeError):
                 pass
 
         bia, error = self._resolve_bia(record)
@@ -2497,7 +2497,7 @@ class EscalationThresholdRecordConsumer(RecordConsumer):
             return {}, Error(record=record, error="point_in_time is mandatory")
         try:
             point_in_time = int(float(point_in_time))
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             return {}, Error(
                 record=record,
                 error=f"Invalid point_in_time '{point_in_time}'",
@@ -2509,7 +2509,7 @@ class EscalationThresholdRecordConsumer(RecordConsumer):
         else:
             try:
                 quali_impact_value = int(float(quali_impact))
-            except ValueError, TypeError:
+            except (ValueError, TypeError):
                 return {}, Error(
                     record=record,
                     error=f"Invalid quali_impact '{quali_impact}'",
@@ -2534,7 +2534,7 @@ class EscalationThresholdRecordConsumer(RecordConsumer):
         else:
             try:
                 quanti_impact_value = float(quanti_impact)
-            except ValueError, TypeError:
+            except (ValueError, TypeError):
                 return {}, Error(
                     record=record,
                     error=f"Invalid quanti_impact '{quanti_impact}'",
@@ -3433,7 +3433,7 @@ class LoadFileView(APIView):
                                 if value != "" and value is not None:
                                     try:
                                         update_data[f"default_{field}"] = int(value)
-                                    except ValueError, TypeError:
+                                    except (ValueError, TypeError):
                                         pass
                             legal_ids = {}
                             for id_type in ["lei", "euid", "duns", "vat"]:
@@ -3479,7 +3479,7 @@ class LoadFileView(APIView):
                     if value != "" and value is not None:
                         try:
                             entity_data[f"default_{field}"] = int(value)
-                        except ValueError, TypeError:
+                        except (ValueError, TypeError):
                             pass
 
                 # Handle legal identifiers (LEI, EUID, DUNS, VAT, etc.)
@@ -3639,7 +3639,7 @@ class LoadFileView(APIView):
                                     update_data["criticality"] = int(
                                         record.get("criticality")
                                     )
-                                except ValueError, TypeError:
+                                except (ValueError, TypeError):
                                     pass
                             serializer = SolutionWriteSerializer(
                                 instance=existing_solution,
@@ -3672,7 +3672,7 @@ class LoadFileView(APIView):
                 ):
                     try:
                         solution_data["criticality"] = int(record.get("criticality"))
-                    except ValueError, TypeError:
+                    except (ValueError, TypeError):
                         pass
 
                 # Create the solution
@@ -3829,7 +3829,7 @@ class LoadFileView(APIView):
                         contract_data["annual_expense"] = float(
                             record.get("annual_expense")
                         )
-                    except ValueError, TypeError:
+                    except (ValueError, TypeError):
                         pass
                 if record.get("currency"):
                     contract_data["currency"] = record.get("currency")

--- a/backend/doc_management/views.py
+++ b/backend/doc_management/views.py
@@ -228,7 +228,7 @@ class DocumentAttachmentViewSet(BaseModelViewSet):
         """Serve the attachment file with correct content type."""
         try:
             pk_uuid = UUID(pk)
-        except ValueError, AttributeError:
+        except (ValueError, AttributeError):
             return Response(status=status.HTTP_400_BAD_REQUEST)
         object_ids_view = RoleAssignment.get_accessible_object_ids(
             Folder.get_root_folder(), request.user, DocumentAttachment

--- a/backend/ebios_rm/views.py
+++ b/backend/ebios_rm/views.py
@@ -768,7 +768,7 @@ class FearedEventViewSet(BaseModelViewSet):
             # Verify study exists
             try:
                 study = EbiosRMStudy.objects.get(id=uuid.UUID(str(study_id)))
-            except ValueError, AttributeError, EbiosRMStudy.DoesNotExist:
+            except (ValueError, AttributeError, EbiosRMStudy.DoesNotExist):
                 return Response(
                     {"error": "EBIOS RM Study not found"},
                     status=http_status.HTTP_404_NOT_FOUND,
@@ -1252,7 +1252,7 @@ class OperatingModeViewSet(BaseModelViewSet):
 
             try:
                 ea_id = uuid.UUID(str(ea_id))
-            except ValueError, AttributeError:
+            except (ValueError, AttributeError):
                 errors.append(f"Step {i}: invalid elementary_action UUID.")
                 continue
 
@@ -1276,7 +1276,7 @@ class OperatingModeViewSet(BaseModelViewSet):
             for ant_id in antecedent_ids:
                 try:
                     ant_uuid = uuid.UUID(str(ant_id))
-                except ValueError, AttributeError:
+                except (ValueError, AttributeError):
                     errors.append(f"Step {i}: invalid antecedent UUID.")
                     continue
 

--- a/backend/global_settings/serializers.py
+++ b/backend/global_settings/serializers.py
@@ -45,7 +45,7 @@ def validate_default_dashboard_value(value):
         return None
     try:
         uuid.UUID(str(value))
-    except ValueError, TypeError:
+    except (ValueError, TypeError):
         raise serializers.ValidationError(
             {"default_custom_analytics_dashboard": "Must be a valid UUID."}
         )
@@ -181,7 +181,7 @@ class GeneralSettingsSerializer(serializers.ModelSerializer):
             if key == "chat_temperature":
                 try:
                     temp = float(value)
-                except TypeError, ValueError:
+                except (TypeError, ValueError):
                     raise serializers.ValidationError(
                         {"chat_temperature": "Must be a number."}
                     )

--- a/backend/iam/cache_builders.py
+++ b/backend/iam/cache_builders.py
@@ -70,7 +70,7 @@ def _cache_tables_ready() -> bool:
     try:
         with connection.cursor() as cursor:
             tables = set(connection.introspection.table_names(cursor))
-    except OperationalError, ProgrammingError:
+    except (OperationalError, ProgrammingError):
         return False
     return CacheVersion._meta.db_table in tables
 

--- a/backend/iam/models.py
+++ b/backend/iam/models.py
@@ -100,7 +100,7 @@ def _get_root_folder() -> Folder | None:
         )
     except Folder.DoesNotExist:
         return None
-    except OperationalError, ProgrammingError:
+    except (OperationalError, ProgrammingError):
         return None
 
 

--- a/backend/iam/snapshot_cache.py
+++ b/backend/iam/snapshot_cache.py
@@ -142,7 +142,7 @@ class VersionedSnapshotCache(Generic[T]):
         """
         try:
             new_v = VersionStore.bump(self.key)
-        except OperationalError, ProgrammingError:
+        except (OperationalError, ProgrammingError):
             # Still clear local snapshot so this process rebuilds next time it can.
             self._snapshot = None
             return None

--- a/backend/iam/views.py
+++ b/backend/iam/views.py
@@ -139,7 +139,7 @@ class PersonalAccessTokenViewSet(views.APIView):
             expiry_days = int(request.data.get("expiry", 30))
             if expiry_days <= 0:
                 raise ValueError
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             return Response(
                 {"error": "Expiry must be a positive integer (days)."},
                 status=status.HTTP_400_BAD_REQUEST,

--- a/backend/integrations/itsm/jira/mapper.py
+++ b/backend/integrations/itsm/jira/mapper.py
@@ -282,7 +282,7 @@ class JiraFieldMapper(BaseFieldMapper):
                 return None
             try:
                 return int(mapped)
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 return mapped
 
         if field in ("eta", "start_date"):

--- a/backend/integrations/itsm/servicenow/mapper.py
+++ b/backend/integrations/itsm/servicenow/mapper.py
@@ -125,7 +125,7 @@ class ServiceNowFieldMapper(BaseFieldMapper):
                 if int(value) not in [p[0] for p in AppliedControl.PRIORITY]:
                     return None
                 return int(value)
-            except ValueError, TypeError:
+            except (ValueError, TypeError):
                 return None
 
         return value

--- a/backend/library/views.py
+++ b/backend/library/views.py
@@ -380,7 +380,7 @@ class StoredLibraryViewSet(BaseModelViewSet):
                                     ),
                                     status=HTTP_400_BAD_REQUEST,
                                 )
-                        except ValueError, TypeError:
+                        except (ValueError, TypeError):
                             compat_mode = 0
 
                         # Initialize handler (uses ENABLE_SANDBOX setting automatically)

--- a/backend/metrology/models.py
+++ b/backend/metrology/models.py
@@ -286,7 +286,7 @@ class CustomMetricSample(AbstractBaseModel, FolderMixin):
         if isinstance(self.value, str):
             try:
                 value_dict = json.loads(self.value)
-            except json.JSONDecodeError, TypeError:
+            except (json.JSONDecodeError, TypeError):
                 return None
         else:
             value_dict = self.value
@@ -308,7 +308,7 @@ class CustomMetricSample(AbstractBaseModel, FolderMixin):
         if isinstance(self.value, str):
             try:
                 value_dict = json.loads(self.value)
-            except json.JSONDecodeError, TypeError:
+            except (json.JSONDecodeError, TypeError):
                 return "N/A"
         else:
             value_dict = self.value
@@ -513,7 +513,7 @@ class BuiltinMetricSample(AbstractBaseModel):
                 risk_levels = assessment.risk_matrix.risk or []
                 for idx, level in enumerate(risk_levels):
                     risk_level_labels[idx] = level.get("name", str(idx))
-            except KeyError, TypeError, AttributeError:
+            except (KeyError, TypeError, AttributeError):
                 pass
 
         current_level_counts = dict(
@@ -1212,5 +1212,5 @@ def get_builtin_metrics_retention_days():
         settings = GlobalSettings.objects.get(name="general")
         retention = settings.value.get("builtin_metrics_retention_days", 730)
         return max(1, int(retention))
-    except GlobalSettings.DoesNotExist, TypeError, ValueError:
+    except (GlobalSettings.DoesNotExist, TypeError, ValueError):
         return 730

--- a/backend/metrology/serializers.py
+++ b/backend/metrology/serializers.py
@@ -409,7 +409,7 @@ class DashboardWidgetReadSerializer(BaseModelSerializer):
                 model_class = obj.target_content_type.model_class()
                 target_obj = model_class.objects.get(id=obj.target_object_id)
                 return str(target_obj)
-            except model_class.DoesNotExist, AttributeError:
+            except (model_class.DoesNotExist, AttributeError):
                 return None
         return None
 

--- a/backend/metrology/views.py
+++ b/backend/metrology/views.py
@@ -29,7 +29,7 @@ def _user_can_read_target(user, content_type, object_id):
         object_uuid = (
             object_id if isinstance(object_id, uuid.UUID) else uuid.UUID(str(object_id))
         )
-    except ValueError, TypeError:
+    except (ValueError, TypeError):
         return False
     try:
         return RoleAssignment.is_object_readable(user, target_model, object_uuid)

--- a/backend/privacy/views.py
+++ b/backend/privacy/views.py
@@ -143,7 +143,7 @@ class PersonalDataViewSet(BaseModelViewSet):
 
         try:
             processing_uuid = uuid.UUID(str(processing_id))
-        except ValueError, AttributeError:
+        except (ValueError, AttributeError):
             return Response(
                 {"error": "Invalid processing ID"},
                 status=status.HTTP_400_BAD_REQUEST,

--- a/backend/scripts/convert_library_v2.py
+++ b/backend/scripts/convert_library_v2.py
@@ -856,7 +856,7 @@ def _handle_framework(obj, library, object_blocks, prefix_to_urn, compat_mode, v
                             try:
                                 score_to_add = int(val)
                                 choices[i]["add_score"] = score_to_add
-                            except TypeError, ValueError:
+                            except (TypeError, ValueError):
                                 raise ValueError(
                                     f"(answers_definition) Invalid add_score value '{val}' "
                                     f"for answer ID '{answer_id}', choice #{i + 1}. Must be an integer"
@@ -1135,7 +1135,7 @@ def _handle_framework(obj, library, object_blocks, prefix_to_urn, compat_mode, v
                     if (w := int(data["weight"])) <= 0:
                         raise ValueError
                     node["weight"] = w
-                except TypeError, ValueError:
+                except (TypeError, ValueError):
                     raise ValueError(
                         f"(framework) Invalid weight at row #{row[0].row}: {data['weight']}. Must be a strictly positive integer."
                     )
@@ -1150,7 +1150,7 @@ def _handle_framework(obj, library, object_blocks, prefix_to_urn, compat_mode, v
                 ):
                     try:
                         node[int_field] = int(data[int_field])
-                    except TypeError, ValueError:
+                    except (TypeError, ValueError):
                         raise ValueError(
                             f"(framework) Invalid {int_field} at row #{row[0].row}: "
                             f"{data[int_field]}. Must be an integer."
@@ -1291,7 +1291,7 @@ def _handle_metric_definitions(obj, library, compat_mode, verbose):
         if "default_target" in data and data["default_target"] is not None:
             try:
                 entry["default_target"] = float(data["default_target"])
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 raise ValueError(
                     f"(metric_definitions) Invalid default_target '{data['default_target']}' at row #{row[0].row}. Must be a number."
                 )

--- a/backend/sec_intel/feeds.py
+++ b/backend/sec_intel/feeds.py
@@ -409,7 +409,7 @@ class EUVDFeed:
             if epss is not None:
                 try:
                     epss_score = Decimal(str(epss)) / 100
-                except ValueError, ArithmeticError:
+                except (ValueError, ArithmeticError):
                     logger.warning("Invalid EPSS value", euvd_id=euvd_id, epss=epss)
 
             pub = entry.get("datePublished")

--- a/backend/serdes/views.py
+++ b/backend/serdes/views.py
@@ -450,7 +450,7 @@ class FullRestoreView(APIView):
                                 header = json.loads(block_data[:i].decode("utf-8"))
                                 header_end = i
                                 break
-                            except json.JSONDecodeError, UnicodeDecodeError:
+                            except (json.JSONDecodeError, UnicodeDecodeError):
                                 continue
 
                         if not header:
@@ -895,7 +895,7 @@ class BatchUploadAttachmentsView(APIView):
                             header = json.loads(block_data[:i].decode("utf-8"))
                             header_end = i
                             break
-                        except json.JSONDecodeError, UnicodeDecodeError:
+                        except (json.JSONDecodeError, UnicodeDecodeError):
                             continue
 
                     if not header:

--- a/backend/tprm/views.py
+++ b/backend/tprm/views.py
@@ -945,7 +945,7 @@ class EntityViewSet(ExportMixin, BaseModelViewSet):
 
             try:
                 folder = Folder.objects.get(id=uuid.UUID(str(folder_id)))
-            except ValueError, AttributeError, Folder.DoesNotExist:
+            except (ValueError, AttributeError, Folder.DoesNotExist):
                 return Response(
                     {"error": "Folder not found"},
                     status=status.HTTP_404_NOT_FOUND,


### PR DESCRIPTION
## Fix Python 3 syntax errors: parenthesize multi-type `except` clauses

### Problem
The backend currently **does not import on Python 3**. A prior formatting pass (#4335, "align to ruff v0.15.x and code quality recovery") removed the parentheses from every multi-exception `except` clause, leaving Python-2 syntax:

```python
except TypeError, ValueError:
```

On Python 3 this is a hard `SyntaxError`:

```
  File "backend/core/views.py", line 368
    except TypeError, ValueError:
           ^^^^^^^^^^^^^^^^^^^^^
SyntaxError: multiple exception types must be parenthesized
```

This affects **87 clauses across 37 files**, including core modules that are imported on every request — `core/views.py`, `core/serializers.py`, `core/models.py`, `core/focus_middleware.py` — so the application cannot start. (`backend/scripts/convert_library_v2.py` is affected too, which is what surfaced this for me while contributing framework libraries.)

### Fix
Wrap each multi-type `except` in a tuple:

```python
except (TypeError, ValueError):
```

This was applied mechanically and only to multi-type clauses (single-type `except X:` and `except X as e:` are untouched). No behavioral change.

### Verification
- `ast.parse` now succeeds for every `backend/**/*.py` (0 files failing; previously 37 failed).
- `python manage.py check` → **System check identified no issues (0 silenced)**.
- `manage.py migrate` + dev server boot succeed and the REST API serves requests (verified on a fresh SQLite instance).

### Note
Supersedes #4381, which fixed only `convert_library_v2.py`. This PR resolves the same class of issue across the whole backend. Happy to close #4381 once this is reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal code syntax for Python 3 compatibility across multiple backend modules. No user-facing changes or functional updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->