### PR TITLE
fix(security)!: harden IAM checks on integration and decomission fallback login endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,12 +717,12 @@ The goal of the test harness is to prevent any regression, i.e. all the tests sh
 
 To interact with the API via Swagger or directly with HTTP calls:
 
-1. Authenticate by sending a POST request to `/api/iam/login/` with your credentials in the request body. The response will include an authentication token.
+1. Create a Personal Access Token (PAT) from your user profile in the application.
 2. Include this token in the header of subsequent requests as: `Authorization: Token <token>`
 
 ⚠️ Note: use `Token`, **not** `Bearer`.
 
-When using the interactive Swagger UI, simply log in, the token will be automatically handled for subsequent requests.
+PATs respect MFA: they are issued from an authenticated session, so an account protected by MFA stays protected. For interactive/browser flows, authentication goes through the standard login (which enforces MFA when enabled).
 
 ## Setting CISO Assistant for production
 

--- a/backend/ciso_assistant/settings.py
+++ b/backend/ciso_assistant/settings.py
@@ -820,6 +820,7 @@ HUEY = {
 AUDITLOG_RETENTION_DAYS = int(os.environ.get("AUDITLOG_RETENTION_DAYS", 90))
 AUDITLOG_MAX_RECORDS = int(os.environ.get("AUDITLOG_MAX_RECORDS", 50000))
 
-WEBHOOK_ALLOW_PRIVATE_IPS = os.environ.get(
-    "WEBHOOK_ALLOW_PRIVATE_IPS", "False"
+# Allow outbound server-side requests (webhooks, integrations, LLM URLs) to private/loopback addresses
+ALLOW_PRIVATE_NETWORK_REQUESTS = os.environ.get(
+    "ALLOW_PRIVATE_NETWORK_REQUESTS", "False"
 ).lower() in ("true", "1", "yes")

--- a/backend/core/net_safety.py
+++ b/backend/core/net_safety.py
@@ -66,12 +66,10 @@ def assert_public_url(
 def assert_public_url_unless_dev(
     url: str, *, allowed_schemes: tuple[str, ...] = ("https",)
 ) -> None:
-    """assert_public_url, skipped when WEBHOOK_ALLOW_PRIVATE_IPS is set
-    (shared dev/loopback escape hatch across webhooks and integrations).
-    """
+    """assert_public_url, skipped when ALLOW_PRIVATE_NETWORK_REQUESTS is set."""
     from django.conf import settings
 
-    if getattr(settings, "WEBHOOK_ALLOW_PRIVATE_IPS", False):
+    if getattr(settings, "ALLOW_PRIVATE_NETWORK_REQUESTS", False):
         return
     assert_public_url(url, allowed_schemes=allowed_schemes)
 

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -19330,10 +19330,13 @@ class TaskNodeViewSet(BaseModelViewSet):
         detail=True, name="Remove/Move evidence to expected evidence", methods=["post"]
     )
     def remove_evidence(self, request, pk):
-        task_node = TaskNode.objects.get(id=pk)
+        task_node = self.get_object()
         evidence_id = request.data.get("evidence_id")
         to_move = request.data.get("move", False)
-        evidence = Evidence.objects.get(id=evidence_id)
+        accessible_evidence_ids = RoleAssignment.get_accessible_object_ids(
+            Folder.get_root_folder(), request.user, Evidence
+        )[0]
+        evidence = Evidence.objects.get(id=evidence_id, id__in=accessible_evidence_ids)
         task_node.evidences.remove(evidence)
         if to_move:
             task_node.task_template.evidences.add(evidence)

--- a/backend/doc_management/views.py
+++ b/backend/doc_management/views.py
@@ -490,7 +490,7 @@ class DocumentRevisionViewSet(BaseModelViewSet):
 
         # Generate PDF snapshot
         try:
-            self._generate_pdf_snapshot(revision)
+            self._generate_pdf_snapshot(revision, request.user)
         except Exception as e:
             logger.warning("Failed to generate PDF snapshot", error=str(e))
 
@@ -591,13 +591,15 @@ class DocumentRevisionViewSet(BaseModelViewSet):
         )
 
     @staticmethod
-    def _inline_images(html_content):
+    def _inline_images(html_content, accessible_ids):
         """Replace document attachment image URLs with base64 data URIs for PDF export."""
         import base64
         import re
 
         def replace_match(match):
             attachment_id = match.group(1)
+            if UUID(attachment_id) not in accessible_ids:
+                return match.group(0)
             try:
                 attachment = DocumentAttachment.objects.get(pk=attachment_id)
                 if attachment.file and attachment.file.storage.exists(
@@ -626,7 +628,7 @@ class DocumentRevisionViewSet(BaseModelViewSet):
     def export_pdf(self, request, pk=None):
         """Export revision content as a PDF document."""
         revision = self.get_object()
-        pdf = self._render_pdf_bytes(revision)
+        pdf = self._render_pdf_bytes(revision, request.user)
         response = HttpResponse(pdf, content_type="application/pdf")
         filename = slugify(revision.document.display_name)
         response["Content-Disposition"] = (
@@ -638,7 +640,7 @@ class DocumentRevisionViewSet(BaseModelViewSet):
     def status(self, request):
         return Response(dict(DocumentRevision.Status.choices))
 
-    def _render_pdf_bytes(self, revision):
+    def _render_pdf_bytes(self, revision, user):
         """Render a revision to PDF bytes (shared by export and snapshot)."""
         import markdown as md_lib
 
@@ -646,7 +648,10 @@ class DocumentRevisionViewSet(BaseModelViewSet):
             revision.content,
             extensions=["tables", "fenced_code", "toc", "nl2br"],
         )
-        content_html = self._inline_images(content_html)
+        accessible_ids = RoleAssignment.get_accessible_object_ids(
+            Folder.get_root_folder(), user, DocumentAttachment
+        )[0]
+        content_html = self._inline_images(content_html, set(accessible_ids))
         author_name = ""
         if revision.author:
             author_name = (
@@ -673,11 +678,11 @@ class DocumentRevisionViewSet(BaseModelViewSet):
 
         return HTML(string=html_string, url_fetcher=_safe_url_fetcher).write_pdf()
 
-    def _generate_pdf_snapshot(self, revision):
+    def _generate_pdf_snapshot(self, revision, user):
         """Generate and save a PDF snapshot for a revision."""
         from django.core.files.base import ContentFile
 
-        pdf_content = self._render_pdf_bytes(revision)
+        pdf_content = self._render_pdf_bytes(revision, user)
         filename = slugify(revision.document.display_name)
         revision.pdf_snapshot.save(
             f"{filename}_v{revision.version_number}.pdf",

--- a/backend/global_settings/serializers.py
+++ b/backend/global_settings/serializers.py
@@ -96,6 +96,11 @@ GENERAL_SETTINGS_KEYS = [
     "audit_tree_aggregation_strategy",
 ]
 
+LLM_URL_DEFAULTS = {
+    "ollama_base_url": "http://localhost:11434",
+    "openai_api_base": "http://localhost:1234/v1",
+}
+
 
 class GlobalSettingsSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
@@ -162,18 +167,20 @@ class GeneralSettingsSerializer(serializers.ModelSerializer):
                     raise serializers.ValidationError(
                         {key: "URL must not contain a fragment (#)."}
                     )
-                try:
-                    assert_public_url_unless_dev(
-                        value, allowed_schemes=("http", "https")
-                    )
-                except BlockedRequestError:
-                    raise serializers.ValidationError(
-                        {key: "URL must point to a public address."}
-                    )
-                except DnsLookupError:
-                    raise serializers.ValidationError(
-                        {key: "URL hostname could not be resolved."}
-                    )
+                stored = (instance.value or {}).get(key)
+                if value != stored and value != LLM_URL_DEFAULTS.get(key):
+                    try:
+                        assert_public_url_unless_dev(
+                            value, allowed_schemes=("http", "https")
+                        )
+                    except BlockedRequestError:
+                        raise serializers.ValidationError(
+                            {key: "URL must point to a public address."}
+                        )
+                    except DnsLookupError:
+                        raise serializers.ValidationError(
+                            {key: "URL hostname could not be resolved."}
+                        )
             # Validate builtin_metrics_retention_days minimum value
             if key == "builtin_metrics_retention_days":
                 if not isinstance(value, int) or value < 1:

--- a/backend/global_settings/serializers.py
+++ b/backend/global_settings/serializers.py
@@ -7,6 +7,11 @@ from rest_framework import serializers
 
 from urllib.parse import urlparse
 
+from core.net_safety import (
+    BlockedRequestError,
+    DnsLookupError,
+    assert_public_url_unless_dev,
+)
 from .models import GlobalSettings
 
 
@@ -156,6 +161,18 @@ class GeneralSettingsSerializer(serializers.ModelSerializer):
                 if "#" in value:
                     raise serializers.ValidationError(
                         {key: "URL must not contain a fragment (#)."}
+                    )
+                try:
+                    assert_public_url_unless_dev(
+                        value, allowed_schemes=("http", "https")
+                    )
+                except BlockedRequestError:
+                    raise serializers.ValidationError(
+                        {key: "URL must point to a public address."}
+                    )
+                except DnsLookupError:
+                    raise serializers.ValidationError(
+                        {key: "URL hostname could not be resolved."}
                     )
             # Validate builtin_metrics_retention_days minimum value
             if key == "builtin_metrics_retention_days":

--- a/backend/iam/serializers.py
+++ b/backend/iam/serializers.py
@@ -1,5 +1,5 @@
 import structlog
-from django.contrib.auth import authenticate, password_validation
+from django.contrib.auth import password_validation
 from rest_framework import serializers
 
 from core.serializer_fields import FieldsRelatedField
@@ -7,36 +7,6 @@ from core.serializer_fields import FieldsRelatedField
 from .models import PersonalAccessToken, User
 
 logger = structlog.get_logger(__name__)
-
-
-class LoginSerializer(serializers.Serializer):
-    username = serializers.CharField(write_only=True)
-    password = serializers.CharField(
-        # This will be used when the DRF browsable API is enabled
-        style={"input_type": "password"},
-        trim_whitespace=False,
-        write_only=True,
-    )
-
-    def validate(self, attrs):
-        username = attrs.get("username")
-        password = attrs.get("password")
-
-        if username and password:
-            user = authenticate(
-                request=self.context.get("request"),
-                username=username,
-                password=password,
-            )
-            if not user:
-                msg = "Unable to log in with provided credentials."
-                raise serializers.ValidationError(msg, code="authorization")
-        else:
-            msg = 'Must include "username" and "password".'
-            raise serializers.ValidationError(msg, code="authorization")
-
-        attrs["user"] = user
-        return attrs
 
 
 class ChangePasswordSerializer(serializers.Serializer):

--- a/backend/iam/urls.py
+++ b/backend/iam/urls.py
@@ -6,7 +6,6 @@ from .views import (
     PersonalAccessTokenViewSet,
     ChangePasswordView,
     CurrentUserView,
-    LoginView,
     PasswordResetView,
     ResetPasswordConfirmView,
     SessionTokenView,
@@ -15,7 +14,6 @@ from .views import (
 )
 
 urlpatterns = [
-    path(r"login/", LoginView.as_view(), name="knox_login"),
     path(r"logout/", knox_views.LogoutView.as_view(), name="knox_logout"),
     path(r"logoutall/", knox_views.LogoutAllView.as_view(), name="knox_logoutall"),
     path("current-user/", CurrentUserView.as_view(), name="current-user"),

--- a/backend/iam/views.py
+++ b/backend/iam/views.py
@@ -15,9 +15,7 @@ from knox import crypto
 from knox.auth import TokenAuthentication, get_token_model, knox_settings
 from knox.models import AuthToken
 from knox.views import DateTimeField
-from knox.views import LoginView as KnoxLoginView
 from rest_framework import permissions, serializers, status, views
-from rest_framework.authtoken.serializers import AuthTokenSerializer
 from rest_framework.response import Response
 from rest_framework.status import (
     HTTP_200_OK,
@@ -33,7 +31,6 @@ from core.models import Actor
 from .models import Folder, PersonalAccessToken, Role, RoleAssignment
 from .serializers import (
     ChangePasswordSerializer,
-    LoginSerializer,
     PersonalAccessTokenReadSerializer,
     ResetPasswordConfirmSerializer,
     SetPasswordSerializer,
@@ -42,18 +39,6 @@ from .serializers import (
 logger = structlog.get_logger(__name__)
 
 User = get_user_model()
-
-
-class LoginView(KnoxLoginView):
-    permission_classes = (permissions.AllowAny,)
-    serializer_class = LoginSerializer
-
-    def post(self, request, format=None):
-        serializer = AuthTokenSerializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        user = serializer.validated_data["user"]
-        login(request, user)
-        return super(LoginView, self).post(request, format=None)
 
 
 class LogoutView(views.APIView):

--- a/backend/integrations/serializers.py
+++ b/backend/integrations/serializers.py
@@ -4,7 +4,8 @@ from django.urls import reverse
 from django.utils.crypto import get_random_string
 from rest_framework import serializers
 
-from iam.models import Folder
+from core.serializers import BaseModelSerializer
+from iam.models import Folder, RoleAssignment
 from .models import IntegrationProvider, IntegrationConfiguration, SyncMapping
 from .registry import IntegrationRegistry
 
@@ -69,7 +70,7 @@ class ConnectionTestSerializer(serializers.Serializer):
         return data
 
 
-class IntegrationConfigurationSerializer(serializers.ModelSerializer):
+class IntegrationConfigurationSerializer(BaseModelSerializer):
     """
     Serializer for creating, reading, and updating IntegrationConfiguration instances.
     """
@@ -87,7 +88,7 @@ class IntegrationConfigurationSerializer(serializers.ModelSerializer):
     folder = serializers.StringRelatedField(read_only=True)
     # On write, accept the folder's primary key
     folder_id = serializers.PrimaryKeyRelatedField(
-        queryset=Folder.objects.all(),  # You might want to filter this based on user permissions
+        queryset=Folder.objects.all(),
         source="folder",
         label="Folder ID",
     )
@@ -99,6 +100,17 @@ class IntegrationConfigurationSerializer(serializers.ModelSerializer):
 
     has_api_token = serializers.SerializerMethodField()
     has_webhook_secret = serializers.SerializerMethodField()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        request = self.context.get("request")
+        if request is not None and "folder_id" in self.fields:
+            accessible_folders = RoleAssignment.get_accessible_object_ids(
+                Folder.get_root_folder(), request.user, Folder
+            )[0]
+            self.fields["folder_id"].queryset = Folder.objects.filter(
+                id__in=accessible_folders
+            )
 
     class Meta:
         model = IntegrationConfiguration
@@ -187,7 +199,7 @@ class IntegrationConfigurationSerializer(serializers.ModelSerializer):
             # Raise a validation error that DRF can render nicely
             raise serializers.ValidationError({"provider_specific_errors": errors})
 
-        return data
+        return super().validate(data)
 
 
 # Aliases expected by BaseModelViewSet's SerializerFactory

--- a/backend/webhooks/models.py
+++ b/backend/webhooks/models.py
@@ -134,7 +134,7 @@ class WebhookEndpoint(NameDescriptionMixin, FolderMixin):
         super().clean()
         if self.transport != self.Transport.HTTP:
             return
-        if getattr(settings, "WEBHOOK_ALLOW_PRIVATE_IPS", False):
+        if getattr(settings, "ALLOW_PRIVATE_NETWORK_REQUESTS", False):
             return
         try:
             assert_public_url(self.url, allowed_schemes=("http", "https"))

--- a/backend/webhooks/test_audit_forwarding.py
+++ b/backend/webhooks/test_audit_forwarding.py
@@ -33,7 +33,7 @@ def domain_folder(db, root_folder):
 
 
 def _make_audit_sink(folder, **kwargs):
-    with override_settings(WEBHOOK_ALLOW_PRIVATE_IPS=True):
+    with override_settings(ALLOW_PRIVATE_NETWORK_REQUESTS=True):
         defaults = dict(
             name="siem",
             url="https://siem.example/collector",
@@ -218,7 +218,7 @@ def test_replay_respects_folder_scope(root_folder, domain_folder):
 
 
 @pytest.mark.django_db
-@override_settings(WEBHOOK_ALLOW_PRIVATE_IPS=True)
+@override_settings(ALLOW_PRIVATE_NETWORK_REQUESTS=True)
 def test_send_audit_request_uses_static_headers_no_hmac(root_folder):
     ep = _make_audit_sink(root_folder)
     mock_response = MagicMock()
@@ -385,7 +385,7 @@ def test_update_preserves_headers_when_omitted(root_folder):
     from webhooks.serializers import AuditSinkSerializer
 
     ep = _make_audit_sink(root_folder, headers={"Authorization": "Splunk token"})
-    with override_settings(WEBHOOK_ALLOW_PRIVATE_IPS=True):
+    with override_settings(ALLOW_PRIVATE_NETWORK_REQUESTS=True):
         AuditSinkSerializer().update(ep, {"url": "https://siem.example/v2"})
     ep.refresh_from_db()
     assert ep.url == "https://siem.example/v2"

--- a/backend/webhooks/tests.py
+++ b/backend/webhooks/tests.py
@@ -12,7 +12,7 @@ from webhooks.tasks import send_webhook_request
 
 @pytest.fixture
 def public_endpoint(db):
-    with override_settings(WEBHOOK_ALLOW_PRIVATE_IPS=True):
+    with override_settings(ALLOW_PRIVATE_NETWORK_REQUESTS=True):
         return WebhookEndpoint.objects.create(
             name="public",
             url="https://example.com/hook",
@@ -24,9 +24,9 @@ def public_endpoint(db):
 @pytest.fixture
 def private_endpoint(db):
     """WebhookEndpoint pointing at a private IP. Bypasses the save-time
-    guard via WEBHOOK_ALLOW_PRIVATE_IPS to simulate a pre-existing
+    guard via ALLOW_PRIVATE_NETWORK_REQUESTS to simulate a pre-existing
     record or post-save DNS flip."""
-    with override_settings(WEBHOOK_ALLOW_PRIVATE_IPS=True):
+    with override_settings(ALLOW_PRIVATE_NETWORK_REQUESTS=True):
         return WebhookEndpoint.objects.create(
             name="private",
             url="http://10.0.0.1/admin",
@@ -36,7 +36,7 @@ def private_endpoint(db):
 
 
 @pytest.mark.django_db
-@override_settings(WEBHOOK_ALLOW_PRIVATE_IPS=False)
+@override_settings(ALLOW_PRIVATE_NETWORK_REQUESTS=False)
 def test_blocked_url_returns_terminally(private_endpoint):
     # Permanent policy denial must be terminal: return (not raise) so
     # Huey doesn't retry 5x with fresh webhook-ids.
@@ -47,7 +47,7 @@ def test_blocked_url_returns_terminally(private_endpoint):
 
 
 @pytest.mark.django_db
-@override_settings(WEBHOOK_ALLOW_PRIVATE_IPS=False)
+@override_settings(ALLOW_PRIVATE_NETWORK_REQUESTS=False)
 def test_redirect_returns_terminally(public_endpoint):
     # 3xx must not be followed and must not trigger retries — each
     # retry would mint a new webhook-id, so a 307/308 target would see
@@ -64,7 +64,7 @@ def test_redirect_returns_terminally(public_endpoint):
 
 
 @pytest.mark.django_db
-@override_settings(WEBHOOK_ALLOW_PRIVATE_IPS=False)
+@override_settings(ALLOW_PRIVATE_NETWORK_REQUESTS=False)
 def test_dns_failure_is_transient_and_propagates(public_endpoint):
     # DnsLookupError must propagate so Huey retries; it must NOT be
     # caught by the BlockedRequestError handler.
@@ -79,7 +79,7 @@ def test_dns_failure_is_transient_and_propagates(public_endpoint):
 
 
 @pytest.mark.django_db
-@override_settings(WEBHOOK_ALLOW_PRIVATE_IPS=False)
+@override_settings(ALLOW_PRIVATE_NETWORK_REQUESTS=False)
 def test_5xx_raises_for_retry(public_endpoint):
     # Non-redirect non-2xx must raise so Huey retries the transient
     # remote failure.
@@ -94,7 +94,7 @@ def test_5xx_raises_for_retry(public_endpoint):
 
 
 @pytest.mark.django_db
-@override_settings(WEBHOOK_ALLOW_PRIVATE_IPS=True)
+@override_settings(ALLOW_PRIVATE_NETWORK_REQUESTS=True)
 def test_allow_private_ips_bypasses_guard(private_endpoint):
     # Dev escape hatch: the SSRF check is skipped.
     mock_response = MagicMock()

--- a/dispatcher/README.md
+++ b/dispatcher/README.md
@@ -128,8 +128,7 @@ The dispatcher authenticates with a Personal Access Token (PAT) that you generat
 > [!IMPORTANT]
 > The token is tied to a CISO Assistant user and inherits their permissions. Issue it from a dedicated service account scoped to only what the dispatcher needs.
 
-> [!NOTE]
-> PATs are issued from an authenticated session, so MFA on the account stays effective. If the API returns `401`, the token is invalid or expired — generate a new PAT and update `USER_TOKEN`.
+PATs are issued from an authenticated session, so MFA on the account stays effective. If the API returns `401`, the token is invalid or expired — generate a new PAT and update `USER_TOKEN`.
 
 ### S3 storage configuration
 

--- a/dispatcher/README.md
+++ b/dispatcher/README.md
@@ -69,8 +69,7 @@ The **CISO Assistant Dispatcher** is a command-line tool that bridges event-driv
    --name ciso-assistant-dispatcher \
    -e API_URL=https://localhost:8443 \
    -e BOOTSTRAP_SERVERS=localhost:9092 \
-   -e USER_EMAIL=user@company.org \
-   -e USER_PASSWORD=your_password \
+   -e USER_TOKEN=your_ciso_assistant_access_token \
    ciso-assistant-dispatcher
    ```
 
@@ -87,10 +86,7 @@ You can configure the dispatcher using environment variables, the `init-config` 
 DEBUG=True/False # Set to true to enable debug logging
 
 API_URL=https://localhost:8443 # The URL of the CISO Assistant REST API
-USER_EMAIL=user@company.org # The email address of the CISO Assistant user to authenticate with
-USER_PASSWORD=your_password # The password of the CISO Assistant user to authenticate with
-AUTO_RENEW_SESSION=True/False # Set to True to enable automatic token refresh, do not set if using token-based authentication
-USER_TOKEN=your_ciso_assistant_access_token # Personal Access Token, do not set if using credentials-based authentication
+USER_TOKEN=your_ciso_assistant_access_token # Personal Access Token used to authenticate to the CISO Assistant API
 VERIFY_CERTIFICATE=True/False # Set to True to verify SSL certificates between the dispatcher and API
 BOOTSTRAP_SERVERS=localhost:9092 # The Kafka bootstrap servers, comma separated list
 KAFKA_USE_AUTH=False # Set to True to enable authentication to Kafka
@@ -120,46 +116,20 @@ rest:
   url: "https://localhost:8443"
   verify_certificate: True
 credentials:
-  email: "user@company.org"
-  password: ""
+  token: ""
 ```
 
-Update this file with your actual REST API credentials.
+Update this file with your actual access token.
 
 ### Authentication to the CISO Assistant API
 
-Use the `auth` command to authenticate with the CISO Assistant API.
-There are currently two modes of authentication supported by the dispatcher:
-
-- Token-based authentication
-- Credentials-based authentication
+The dispatcher authenticates with a Personal Access Token (PAT) that you generate in CISO Assistant (from your user profile). Set it via the `USER_TOKEN` environment variable, in the configuration file, or during interactive configuration with `init-config -i`.
 
 > [!IMPORTANT]
-> Whichever mode you choose, it is tied to a CISO Assistant user and will inherit their permissions.
+> The token is tied to a CISO Assistant user and inherits their permissions. Issue it from a dedicated service account scoped to only what the dispatcher needs.
 
-#### Token-based authentication
-
-This is done using a Personal Access Token (PAT) that you can generate in CISO Assistant.
-To use token-based authentication, you need to set the `USER_TOKEN` environment variable or specify it in the configuration file or during interactive configuration definition using the `init-config` with the `-i` flag enabled.
-
-#### Credentials-based authentication
-
-This is done using your email and password. You can specify these credentials in the configuration file or pass them as command-line arguments to the `auth` command.
-
-```bash
-python dispatcher.py auth --email your_email@company.org --password your_password
-```
-
-If you have specified the credentials in the configuration file, or in the `USER_EMAIL` and `USER_PASSWORD` environment variables, you can skip the `--email` and `--password` arguments.
-
-> [!WARNING]
-> Multi-factor authentication is not yet supported in the dispatcher. Accounts with MFA enabled will not be able to authenticate using the dispatcher.
-
-#### Automatic token refresh
-
-Using credentials-based authentication, it is possible to enable silent re-authentication on token expiration. You can do so using the `auto_renew_session` setting. As usual, it can be set either as an environment variable or in the configuration file.
-
-The authentication token will be saved in a temporary file (`.tmp.yaml`).
+> [!NOTE]
+> PATs are issued from an authenticated session, so MFA on the account stays effective. If the API returns `401`, the token is invalid or expired — generate a new PAT and update `USER_TOKEN`.
 
 ### S3 storage configuration
 

--- a/dispatcher/dispatcher.py
+++ b/dispatcher/dispatcher.py
@@ -3,7 +3,6 @@ import sys
 import click
 import requests
 import json
-import yaml
 from kafka import KafkaConsumer, KafkaProducer
 from kafka.errors import NoBrokersAvailable, UnsupportedCodecError
 
@@ -42,46 +41,12 @@ def cli():
     pass
 
 
-def _auth(email, password):
-    """Authenticate to get a temp token (config file or params). Pass the email and password or set them on the config file"""
-    url = f"{settings.API_URL}/iam/login/"
-    if email and password:
-        data = {"username": email, "password": password}
-    else:
-        logger.info("trying credentials from the config file")
-        if settings.USER_EMAIL and settings.USER_PASSWORD:
-            data = {"username": settings.USER_EMAIL, "password": settings.USER_PASSWORD}
-        else:
-            logger.error("Could not find any usable credentials.")
-            sys.exit(1)
-    headers = {"accept": "application/json", "Content-Type": "application/json"}
-
-    res = api.post(url, json=data, headers=headers, verify=settings.VERIFY_CERTIFICATE)
-    if res.ok:
-        with open(".tmp.yaml", "w") as yfile:
-            yaml.safe_dump(res.json(), yfile)
-            logger.success("Successfully authenticated. Token saved to .tmp.yaml")
-        api.update_session_token()
-    else:
-        logger.error(
-            "Authentication failed. Check your credentials again. You can set them on the config file or on the command line.",
-        )
-        sys.exit(1)
-
-
-@click.command()
-@click.option("--email", required=False)
-@click.option("--password", required=False)
-def auth(email: str, password: str):
-    """Authenticate to get a temp token (config file or params). Pass the email and password or set them on the config file"""
-    return _auth(email, password)
-
-
 @click.command()
 def consume():
     """
     Consume messages from the Kafka topic and process them.
     """
+    api.update_session_token()
     kafka_cfg = build_kafka_config()
     logger.info("Starting consumer", bootstrap_servers=settings.BOOTSTRAP_SERVERS)
     try:
@@ -148,23 +113,11 @@ def consume():
                             f"Request failed with status code {e.response.status_code} and message: {e.response.text}"
                         )
                         if e.response.status_code == 401:
-                            if not settings.AUTO_RENEW_SESSION:
-                                logger.error(
-                                    "Session expired. Please run the `auth` command."
-                                )
-                                raise
-                            try:
-                                logger.debug(
-                                    "Automatic session renewal enabled, attempting silent reauthentication."
-                                )
-                                _auth(settings.USER_EMAIL, settings.USER_PASSWORD)
-                                continue
-                            except Exception as e:
-                                logger.error(
-                                    "Silent reauthentication failed. Please run the `auth` command.",
-                                    e,
-                                )
-                                raise
+                            logger.error(
+                                "Authentication failed (401). The access token is invalid or expired. "
+                                "Provision a new Personal Access Token in CISO Assistant and update USER_TOKEN."
+                            )
+                            raise
                         raise
 
                 except Exception as e:
@@ -192,7 +145,6 @@ def consume():
         error_producer.close()
 
 
-cli.add_command(auth)
 cli.add_command(consume)
 cli.add_command(init_config)
 

--- a/dispatcher/settings.py
+++ b/dispatcher/settings.py
@@ -126,6 +126,7 @@ def init_config(y, interactive):
         access_token = click.prompt(
             "Enter the Personal Access Token used to authenticate the dispatcher to the CISO Assistant API.",
             hide_input=True,
+            show_default=False,
             default=os.getenv("USER_TOKEN", ""),
         )
 

--- a/dispatcher/settings.py
+++ b/dispatcher/settings.py
@@ -44,8 +44,6 @@ def load_env_config():
         },
         "credentials": {
             "token": os.getenv("USER_TOKEN"),
-            "email": os.getenv("USER_EMAIL"),
-            "password": os.getenv("USER_PASSWORD"),
         },
         "kafka": {
             "use_auth": os.getenv("KAFKA_USE_AUTH") == "True" or None,
@@ -54,7 +52,6 @@ def load_env_config():
             "sasl_plain_username": os.getenv("KAFKA_USERNAME"),
             "sasl_plain_password": os.getenv("KAFKA_PASSWORD"),
         },
-        "auto_renew_session": os.getenv("AUTO_RENEW_SESSION") == "True" or None,
         "bootstrap_servers": os.getenv("BOOTSTRAP_SERVERS"),
         "errors_topic": os.getenv("ERRORS_TOPIC"),
         "s3_url": os.getenv("S3_URL"),
@@ -126,40 +123,11 @@ def init_config(y, interactive):
             default=verify_default,
         )
 
-        authentication_mode = click.prompt(
-            "Enter your mode of authentication (credentials/token)",
-            default="credentials",
+        access_token = click.prompt(
+            "Enter the Personal Access Token used to authenticate the dispatcher to the CISO Assistant API.",
+            hide_input=True,
+            default=os.getenv("USER_TOKEN", ""),
         )
-
-        auto_renew_session = False
-        user_email = None
-        user_password = None
-        access_token = None
-
-        if authentication_mode == "credentials":
-            user_email = click.prompt(
-                "Enter the email of the CISO Assistant user account. This is the user account that will be used to authenticate the dispatcher to the CISO Assistant API.",
-                default=os.getenv("USER_EMAIL", "user@company.org"),
-            )
-            # Use confirmation_prompt for passwords to ensure they match.
-            user_password = click.prompt(
-                "Enter the password of the CISO Assistant user account",
-                hide_input=True,
-                confirmation_prompt=True,
-                default=os.getenv("USER_PASSWORD", ""),
-            )
-            auto_renew_default = os.getenv("AUTO_RENEW_SESSION", "True") == "True"
-            auto_renew_session = click.confirm(
-                "Enable silent reauthentication on session expiry?",
-                default=auto_renew_default,
-            )
-
-        else:
-            access_token = click.prompt(
-                "Enter access token",
-                hide_input=True,
-                default=os.getenv("USER_TOKEN", ""),
-            )
 
         bootstrap_servers = click.prompt(
             "Enter the URLs of the Kafka brokers (comma-separated), e.g., 'localhost:9092'",
@@ -233,8 +201,6 @@ def init_config(y, interactive):
             },
             "credentials": {
                 "token": access_token,
-                "email": user_email,
-                "password": user_password,
             },
             "kafka": {
                 "use_auth": kafka_use_auth,
@@ -243,7 +209,6 @@ def init_config(y, interactive):
                 "sasl_plain_password": kafka_password,
                 "security_protocol": kafka_security_protocol,
             },
-            "auto_renew_session": auto_renew_session,
             "bootstrap_servers": bootstrap_servers,
             "errors_topic": errors_topic,
             "s3_url": s3_url,
@@ -276,9 +241,9 @@ if "rest" not in config or "url" not in config["rest"]:
     )
     sys.exit(1)
 creds = config.get("credentials", {})
-if not (creds.get("token") or (creds.get("email") and creds.get("password"))):
+if not creds.get("token"):
     logger.warning(
-        "Missing credentials in configuration. Please set USER_EMAIL and USER_PASSWORD via environment variables or in the config file.",
+        "Missing access token in configuration. Please set USER_TOKEN (a Personal Access Token) via environment variables or in the config file.",
     )
 
 DEBUG = config.get("debug", False)
@@ -286,9 +251,6 @@ API_URL = config.get("rest", {}).get("url", "https://localhost:8443")
 if API_URL:
     API_URL = API_URL.rstrip("/")
 VERIFY_CERTIFICATE = config.get("rest", {}).get("verify_certificate", True)
-USER_EMAIL = config["credentials"].get("email", "user@company.org")
-USER_PASSWORD = config["credentials"].get("password", "")
-AUTO_RENEW_SESSION = config.get("auto_renew_session", False)
 BOOTSTRAP_SERVERS = config.get("bootstrap_servers", "localhost:9092")
 KAFKA_USE_AUTH = config.get("kafka", {}).get("use_auth", False)
 KAFKA_SASL_MECHANISM = config.get("kafka", {}).get("sasl_mechanism", "PLAIN")

--- a/dispatcher/settings.py
+++ b/dispatcher/settings.py
@@ -266,22 +266,12 @@ S3_ACCESS_KEY = config.get("s3_access_key", "")
 S3_SECRET_KEY = config.get("s3_secret_key", "")
 
 
-def get_access_token(token_file=".tmp.yaml", user_token=None):
-    """Retrieve the access token from environment or a temporary YAML file."""
+def get_access_token(user_token=None):
+    """Retrieve the access token (a Personal Access Token) from config or environment."""
     if user_token is None:
         user_token = config["credentials"].get("token")
     if user_token:
         return user_token
 
-    token_path = Path(token_file)
-    if token_path.exists():
-        try:
-            with token_path.open("r") as file:
-                auth_data = yaml.safe_load(file)
-            return auth_data.get("token")
-        except Exception as e:
-            logger.error(f"Error reading token file: {e}")
-            return None
-    else:
-        click.echo("Authentication data not found.", err=True)
-        return None
+    click.echo("No access token configured. Set USER_TOKEN.", err=True)
+    return None

--- a/dispatcher/tests/integration/test_messages.py
+++ b/dispatcher/tests/integration/test_messages.py
@@ -70,21 +70,3 @@ def test_dispatcher_is_running(
     result = cli.invoke(ds.cli, ["--help"])
     assert result.exit_code == 0
     assert "Usage:" in result.output
-
-
-def test_dispatcher_can_authenticate_using_credentials(
-    cli: CliRunner, api: DockerContainer
-):
-    result = cli.invoke(
-        ds.cli,
-        [
-            "auth",
-            "--email",
-            DJANGO_SUPERUSER_EMAIL,
-            "--password",
-            DJANGO_SUPERUSER_PASSWORD,
-        ],
-    )
-    assert result.exit_code == 0
-    print(vars(result))
-    assert "Successfully authenticated" in result.output

--- a/enterprise/backend/enterprise_core/settings.py
+++ b/enterprise/backend/enterprise_core/settings.py
@@ -793,6 +793,7 @@ HUEY = {
 AUDITLOG_RETENTION_DAYS = int(os.environ.get("AUDITLOG_RETENTION_DAYS", 90))
 AUDITLOG_MAX_RECORDS = int(os.environ.get("AUDITLOG_MAX_RECORDS", 50000))
 
-WEBHOOK_ALLOW_PRIVATE_IPS = os.environ.get(
-    "WEBHOOK_ALLOW_PRIVATE_IPS", "False"
+# Allow outbound server-side requests (webhooks, integrations, LLM URLs) to private/loopback addresses
+ALLOW_PRIVATE_NETWORK_REQUESTS = os.environ.get(
+    "ALLOW_PRIVATE_NETWORK_REQUESTS", "False"
 ).lower() in ("true", "1", "yes")

--- a/enterprise/offline-deployment.md
+++ b/enterprise/offline-deployment.md
@@ -164,8 +164,9 @@ LICENSE_EXPIRATION=2025-12-31
 AUDITLOG_RETENTION_DAYS=90
 AUDITLOG_MAX_RECORDS=50000
 
-# Webhook configuration
-# WEBHOOK_ALLOW_PRIVATE_IPS=False
+# Allow outbound server-side requests (webhooks, integrations, chat LLM endpoints)
+# to target private/loopback addresses. Required for local LLMs (e.g. Ollama). Default False.
+# ALLOW_PRIVATE_NETWORK_REQUESTS=False
 
 # Logging
 # LOG_LEVEL=INFO

--- a/enterprise/offline-deployment.md
+++ b/enterprise/offline-deployment.md
@@ -166,6 +166,7 @@ AUDITLOG_MAX_RECORDS=50000
 
 # Allow outbound server-side requests (webhooks, integrations, chat LLM endpoints)
 # to target private/loopback addresses. Required for local LLMs (e.g. Ollama). Default False.
+# Renamed from WEBHOOK_ALLOW_PRIVATE_IPS; the old name is no longer recognized.
 # ALLOW_PRIVATE_NETWORK_REQUESTS=False
 
 # Logging

--- a/product-docs/configuration/settings/general.md
+++ b/product-docs/configuration/settings/general.md
@@ -47,6 +47,10 @@ These settings drive the optional AI features (chat mode, agentic workflows, RAG
 - **Embedding backend** — which backend powers semantic search over knowledge.
 - **Chat system prompt** — system prompt prepended to chat-mode conversations.
 
+{% hint style="warning" %}
+**Local or self-hosted LLMs.** The **Ollama URL** and OpenAI **API base URL** are checked when you save them and must resolve to a public address — private, loopback, and internal IPs are rejected to prevent server-side request forgery (SSRF). To point at a local or in-network model (for example Ollama on `localhost`, LM Studio, or an in-cluster endpoint), start the backend with the environment variable `ALLOW_PRIVATE_NETWORK_REQUESTS=True`.
+{% endhint %}
+
 ## Analytics
 
 - **Default custom analytics dashboard** — UUID of the dashboard shown by default on the analytics page.

--- a/product-docs/configuration/settings/general.md
+++ b/product-docs/configuration/settings/general.md
@@ -48,7 +48,7 @@ These settings drive the optional AI features (chat mode, agentic workflows, RAG
 - **Chat system prompt** — system prompt prepended to chat-mode conversations.
 
 {% hint style="warning" %}
-**Local or self-hosted LLMs.** The **Ollama URL** and OpenAI **API base URL** are checked when you save them and must resolve to a public address — private, loopback, and internal IPs are rejected to prevent server-side request forgery (SSRF). To point at a local or in-network model (for example Ollama on `localhost`, LM Studio, or an in-cluster endpoint), start the backend with the environment variable `ALLOW_PRIVATE_NETWORK_REQUESTS=True`.
+**Local or self-hosted LLMs.** The **Ollama URL** and OpenAI **API base URL** are checked when you save them and must resolve to a public address — private, loopback, and internal IPs are rejected to prevent server-side request forgery (SSRF). To point at a local or in-network model (for example Ollama on `localhost`, LM Studio, or an in-cluster endpoint), start the backend with the environment variable `ALLOW_PRIVATE_NETWORK_REQUESTS=True`. (This variable was previously named `WEBHOOK_ALLOW_PRIVATE_IPS`; the old name is no longer recognized.)
 {% endhint %}
 
 ## Analytics

--- a/product-docs/integrations/audit-log-forwarding.md
+++ b/product-docs/integrations/audit-log-forwarding.md
@@ -132,7 +132,7 @@ The field-level diff and the originating domain (`folder_id`) ride in `unmapped`
 ## Operational details
 
 - **Delivery & retries.** HTTP delivery treats any `2xx` as success. `4xx`/`5xx` responses and network errors or timeouts are retried — up to 5 times with exponential backoff (60s, then doubling, ~30 minutes total) — before the event is dropped. Redirects (`3xx`) are **not** followed and count as a terminal failure (no retry). Kafka delivery retries on producer errors. Forwarding is best-effort — replay is the backstop for gaps.
-- **Egress safety.** Every HTTP sink URL is validated to point at a public host (no private, loopback, or internal addresses) at save time and again at send time; redirects are not followed.
+- **Egress safety.** Every HTTP sink URL is validated to point at a public host (no private, loopback, or internal addresses) at save time and again at send time; redirects are not followed. To forward to an internal collector, start the backend with `ALLOW_PRIVATE_NETWORK_REQUESTS=True`.
 - **SaaS.** Forwarding is pure egress to a destination you own — a SIEM collector URL or a Kafka broker you operate. CISO Assistant runs no per-tenant infrastructure for this.
 
 ## Related

--- a/product-docs/integrations/audit-log-forwarding.md
+++ b/product-docs/integrations/audit-log-forwarding.md
@@ -132,7 +132,7 @@ The field-level diff and the originating domain (`folder_id`) ride in `unmapped`
 ## Operational details
 
 - **Delivery & retries.** HTTP delivery treats any `2xx` as success. `4xx`/`5xx` responses and network errors or timeouts are retried — up to 5 times with exponential backoff (60s, then doubling, ~30 minutes total) — before the event is dropped. Redirects (`3xx`) are **not** followed and count as a terminal failure (no retry). Kafka delivery retries on producer errors. Forwarding is best-effort — replay is the backstop for gaps.
-- **Egress safety.** Every HTTP sink URL is validated to point at a public host (no private, loopback, or internal addresses) at save time and again at send time; redirects are not followed. To forward to an internal collector, start the backend with `ALLOW_PRIVATE_NETWORK_REQUESTS=True`.
+- **Egress safety.** Every HTTP sink URL is validated to point at a public host (no private, loopback, or internal addresses) at save time and again at send time; redirects are not followed. To forward to an internal collector, start the backend with `ALLOW_PRIVATE_NETWORK_REQUESTS=True` (previously named `WEBHOOK_ALLOW_PRIVATE_IPS`; the old name is no longer recognized).
 - **SaaS.** Forwarding is pure egress to a destination you own — a SIEM collector URL or a Kafka broker you operate. CISO Assistant runs no per-tenant infrastructure for this.
 
 ## Related


### PR DESCRIPTION
- **chores: harden IAM verfification on integrations domains**
- **decomission the login endpoint left for dispatcher to only rely on PAT**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  * User-aware PDF rendering for managed document revisions (only inlines images the user can access).

- **Bug Fixes**
  * Strengthened permission checks when removing evidence.
  * Dispatcher now clearly reports invalid/expired tokens on HTTP 401 (no silent reauthentication).

- **Documentation**
  * Updated authentication guidance to use PATs with `Authorization: Token <token>`.
  * Expanded SSRF/private-network guidance and renamed the toggle to `ALLOW_PRIVATE_NETWORK_REQUESTS` (legacy `WEBHOOK_ALLOW_PRIVATE_IPS` no longer recognized).

- **Chores**
  * Removed credential-based login flow (server and dispatcher) and updated related tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->