### PR TITLE
fix(journeys): reuse the add journey modal and support other objects

### DIFF
--- a/backend/core/preset_editor.py
+++ b/backend/core/preset_editor.py
@@ -12,7 +12,22 @@ from core.models import LoadedLibrary, Preset
 REF_RE = re.compile(r"^[A-Za-z0-9_]+$")
 KEY_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
-ALLOWED_SCAFFOLD_TYPES = {"compliance_assessment", "risk_assessment"}
+ALLOWED_SCAFFOLD_TYPES = {
+    "compliance_assessment",
+    "risk_assessment",
+    "applied_control",
+    "policy",
+    "entity",
+    "project",
+    "responsibility_matrix",
+}
+
+# Enum allow-lists for type-specific scaffold fields (mirror the model choices).
+APPLIED_CONTROL_CATEGORIES = {"policy", "process", "technical", "physical", "procedure"}
+CSF_FUNCTIONS = {"govern", "identify", "protect", "detect", "respond", "recover"}
+APPLIED_CONTROL_PRIORITIES = {1, 2, 3, 4}
+PROJECT_KINDS = {"portfolio", "program", "project"}
+RESPONSIBILITY_MATRIX_PRESETS = {"raci", "rasci", "rapid", "custom"}
 
 ALLOWED_TARGET_MODELS = {
     "accreditations",
@@ -32,6 +47,8 @@ ALLOWED_TARGET_MODELS = {
     "perimeters",
     "policies",
     "processings",
+    "projects",
+    "responsibility-matrices",
     "risk-acceptances",
     "risk-assessments",
     "security-exceptions",
@@ -207,6 +224,62 @@ def _validate_scaffolds(scaffolds: list, strict: bool = True) -> tuple[list, set
                     {f"scaffolded_objects[{i}].risk_matrix": "Risk matrix is required."}
                 )
             normalized["risk_matrix"] = risk_matrix
+        elif scaffold_type == "applied_control":
+            category = item.get("category")
+            if category:
+                if category not in APPLIED_CONTROL_CATEGORIES:
+                    raise ValidationError(
+                        {
+                            f"scaffolded_objects[{i}].category": (
+                                f"Must be one of: {sorted(APPLIED_CONTROL_CATEGORIES)}."
+                            )
+                        }
+                    )
+                normalized["category"] = category
+            csf_function = item.get("csf_function")
+            if csf_function:
+                if csf_function not in CSF_FUNCTIONS:
+                    raise ValidationError(
+                        {
+                            f"scaffolded_objects[{i}].csf_function": (
+                                f"Must be one of: {sorted(CSF_FUNCTIONS)}."
+                            )
+                        }
+                    )
+                normalized["csf_function"] = csf_function
+            priority = item.get("priority")
+            if priority is not None:
+                if priority not in APPLIED_CONTROL_PRIORITIES:
+                    raise ValidationError(
+                        {f"scaffolded_objects[{i}].priority": "Must be 1, 2, 3 or 4."}
+                    )
+                normalized["priority"] = priority
+        elif scaffold_type == "project":
+            kind = item.get("kind")
+            if kind:
+                if kind not in PROJECT_KINDS:
+                    raise ValidationError(
+                        {
+                            f"scaffolded_objects[{i}].kind": (
+                                f"Must be one of: {sorted(PROJECT_KINDS)}."
+                            )
+                        }
+                    )
+                normalized["kind"] = kind
+            if item.get("ref_id"):
+                normalized["ref_id"] = item["ref_id"]
+        elif scaffold_type == "responsibility_matrix":
+            matrix_preset = item.get("matrix_preset")
+            if matrix_preset:
+                if matrix_preset not in RESPONSIBILITY_MATRIX_PRESETS:
+                    raise ValidationError(
+                        {
+                            f"scaffolded_objects[{i}].matrix_preset": (
+                                f"Must be one of: {sorted(RESPONSIBILITY_MATRIX_PRESETS)}."
+                            )
+                        }
+                    )
+                normalized["matrix_preset"] = matrix_preset
         translations = item.get("translations")
         if translations is not None:
             if not isinstance(translations, dict):

--- a/backend/core/preset_editor.py
+++ b/backend/core/preset_editor.py
@@ -17,6 +17,8 @@ ALLOWED_SCAFFOLD_TYPES = {
     "risk_assessment",
     "applied_control",
     "policy",
+    "security_exception",
+    "risk_acceptance",
     "entity",
     "project",
     "responsibility_matrix",
@@ -26,6 +28,15 @@ ALLOWED_SCAFFOLD_TYPES = {
 APPLIED_CONTROL_CATEGORIES = {"policy", "process", "technical", "physical", "procedure"}
 CSF_FUNCTIONS = {"govern", "identify", "protect", "detect", "respond", "recover"}
 APPLIED_CONTROL_PRIORITIES = {1, 2, 3, 4}
+SECURITY_EXCEPTION_SEVERITIES = {-1, 0, 1, 2, 3, 4}
+SECURITY_EXCEPTION_STATUSES = {
+    "draft",
+    "in_review",
+    "approved",
+    "resolved",
+    "expired",
+    "deprecated",
+}
 PROJECT_KINDS = {"portfolio", "program", "project"}
 RESPONSIBILITY_MATRIX_PRESETS = {"raci", "rasci", "rapid", "custom"}
 
@@ -254,6 +265,29 @@ def _validate_scaffolds(scaffolds: list, strict: bool = True) -> tuple[list, set
                         {f"scaffolded_objects[{i}].priority": "Must be 1, 2, 3 or 4."}
                     )
                 normalized["priority"] = priority
+        elif scaffold_type == "security_exception":
+            severity = item.get("severity")
+            if severity is not None:
+                if severity not in SECURITY_EXCEPTION_SEVERITIES:
+                    raise ValidationError(
+                        {
+                            f"scaffolded_objects[{i}].severity": (
+                                f"Must be one of: {sorted(SECURITY_EXCEPTION_SEVERITIES)}."
+                            )
+                        }
+                    )
+                normalized["severity"] = severity
+            status = item.get("status")
+            if status:
+                if status not in SECURITY_EXCEPTION_STATUSES:
+                    raise ValidationError(
+                        {
+                            f"scaffolded_objects[{i}].status": (
+                                f"Must be one of: {sorted(SECURITY_EXCEPTION_STATUSES)}."
+                            )
+                        }
+                    )
+                normalized["status"] = status
         elif scaffold_type == "project":
             kind = item.get("kind")
             if kind:

--- a/backend/library/preset_executor.py
+++ b/backend/library/preset_executor.py
@@ -60,6 +60,8 @@ from core.models import (
     OrganisationIssue,
     AppliedControl,
     Policy,
+    SecurityException,
+    RiskAcceptance,
     Preset,
     PresetJourney,
     PresetJourneyStep,
@@ -77,6 +79,8 @@ from core.serializers import (
     OrganisationIssueWriteSerializer,
     AppliedControlWriteSerializer,
     PolicyWriteSerializer,
+    SecurityExceptionWriteSerializer,
+    RiskAcceptanceWriteSerializer,
 )
 from ebios_rm.models import EbiosRMStudy
 from ebios_rm.serializers import EbiosRMStudyWriteSerializer
@@ -390,6 +394,8 @@ class PresetExecutor:
         "risk_scenario": RiskScenario,
         "applied_control": AppliedControl,
         "policy": Policy,
+        "security_exception": SecurityException,
+        "risk_acceptance": RiskAcceptance,
         "project": Project,
         "responsibility_matrix": ResponsibilityMatrix,
     }
@@ -708,6 +714,34 @@ class PresetExecutor:
                 if item.get("status"):
                     data["status"] = item["status"]
                 serializer = PolicyWriteSerializer(data=data, context=context)
+                serializer.is_valid(raise_exception=True)
+                obj = serializer.save()
+
+            elif obj_type == "security_exception":
+                data = {
+                    "folder": str(folder.id),
+                    "name": name,
+                    "description": description,
+                }
+                if item.get("severity") is not None:
+                    data["severity"] = item["severity"]
+                if item.get("status"):
+                    data["status"] = item["status"]
+                serializer = SecurityExceptionWriteSerializer(
+                    data=data, context=context
+                )
+                serializer.is_valid(raise_exception=True)
+                obj = serializer.save()
+
+            elif obj_type == "risk_acceptance":
+                # Shell only: state defaults to "created"; approver and risk
+                # scenarios are linked by the user later.
+                data = {
+                    "folder": str(folder.id),
+                    "name": name,
+                    "description": description,
+                }
+                serializer = RiskAcceptanceWriteSerializer(data=data, context=context)
                 serializer.is_valid(raise_exception=True)
                 obj = serializer.save()
 

--- a/backend/library/preset_executor.py
+++ b/backend/library/preset_executor.py
@@ -58,6 +58,8 @@ from core.models import (
     TaskTemplate,
     OrganisationObjective,
     OrganisationIssue,
+    AppliedControl,
+    Policy,
     Preset,
     PresetJourney,
     PresetJourneyStep,
@@ -73,6 +75,8 @@ from core.serializers import (
     TaskTemplateWriteSerializer,
     OrganisationObjectiveWriteSerializer,
     OrganisationIssueWriteSerializer,
+    AppliedControlWriteSerializer,
+    PolicyWriteSerializer,
 )
 from ebios_rm.models import EbiosRMStudy
 from ebios_rm.serializers import EbiosRMStudyWriteSerializer
@@ -84,6 +88,11 @@ from tprm.models import Entity
 from tprm.serializers import EntityWriteSerializer
 from metrology.models import MetricInstance, MetricDefinition
 from metrology.serializers import MetricInstanceWriteSerializer
+from pmbok.models import Project, ResponsibilityMatrix
+from pmbok.serializers import (
+    ProjectWriteSerializer,
+    ResponsibilityMatrixWriteSerializer,
+)
 from global_settings.models import GlobalSettings
 from iam.models import Folder, User
 
@@ -379,6 +388,10 @@ class PresetExecutor:
         "metric_instance": MetricInstance,
         "asset": Asset,
         "risk_scenario": RiskScenario,
+        "applied_control": AppliedControl,
+        "policy": Policy,
+        "project": Project,
+        "responsibility_matrix": ResponsibilityMatrix,
     }
 
     def _find_existing(self, folder: Folder, obj_type: str, item: dict, name: str):
@@ -415,6 +428,11 @@ class PresetExecutor:
             queryset = queryset.filter(metric_definition=metric_def)
         elif obj_type == "asset":
             queryset = queryset.filter(type=item.get("asset_type", "SP"))
+        elif obj_type == "applied_control":
+            if item.get("category"):
+                queryset = queryset.filter(category=item["category"])
+        elif obj_type == "project":
+            queryset = queryset.filter(kind=item.get("kind", "project"))
 
         return queryset.first()
 
@@ -658,6 +676,68 @@ class PresetExecutor:
                     "type": item.get("asset_type", "SP"),
                 }
                 serializer = AssetWriteSerializer(data=data, context=context)
+                serializer.is_valid(raise_exception=True)
+                obj = serializer.save()
+
+            elif obj_type == "applied_control":
+                data = {
+                    "folder": str(folder.id),
+                    "name": name,
+                    "description": description,
+                }
+                if item.get("category"):
+                    data["category"] = item["category"]
+                if item.get("csf_function"):
+                    data["csf_function"] = item["csf_function"]
+                if item.get("priority") is not None:
+                    data["priority"] = item["priority"]
+                if item.get("status"):
+                    data["status"] = item["status"]
+                serializer = AppliedControlWriteSerializer(data=data, context=context)
+                serializer.is_valid(raise_exception=True)
+                obj = serializer.save()
+
+            elif obj_type == "policy":
+                data = {
+                    "folder": str(folder.id),
+                    "name": name,
+                    "description": description,
+                }
+                if item.get("priority") is not None:
+                    data["priority"] = item["priority"]
+                if item.get("status"):
+                    data["status"] = item["status"]
+                serializer = PolicyWriteSerializer(data=data, context=context)
+                serializer.is_valid(raise_exception=True)
+                obj = serializer.save()
+
+            elif obj_type == "project":
+                data = {
+                    "folder": str(folder.id),
+                    "name": name,
+                    "description": description,
+                    "kind": item.get("kind", "project"),
+                }
+                if item.get("ref_id"):
+                    data["ref_id"] = item["ref_id"]
+                if item.get("priority") is not None:
+                    data["priority"] = item["priority"]
+                serializer = ProjectWriteSerializer(data=data, context=context)
+                serializer.is_valid(raise_exception=True)
+                obj = serializer.save()
+
+            elif obj_type == "responsibility_matrix":
+                # Shell only: create the matrix with its taxonomy; roles auto-populate
+                # from the preset. Activities/actors/assignments are left to the user.
+                data = {
+                    "folder": str(folder.id),
+                    "name": name,
+                    "description": description,
+                    "preset": item.get("matrix_preset", "raci"),
+                }
+                serializer = ResponsibilityMatrixWriteSerializer(
+                    data=data, context=context
+                )
                 serializer.is_valid(raise_exception=True)
                 obj = serializer.save()
 

--- a/frontend/src/lib/components/Forms/ModelForm/EbiosRmForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/EbiosRmForm.svelte
@@ -35,7 +35,8 @@
 		.then((r) => r.json())
 		.then((data) => {
 			hasEntities = (data.count ?? 0) > 0;
-		});
+		})
+		.catch(() => {});
 
 	page.url.searchParams.forEach((value, key) => {
 		if (key === 'activity' && value === 'one') {

--- a/frontend/src/lib/components/Modals/ApplyPresetModal.svelte
+++ b/frontend/src/lib/components/Modals/ApplyPresetModal.svelte
@@ -2,12 +2,19 @@
 	import { getModalStore } from './stores';
 	import { m } from '$paraglide/messages';
 	import { page } from '$app/stores';
+	import { onDestroy } from 'svelte';
+	import FolderTreeSelect from '$lib/components/Forms/FolderTreeSelect.svelte';
+	import { defaults, superForm } from 'sveltekit-superforms';
+	import { zod4 as zod } from 'sveltekit-superforms/adapters';
+	import { z } from 'zod';
 
 	interface Props {
 		parent: any;
-		presetName: string;
+		presetName?: string;
+		presets?: { id: string; name: string }[];
 		domains: { id: string; name: string }[];
 		onApply: (data: {
+			preset_id?: string;
 			folder_name?: string;
 			folder_id?: string;
 			create_objects?: boolean;
@@ -15,7 +22,7 @@
 		}) => Promise<{ ok: boolean; error?: string }>;
 	}
 
-	let { parent, presetName, domains, onApply }: Props = $props();
+	let { parent, presetName = '', presets = [], domains, onApply }: Props = $props();
 
 	const modalStore = getModalStore();
 
@@ -23,13 +30,40 @@
 		Object.hasOwn($page.data.user?.permissions ?? {}, 'change_globalsettings')
 	);
 
+	// When no preset is pre-selected (e.g. opened from the journeys list "Start a journey"
+	// button), let the user pick which preset to apply.
+	const showPresetPicker = $derived(presets.length > 0);
+
 	let mode: 'new' | 'existing' = $state('new');
+	let selectedPresetId: string = $state('');
 	let folderName: string = $state(presetName);
 	let selectedFolderId: string = $state('');
 	let createObjects: boolean = $state(true);
 	let applyFeatureFlags: boolean = $state(true);
 	let errorMessage: string = $state('');
 	let submitting: boolean = $state(false);
+
+	// Standalone SPA form backing the hierarchical domain picker (FolderTreeSelect
+	// requires a SuperForm); we mirror its value into selectedFolderId.
+	const folderSchema = z.object({ folder: z.string() });
+	const _form = superForm(defaults({ folder: '' }, zod(folderSchema)), {
+		dataType: 'json',
+		taintedMessage: false,
+		validators: zod(folderSchema),
+		SPA: true
+	});
+	const unsubscribeFolder = _form.form.subscribe((v) => {
+		selectedFolderId = v.folder ?? '';
+	});
+	onDestroy(unsubscribeFolder);
+
+	// Default the new-domain name to the chosen preset's name.
+	$effect(() => {
+		if (showPresetPicker && selectedPresetId) {
+			const p = presets.find((x) => x.id === selectedPresetId);
+			if (p) folderName = p.name;
+		}
+	});
 
 	async function handleSubmit(event: SubmitEvent) {
 		event.preventDefault();
@@ -38,6 +72,7 @@
 
 		try {
 			let payload: {
+				preset_id?: string;
 				folder_name?: string;
 				folder_id?: string;
 				create_objects?: boolean;
@@ -51,12 +86,20 @@
 					apply_feature_flags: canChangeSettings && applyFeatureFlags
 				};
 			} else {
-				if (!selectedFolderId) return;
+				if (!selectedFolderId) {
+					errorMessage = m.selectDomain();
+					return;
+				}
 				payload = {
 					folder_id: selectedFolderId,
 					create_objects: createObjects,
 					apply_feature_flags: canChangeSettings && applyFeatureFlags
 				};
+			}
+			// Only carry preset_id when the picker is in use, so we never clobber a
+			// preset_id the caller already supplied (standard per-card apply).
+			if (showPresetPicker && selectedPresetId) {
+				payload.preset_id = selectedPresetId;
 			}
 
 			const result = await onApply(payload);
@@ -87,6 +130,24 @@
 		{/if}
 
 		<form class="space-y-4" onsubmit={handleSubmit}>
+			<!-- Preset picker (only when no preset was pre-selected) -->
+			{#if showPresetPicker}
+				<label class="label">
+					<span class="text-sm">{m.preset()}</span>
+					<select
+						class="select"
+						bind:value={selectedPresetId}
+						data-testid="apply-preset-select"
+						required
+					>
+						<option value="" disabled>{m.preset()}...</option>
+						{#each presets as preset}
+							<option value={preset.id}>{preset.name}</option>
+						{/each}
+					</select>
+				</label>
+			{/if}
+
 			<!-- Radio toggle -->
 			<div class="flex gap-4">
 				<label class="flex items-center gap-2 cursor-pointer">
@@ -121,15 +182,7 @@
 					/>
 				</label>
 			{:else}
-				<label class="label">
-					<span class="text-sm">{m.selectDomain()}</span>
-					<select class="select" bind:value={selectedFolderId} required>
-						<option value="" disabled>{m.selectDomain()}...</option>
-						{#each domains as domain}
-							<option value={domain.id}>{domain.name}</option>
-						{/each}
-					</select>
-				</label>
+				<FolderTreeSelect form={_form} field="folder" label={m.selectDomain()} />
 			{/if}
 
 			<!-- Create objects toggle -->

--- a/frontend/src/lib/components/Modals/UpdateModal.svelte
+++ b/frontend/src/lib/components/Modals/UpdateModal.svelte
@@ -26,6 +26,7 @@
 		selectOptions?: Record<string, any>;
 		debug?: boolean;
 		customNameDescription?: boolean;
+		customFolder?: boolean;
 	}
 
 	let {
@@ -39,7 +40,8 @@
 		suggestions = {},
 		selectOptions = {},
 		debug = false,
-		customNameDescription = true
+		customNameDescription = true,
+		customFolder = false
 	}: Props = $props();
 </script>
 
@@ -59,6 +61,7 @@
 		</div>
 		<ModelForm
 			{customNameDescription}
+			{customFolder}
 			{form}
 			{object}
 			{suggestions}

--- a/frontend/src/routes/(app)/(internal)/ebios-rm/[id=uuid]/workshop-1/baseline/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/ebios-rm/[id=uuid]/workshop-1/baseline/+page.svelte
@@ -49,7 +49,8 @@
 				form: data.updateForm,
 				model: data.updatedModel,
 				object: data.object,
-				context: 'selectAudit'
+				context: 'selectAudit',
+				customFolder: true
 			}
 		};
 		let modal: ModalSettings = {

--- a/frontend/src/routes/(app)/(internal)/ebios-rm/[id=uuid]/workshop-1/ebios-rm-study/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/ebios-rm/[id=uuid]/workshop-1/ebios-rm-study/+page.svelte
@@ -71,7 +71,8 @@
 				form: data.updateForm,
 				model: data.updatedModel,
 				object: data.object,
-				context: 'selectAsset'
+				context: 'selectAsset',
+				customFolder: true
 			}
 		};
 		let modal: ModalSettings = {

--- a/frontend/src/routes/(app)/(internal)/ebios-rm/[id=uuid]/workshop-1/ebios-rm-study/edit/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/ebios-rm/[id=uuid]/workshop-1/ebios-rm-study/edit/+page.svelte
@@ -15,6 +15,7 @@
 		selectOptions={data.selectOptions}
 		model={data.model}
 		context="ebiosRmStudy"
+		customFolder
 		scopeFolder={data.data.folder}
 	/>
 </div>

--- a/frontend/src/routes/(app)/(internal)/experimental/preset-editor/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/experimental/preset-editor/[id=uuid]/+page.svelte
@@ -19,6 +19,7 @@
 		category?: string;
 		csf_function?: string;
 		priority?: number;
+		severity?: number;
 		asset_type?: string;
 		kind?: string;
 		matrix_preset?: string;
@@ -58,6 +59,8 @@
 		asset: 'assets',
 		applied_control: 'applied-controls',
 		policy: 'policies',
+		security_exception: 'security-exceptions',
+		risk_acceptance: 'risk-acceptances',
 		project: 'projects',
 		responsibility_matrix: 'responsibility-matrices'
 	};
@@ -75,9 +78,7 @@
 		'actors',
 		'evidences',
 		'incidents',
-		'metric-instances',
-		'risk-acceptances',
-		'security-exceptions'
+		'metric-instances'
 	];
 	const ALL_MODELS = ['', ...NAV_ONLY_MODELS, ...Object.values(TYPE_TO_MODEL)].sort((a, b) =>
 		a.localeCompare(b)
@@ -89,6 +90,13 @@
 		{ value: 'PR', labelKey: 'primary' }
 	];
 	const APPLIED_CONTROL_CATEGORIES = ['policy', 'process', 'technical', 'physical', 'procedure'];
+	const SECURITY_EXCEPTION_SEVERITIES = [
+		{ value: 0, labelKey: 'info' },
+		{ value: 1, labelKey: 'low' },
+		{ value: 2, labelKey: 'medium' },
+		{ value: 3, labelKey: 'high' },
+		{ value: 4, labelKey: 'critical' }
+	];
 	const PROJECT_KINDS = ['portfolio', 'program', 'project'];
 	const MATRIX_PRESETS = ['raci', 'rasci', 'rapid', 'custom'];
 
@@ -684,6 +692,23 @@
 			>
 				{#each MATRIX_PRESETS as p (p)}
 					<option value={p}>{p.toUpperCase()}</option>
+				{/each}
+			</select>
+		</label>
+	{:else if scaffold.type === 'security_exception'}
+		<label class="flex flex-col gap-1 text-sm">
+			<span class="text-xs text-surface-600-400">Severity</span>
+			<select
+				class="text-sm bg-surface-50-950 border border-surface-200-800 rounded-lg px-2.5 py-1.5 outline-none focus:border-blue-400 focus:ring-2 focus:ring-blue-500/20 transition-colors"
+				value={scaffold.severity === undefined ? '' : String(scaffold.severity)}
+				onchange={(e) => {
+					const v = (e.target as HTMLSelectElement).value;
+					updateScaffoldByIndex(idx, { severity: v === '' ? undefined : Number(v) });
+				}}
+			>
+				<option value="">Undefined</option>
+				{#each SECURITY_EXCEPTION_SEVERITIES as s (s.value)}
+					<option value={String(s.value)}>{safeTranslate(s.labelKey)}</option>
 				{/each}
 			</select>
 		</label>

--- a/frontend/src/routes/(app)/(internal)/experimental/preset-editor/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/experimental/preset-editor/[id=uuid]/+page.svelte
@@ -17,7 +17,11 @@
 		risk_matrix?: string;
 		implementation_groups?: string[];
 		category?: string;
+		csf_function?: string;
+		priority?: number;
 		asset_type?: string;
+		kind?: string;
+		matrix_preset?: string;
 		step_ref_id?: string;
 		[k: string]: any;
 	};
@@ -51,21 +55,27 @@
 		organisation_objective: 'organisation-objectives',
 		organisation_issue: 'organisation-issues',
 		perimeter: 'perimeters',
-		asset: 'assets'
+		asset: 'assets',
+		applied_control: 'applied-controls',
+		policy: 'policies',
+		project: 'projects',
+		responsibility_matrix: 'responsibility-matrices'
 	};
 	const MODEL_TO_TYPE: Record<string, string> = Object.fromEntries(
 		Object.entries(TYPE_TO_MODEL).map(([t, m]) => [m, t])
 	);
 	const SCAFFOLD_TYPES = Object.keys(TYPE_TO_MODEL);
 
+	// Object types behind the project_management feature flag; presets scaffolding
+	// these must enable that flag (the editor warns the author).
+	const PROJECT_MANAGEMENT_TYPES = ['project', 'responsibility_matrix'];
+
 	const NAV_ONLY_MODELS = [
 		'accreditations',
 		'actors',
-		'applied-controls',
 		'evidences',
 		'incidents',
 		'metric-instances',
-		'policies',
 		'risk-acceptances',
 		'security-exceptions'
 	];
@@ -78,6 +88,9 @@
 		{ value: 'SP', labelKey: 'support' },
 		{ value: 'PR', labelKey: 'primary' }
 	];
+	const APPLIED_CONTROL_CATEGORIES = ['policy', 'process', 'technical', 'physical', 'procedure'];
+	const PROJECT_KINDS = ['portfolio', 'program', 'project'];
+	const MATRIX_PRESETS = ['raci', 'rasci', 'rapid', 'custom'];
 
 	let draft: Draft | null = $state(null);
 	let initialJson = $state('');
@@ -92,6 +105,12 @@
 	let isReadOnly = $derived(!data.preset.is_user_authored);
 
 	const dirty = $derived(draft != null && JSON.stringify(draft) !== initialJson);
+
+	// Project & responsibility-matrix scaffolds only surface once the project_management
+	// feature flag is on; remind the author since the flag isn't editable here.
+	const needsProjectManagement = $derived(
+		!!draft?.scaffolded_objects?.some((s) => PROJECT_MANAGEMENT_TYPES.includes(s.type))
+	);
 
 	beforeNavigate(({ cancel }) => {
 		if (dirty && !confirm('You have unsaved changes. Leave anyway?')) cancel();
@@ -418,6 +437,8 @@
 			return { ...base, risk_matrix: '' };
 		if (type === 'findings_assessment') return { ...base, category: 'pentest' };
 		if (type === 'asset') return { ...base, asset_type: 'SP' };
+		if (type === 'project') return { ...base, kind: 'project' };
+		if (type === 'responsibility_matrix') return { ...base, matrix_preset: 'raci' };
 		return base;
 	}
 
@@ -623,6 +644,49 @@
 				{/each}
 			</select>
 		</label>
+	{:else if scaffold.type === 'applied_control'}
+		<label class="flex flex-col gap-1 text-sm">
+			<span class="text-xs text-surface-600-400">Category</span>
+			<select
+				class="text-sm bg-surface-50-950 border border-surface-200-800 rounded-lg px-2.5 py-1.5 outline-none focus:border-blue-400 focus:ring-2 focus:ring-blue-500/20 transition-colors"
+				value={scaffold.category ?? ''}
+				onchange={(e) =>
+					updateScaffoldByIndex(idx, { category: (e.target as HTMLSelectElement).value })}
+			>
+				<option value="">Any category…</option>
+				{#each APPLIED_CONTROL_CATEGORIES as c (c)}
+					<option value={c}>{safeTranslate(c)}</option>
+				{/each}
+			</select>
+		</label>
+	{:else if scaffold.type === 'project'}
+		<label class="flex flex-col gap-1 text-sm">
+			<span class="text-xs text-surface-600-400">Kind</span>
+			<select
+				class="text-sm bg-surface-50-950 border border-surface-200-800 rounded-lg px-2.5 py-1.5 outline-none focus:border-blue-400 focus:ring-2 focus:ring-blue-500/20 transition-colors"
+				value={scaffold.kind ?? 'project'}
+				onchange={(e) =>
+					updateScaffoldByIndex(idx, { kind: (e.target as HTMLSelectElement).value })}
+			>
+				{#each PROJECT_KINDS as k (k)}
+					<option value={k}>{safeTranslate(k)}</option>
+				{/each}
+			</select>
+		</label>
+	{:else if scaffold.type === 'responsibility_matrix'}
+		<label class="flex flex-col gap-1 text-sm">
+			<span class="text-xs text-surface-600-400">Matrix preset</span>
+			<select
+				class="text-sm bg-surface-50-950 border border-surface-200-800 rounded-lg px-2.5 py-1.5 outline-none focus:border-blue-400 focus:ring-2 focus:ring-blue-500/20 transition-colors"
+				value={scaffold.matrix_preset ?? 'raci'}
+				onchange={(e) =>
+					updateScaffoldByIndex(idx, { matrix_preset: (e.target as HTMLSelectElement).value })}
+			>
+				{#each MATRIX_PRESETS as p (p)}
+					<option value={p}>{p.toUpperCase()}</option>
+				{/each}
+			</select>
+		</label>
 	{/if}
 {/snippet}
 
@@ -642,6 +706,20 @@
 {:else if !draft}
 	<div class="p-6 text-red-700">Failed to load draft.</div>
 {:else}
+	{#if needsProjectManagement}
+		<div
+			class="mb-3 flex items-start gap-2.5 rounded-lg border border-amber-300 bg-amber-50 px-3.5 py-2.5 text-sm text-amber-800"
+		>
+			<i class="fa-solid fa-triangle-exclamation mt-0.5 text-amber-500"></i>
+			<span>
+				This preset scaffolds projects or responsibility matrices, which require the
+				<span class="font-medium">project management</span> feature. Make sure the preset's
+				<span class="font-mono text-xs">feature_flags</span> enable
+				<span class="font-mono text-xs">project_management</span>, otherwise the created objects
+				won't be visible.
+			</span>
+		</div>
+	{/if}
 	<div class="bg-surface-50-950 rounded-lg shadow-sm border border-surface-200-800 overflow-hidden">
 		<!-- Sticky toolbar -->
 		<div class="sticky top-0 z-40 bg-surface-50-950 border-b border-surface-200-800 px-4 py-2.5">

--- a/frontend/src/routes/(app)/(internal)/journeys/+page.server.ts
+++ b/frontend/src/routes/(app)/(internal)/journeys/+page.server.ts
@@ -1,0 +1,40 @@
+import { BASE_API_URL } from '$lib/utils/constants';
+import { listViewFields } from '$lib/utils/table';
+import { type TableSource } from '@skeletonlabs/skeleton-svelte';
+import { superValidate } from 'sveltekit-superforms';
+import { zod4 as zod } from 'sveltekit-superforms/adapters';
+import { z } from 'zod';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ fetch }) => {
+	// Build the (empty) table skeleton from the journeys list-view config; ModelTable
+	// fetches the rows client-side from /journeys.
+	const base = listViewFields['journeys'];
+	const head = base ? [...base.head] : [];
+	const body = base ? [...base.body] : [];
+	const headData: Record<string, string> = body.reduce(
+		(obj, key, index) => {
+			obj[key] = head[index];
+			return obj;
+		},
+		{} as Record<string, string>
+	);
+	const table: TableSource = { head: headData, body: [], meta: [] };
+
+	const deleteForm = await superValidate(zod(z.object({ id: z.string().uuid() })));
+
+	// Presets feed the "Start a journey" picker; domains feed the folder selector.
+	const presetsPromise = fetch(`${BASE_API_URL}/presets/`)
+		.then((res) => res.json())
+		.then((data) => data.results ?? data)
+		.catch(() => []);
+
+	const domainsPromise = fetch(`${BASE_API_URL}/folders?content_type=DO&content_type=GL`)
+		.then((res) => res.json())
+		.then((data) => data.results ?? data)
+		.catch(() => []);
+
+	const [presets, domains] = await Promise.all([presetsPromise, domainsPromise]);
+
+	return { table, deleteForm, presets, domains, URLModel: 'journeys' };
+};

--- a/frontend/src/routes/(app)/(internal)/journeys/+page.server.ts
+++ b/frontend/src/routes/(app)/(internal)/journeys/+page.server.ts
@@ -24,17 +24,23 @@ export const load: PageServerLoad = async ({ fetch }) => {
 	const deleteForm = await superValidate(zod(z.object({ id: z.string().uuid() })));
 
 	// Presets feed the "Start a journey" picker; domains feed the folder selector.
-	const presetsPromise = fetch(`${BASE_API_URL}/presets/`)
-		.then((res) => res.json())
-		.then((data) => data.results ?? data)
-		.catch(() => []);
+	// Always resolve to an array: tolerate non-OK responses and non-list payloads.
+	const fetchCollection = async (endpoint: string) => {
+		try {
+			const res = await fetch(endpoint);
+			if (!res.ok) return [];
+			const data = await res.json();
+			const list = data?.results ?? data;
+			return Array.isArray(list) ? list : [];
+		} catch {
+			return [];
+		}
+	};
 
-	const domainsPromise = fetch(`${BASE_API_URL}/folders?content_type=DO&content_type=GL`)
-		.then((res) => res.json())
-		.then((data) => data.results ?? data)
-		.catch(() => []);
-
-	const [presets, domains] = await Promise.all([presetsPromise, domainsPromise]);
+	const [presets, domains] = await Promise.all([
+		fetchCollection(`${BASE_API_URL}/presets/`),
+		fetchCollection(`${BASE_API_URL}/folders?content_type=DO&content_type=GL`)
+	]);
 
 	return { table, deleteForm, presets, domains, URLModel: 'journeys' };
 };

--- a/frontend/src/routes/(app)/(internal)/journeys/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/journeys/+page.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+	import { m } from '$paraglide/messages';
+	import { getModalStore } from '$lib/components/Modals/stores';
+	import ApplyPresetModal from '$lib/components/Modals/ApplyPresetModal.svelte';
+	import ModelTable from '$lib/components/ModelTable/ModelTable.svelte';
+	import { goto } from '$lib/utils/breadcrumbs';
+	import { page } from '$app/stores';
+
+	let { data }: { data: PageData } = $props();
+
+	const modalStore = getModalStore();
+
+	const canApplyPreset = $derived(
+		Object.hasOwn($page.data.user?.permissions ?? {}, 'add_loadedlibrary')
+	);
+
+	function startJourney() {
+		modalStore.trigger({
+			type: 'component',
+			title: m.applyPreset(),
+			body: m.applyPresetConfirm(),
+			component: {
+				ref: ApplyPresetModal,
+				props: {
+					presets: data.presets,
+					domains: data.domains,
+					onApply: async (payload: {
+						preset_id?: string;
+						folder_name?: string;
+						folder_id?: string;
+						create_objects?: boolean;
+						apply_feature_flags?: boolean;
+					}) => {
+						try {
+							const response = await fetch(`/presets/apply`, {
+								method: 'POST',
+								headers: { 'Content-Type': 'application/json' },
+								body: JSON.stringify(payload)
+							});
+							if (response.ok) {
+								const result = await response.json();
+								goto(`/journeys/${result.journey_id}`, {
+									label: result.journey_name,
+									breadcrumbAction: 'push'
+								});
+								return { ok: true };
+							}
+							const err = await response.json().catch(() => ({}));
+							const raw = err.error ?? err;
+							let message: string;
+							if (typeof raw === 'string') {
+								message = raw;
+							} else if (typeof raw === 'object') {
+								message = Object.values(raw).flat().join(', ');
+							} else {
+								message = String(raw);
+							}
+							return { ok: false, error: message };
+						} catch (e) {
+							console.error('Failed to apply preset', e);
+							return { ok: false, error: String(e) };
+						}
+					}
+				}
+			}
+		});
+	}
+</script>
+
+{#if data?.table}
+	<div class="shadow-lg">
+		<ModelTable
+			source={data.table}
+			deleteForm={data.deleteForm}
+			URLModel="journeys"
+			disableEdit={true}
+		>
+			{#snippet addButton()}
+				{#if canApplyPreset}
+					<div class="inline-flex overflow-hidden rounded-md border bg-surface-50-950 shadow-xs">
+						<button
+							class="inline-block p-3 btn-mini-primary w-12 focus:relative"
+							data-testid="add-button"
+							id="add-button"
+							title={m.applyPreset()}
+							aria-label={m.applyPreset()}
+							onclick={startJourney}><i class="fa-solid fa-route"></i></button
+						>
+					</div>
+				{/if}
+			{/snippet}
+		</ModelTable>
+	</div>
+{/if}

--- a/frontend/src/routes/(app)/(internal)/journeys/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/journeys/+page.svelte
@@ -77,7 +77,7 @@
 			disableEdit={true}
 		>
 			{#snippet addButton()}
-				{#if canApplyPreset}
+				{#if canApplyPreset && data.presets.length > 0}
 					<div class="inline-flex overflow-hidden rounded-md border bg-surface-50-950 shadow-xs">
 						<button
 							class="inline-block p-3 btn-mini-primary w-12 focus:relative"

--- a/frontend/src/routes/(app)/(internal)/journeys/+server.ts
+++ b/frontend/src/routes/(app)/(internal)/journeys/+server.ts
@@ -3,9 +3,7 @@ import { error, type NumericRange } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ fetch, url }) => {
-	const endpoint = `${BASE_API_URL}/journeys/${
-		url.searchParams ? '?' + url.searchParams.toString() : ''
-	}`;
+	const endpoint = `${BASE_API_URL}/journeys/${url.search || ''}`;
 
 	const res = await fetch(endpoint);
 	if (!res.ok) {

--- a/frontend/src/routes/(app)/(internal)/journeys/+server.ts
+++ b/frontend/src/routes/(app)/(internal)/journeys/+server.ts
@@ -1,0 +1,22 @@
+import { BASE_API_URL } from '$lib/utils/constants';
+import { error, type NumericRange } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ fetch, url }) => {
+	const endpoint = `${BASE_API_URL}/journeys/${
+		url.searchParams ? '?' + url.searchParams.toString() : ''
+	}`;
+
+	const res = await fetch(endpoint);
+	if (!res.ok) {
+		error(res.status as NumericRange<400, 599>, await res.json());
+	}
+	const data = await res.json();
+
+	return new Response(JSON.stringify(data), {
+		status: res.status,
+		headers: {
+			'Content-Type': 'application/json'
+		}
+	});
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an internal Journeys interface with an “apply preset” flow that starts a journey and navigates to its workflow.
  * Expanded preset drafting/execution to support additional scaffold types, including project-management guidance.
* **Improvements**
  * Enhanced the “apply preset” modal with optional preset preselection, stronger domain/folder selection UI, and validation before applying.
  * Update modals now support custom folder behavior where applicable.
* **Bug Fixes**
  * Prevented entity-check fetch failures from breaking the Ebios RM form.
  * Removed domain selectors in ebios-rm form / selectors.
* **Chores**
  * Added a backend-proxy route for Journeys API requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->