### PR TITLE
fix: missing display of the choices definition in qualitative metrics definition

### DIFF
--- a/frontend/src/lib/components/DetailView/DetailView.svelte
+++ b/frontend/src/lib/components/DetailView/DetailView.svelte
@@ -542,6 +542,7 @@
 								? 'hidden'
 								: ''}"
 						>
+							<!-- Keys column -->
 							<dt
 								class="font-medium text-surface-950-50 flex items-center gap-2"
 								data-testid="{key.replace('_', '-')}-field-title"
@@ -566,6 +567,7 @@
 									</Tooltip>
 								{/if}
 							</dt>
+							<!-- Value column -->
 							<dd class="text-surface-700-300 sm:col-span-4">
 								<ul class="">
 									<li
@@ -635,6 +637,7 @@
 												{:else}
 													--
 												{/if}
+												<!-- Values that are Arrays -->
 											{:else if Array.isArray(value)}
 												{@const visibleValues = isRelatedField
 													? value.filter((item) => !isMaskedPlaceholder(item))
@@ -663,6 +666,11 @@
 																	{@const [securityObjectiveName, securityObjectiveValue] =
 																		Object.entries(val)[0]}
 																	{safeTranslate(securityObjectiveName).toUpperCase()}: {securityObjectiveValue}
+																{:else if key === 'choices_definition'}
+																	<span class="font-mono text-xs bg-surface-200-800 px-1 rounded"
+																		>{val.ref_id}</span
+																	>
+																	- {val.name}
 																{:else if val.str && val.id && key !== 'qualifications' && key !== 'relationship' && key !== 'nature'}
 																	{@const itemHref = `/${
 																		data.model?.foreignKeyFields?.find((item) => item.field === key)


### PR DESCRIPTION
## What & why

Closes #4397

## Test plan

1. Go to 'Metric definition'
2. Create a new Qualitative metric with at least one choice definition
3. Display the new metric just created, then click on "view more"
4. The "Choices definition" line should display values and not `[object Object]`

Example:
<img width="365" height="105" alt="image" src="https://github.com/user-attachments/assets/195b0ce9-e0a1-4df7-90eb-64aba102823d" />


## Checklist

- [X] PR title follows Conventional Commits (`!` set if this is a breaking change)
- [X] One focused change, branched off `main`

### Frontend — if you touched `frontend/`

- [X] Svelte 5 syntax; `pnpm run lint` and `pnpm run format` run
- [X] Clicked through the change in the dev server; screenshots attached for UI changes

### Tests & documentation — definition of done

- [X] No tests or docs needed for this change — why: small ui fix 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved how array values are displayed in detail views, with a special format for choice definitions.
  * Choice entries now show a clearer identifier badge and a more readable name label.
* **Style**
  * Added clearer inline labels in the detail layout to make the columns and array section easier to follow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->