### PR TITLE
fix: csv exports encoding

### DIFF
--- a/backend/app_tests/api/test_api_assets.py
+++ b/backend/app_tests/api/test_api_assets.py
@@ -319,7 +319,7 @@ class TestAssetListIAMScope:
         client, assets = self._build_export_fixture()
         r = client.get("/api/assets/export_csv/?type=PR")
         assert r.status_code == status.HTTP_200_OK, r.content
-        assert r["Content-Type"] == "text/csv"
+        assert r["Content-Type"] == "text/csv; charset=utf-8"
         content = r.content.decode("utf-8")
 
         assert assets["a_pr"].name in content, (

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -513,9 +513,10 @@ class ExportMixin:
 
         try:
             queryset = self._get_export_queryset()
-            response = HttpResponse(content_type="text/csv")
+            response = HttpResponse(content_type="text/csv; charset=utf-8")
             filename = f"{self.export_config.get('filename', 'export')}.csv"
             response["Content-Disposition"] = f'attachment; filename="{filename}"'
+            response.write("﻿")
 
             writer = csv.writer(response, delimiter=";")
             fields = self.export_config["fields"]
@@ -4046,7 +4047,8 @@ class RiskAssessmentViewSet(BaseModelViewSet):
         if UUID(pk) in object_ids_view:
             risk_assessment = self.get_object()
 
-            response = HttpResponse(content_type="text/csv")
+            response = HttpResponse(content_type="text/csv; charset=utf-8")
+            response.write("﻿")
 
             writer = csv.writer(response, delimiter=";")
             columns = [
@@ -13076,8 +13078,9 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
 
     @action(detail=True, name="Get compliance assessment (audit) CSV")
     def compliance_assessment_csv(self, request, pk):
-        response = HttpResponse(content_type="text/csv")
+        response = HttpResponse(content_type="text/csv; charset=utf-8")
         response["Content-Disposition"] = 'attachment; filename="audit_export.csv"'
+        response.write("﻿")
 
         (viewable_objects, _, _) = RoleAssignment.get_accessible_object_ids(
             Folder.get_root_folder(), request.user, ComplianceAssessment
@@ -13472,8 +13475,9 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
             queryset, many=True, context={"pk": pk}
         )
 
-        response = HttpResponse(content_type="text/csv")
+        response = HttpResponse(content_type="text/csv; charset=utf-8")
         response["Content-Disposition"] = f'attachment; filename="action_plan_{pk}.csv"'
+        response.write("﻿")
 
         writer = csv.writer(response)
 
@@ -16886,8 +16890,9 @@ def generate_html(
 
 
 def export_mp_csv(request):
-    response = HttpResponse(content_type="text/csv")
+    response = HttpResponse(content_type="text/csv; charset=utf-8")
     response["Content-Disposition"] = 'attachment; filename="MP.csv"'
+    response.write("﻿")
 
     writer = csv.writer(response, delimiter=";")
     columns = [

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -391,6 +391,14 @@ def escape_excel_formula(value):
     return s
 
 
+def escape_csv_row(row):
+    """Apply formula-injection escaping to every string cell of a CSV row."""
+    return [
+        escape_excel_formula(value) if isinstance(value, str) else value
+        for value in row
+    ]
+
+
 def create_xlsx_response(entries, filename, wrap_columns=None):
     """
     DRY helper to create XLSX response with consistent formatting.
@@ -516,7 +524,7 @@ class ExportMixin:
             response = HttpResponse(content_type="text/csv; charset=utf-8")
             filename = f"{self.export_config.get('filename', 'export')}.csv"
             response["Content-Disposition"] = f'attachment; filename="{filename}"'
-            response.write("﻿")
+            response.write("\ufeff")
 
             writer = csv.writer(response, delimiter=";")
             fields = self.export_config["fields"]
@@ -4048,7 +4056,7 @@ class RiskAssessmentViewSet(BaseModelViewSet):
             risk_assessment = self.get_object()
 
             response = HttpResponse(content_type="text/csv; charset=utf-8")
-            response.write("﻿")
+            response.write("\ufeff")
 
             writer = csv.writer(response, delimiter=";")
             columns = [
@@ -4124,7 +4132,7 @@ class RiskAssessmentViewSet(BaseModelViewSet):
                         columns.index("inherent_level"),
                         scenario.get_inherent_risk()["name"],
                     )
-                writer.writerow(row)
+                writer.writerow(escape_csv_row(row))
 
             return response
         else:
@@ -13080,7 +13088,7 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
     def compliance_assessment_csv(self, request, pk):
         response = HttpResponse(content_type="text/csv; charset=utf-8")
         response["Content-Disposition"] = 'attachment; filename="audit_export.csv"'
-        response.write("﻿")
+        response.write("\ufeff")
 
         (viewable_objects, _, _) = RoleAssignment.get_accessible_object_ids(
             Folder.get_root_folder(), request.user, ComplianceAssessment
@@ -13128,7 +13136,7 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
                     ]
                 else:
                     row += ["", "", "", "", ""]
-                writer.writerow(row)
+                writer.writerow(escape_csv_row(row))
 
             return response
         else:
@@ -13477,7 +13485,7 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
 
         response = HttpResponse(content_type="text/csv; charset=utf-8")
         response["Content-Disposition"] = f'attachment; filename="action_plan_{pk}.csv"'
-        response.write("﻿")
+        response.write("\ufeff")
 
         writer = csv.writer(response)
 
@@ -13502,33 +13510,35 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
 
         for item in serializer.data:
             writer.writerow(
-                [
-                    item.get("name"),
-                    item.get("description"),
-                    item.get("category"),
-                    item.get("csf_function"),
-                    item.get("priority"),
-                    item.get("status"),
-                    item.get("eta"),
-                    item.get("expiry_date"),
-                    item.get("effort"),
-                    item.get("control_impact"),
-                    item.get("annual_cost"),
-                    "\n".join(
-                        escape_excel_formula(ra.get("str"))
-                        for ra in (item.get("requirement_assessments") or [])
-                    ),
-                    "\n".join(
-                        escape_excel_formula(evidence.get("str"))
-                        for evidence in (item.get("evidences") or [])
-                        if evidence.get("str")
-                    ),
-                    "\n".join(
-                        escape_excel_formula(evidence.get("filename"))
-                        for evidence in (item.get("evidence_attachments") or [])
-                        if evidence.get("filename")
-                    ),
-                ]
+                escape_csv_row(
+                    [
+                        item.get("name"),
+                        item.get("description"),
+                        item.get("category"),
+                        item.get("csf_function"),
+                        item.get("priority"),
+                        item.get("status"),
+                        item.get("eta"),
+                        item.get("expiry_date"),
+                        item.get("effort"),
+                        item.get("control_impact"),
+                        item.get("annual_cost"),
+                        "\n".join(
+                            escape_excel_formula(ra.get("str"))
+                            for ra in (item.get("requirement_assessments") or [])
+                        ),
+                        "\n".join(
+                            escape_excel_formula(evidence.get("str"))
+                            for evidence in (item.get("evidences") or [])
+                            if evidence.get("str")
+                        ),
+                        "\n".join(
+                            escape_excel_formula(evidence.get("filename"))
+                            for evidence in (item.get("evidence_attachments") or [])
+                            if evidence.get("filename")
+                        ),
+                    ]
+                )
             )
 
         return response
@@ -16892,7 +16902,7 @@ def generate_html(
 def export_mp_csv(request):
     response = HttpResponse(content_type="text/csv; charset=utf-8")
     response["Content-Disposition"] = 'attachment; filename="MP.csv"'
-    response.write("﻿")
+    response.write("\ufeff")
 
     writer = csv.writer(response, delimiter=";")
     columns = [
@@ -16925,16 +16935,16 @@ def export_mp_csv(request):
             mtg.description,
             mtg.category,
             mtg.csf_function,
-            mtg.priority,
             mtg.reference_control,
             mtg.eta,
+            mtg.priority,
             mtg.effort,
             mtg.control_impact,
             mtg.annual_cost,
             mtg.link,
             mtg.status,
         ]
-        writer.writerow(row)
+        writer.writerow(escape_csv_row(row))
 
     return response
 

--- a/backend/data_wizard/views.py
+++ b/backend/data_wizard/views.py
@@ -2648,7 +2648,9 @@ class LoadFileView(APIView):
                         ).fillna("")
                     else:
                         file_type = RecordFileType.CSV
-                        df = pd.read_csv(record_file).fillna("")
+                        # utf-8-sig transparently strips a leading BOM (added to our
+                        # CSV exports for Excel) so the first column header is not corrupted.
+                        df = pd.read_csv(record_file, encoding="utf-8-sig").fillna("")
 
                     try:
                         df = normalize_df_columns(df)


### PR DESCRIPTION
Fix CSV exports encoding to display correctly special characters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSV exports for better Excel/UTF-8 compatibility, including UTF-8 charset signaling and UTF-8 BOM for downloads.
  * Added CSV row escaping to help prevent Excel formula injection by sanitizing CSV cell values.
  * Ensured CSV imports handle Excel-generated UTF-8 BOMs correctly for reliable header parsing.
  * Updated MP export CSV column ordering to match the revised output format.
* **Tests**
  * Adjusted CSV export assertions to expect the updated `Content-Type` with charset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->