### PR TITLE
feat: allow admins to disable the partially compliant option

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -16429,13 +16429,10 @@ class RequirementAssessmentViewSet(BaseModelViewSet):
     def status(self, request):
         return Response(dict(RequirementAssessment.Status.choices))
 
+    @method_decorator(cache_page(60 * LONG_CACHE_TTL))
     @action(detail=False, name="Get result choices")
     def result(self, request):
-        # Not cached: choices depend on a setting an admin can toggle anytime.
-        choices = dict(RequirementAssessment.Result.choices)
-        if general_setting_is_enabled("disable_partially_compliant_result"):
-            choices.pop(RequirementAssessment.Result.PARTIALLY_COMPLIANT, None)
-        return Response(choices)
+        return Response(dict(RequirementAssessment.Result.choices))
 
     @method_decorator(cache_page(60 * LONG_CACHE_TTL))
     @action(detail=False, name="Get extended result choices")

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -16429,10 +16429,13 @@ class RequirementAssessmentViewSet(BaseModelViewSet):
     def status(self, request):
         return Response(dict(RequirementAssessment.Status.choices))
 
-    @method_decorator(cache_page(60 * LONG_CACHE_TTL))
     @action(detail=False, name="Get result choices")
     def result(self, request):
-        return Response(dict(RequirementAssessment.Result.choices))
+        # Not cached: choices depend on a setting an admin can toggle anytime.
+        choices = dict(RequirementAssessment.Result.choices)
+        if general_setting_is_enabled("disable_partially_compliant_result"):
+            choices.pop(RequirementAssessment.Result.PARTIALLY_COMPLIANT, None)
+        return Response(choices)
 
     @method_decorator(cache_page(60 * LONG_CACHE_TTL))
     @action(detail=False, name="Get extended result choices")

--- a/backend/global_settings/serializers.py
+++ b/backend/global_settings/serializers.py
@@ -98,6 +98,7 @@ GENERAL_SETTINGS_KEYS = [
     "default_landing",
     "personal_folders",
     "personal_folders_parent",
+    "disable_partially_compliant_result",
 ]
 
 LLM_URL_DEFAULTS = {

--- a/backend/global_settings/views.py
+++ b/backend/global_settings/views.py
@@ -181,6 +181,7 @@ class GeneralSettingsViewSet(viewsets.ModelViewSet):
             "enforce_mfa": False,
             "default_language": "en",
             "default_custom_analytics_dashboard": None,
+            "disable_partially_compliant_result": False,
         }
 
         settings, created = GlobalSettings.objects.get_or_create(name="general")

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -853,6 +853,8 @@
 	"nonCompliantMinor": "Non compliant minor",
 	"nonCompliantMajor": "Non compliant major",
 	"partiallyCompliant": "Partially compliant",
+	"disablePartiallyCompliantResult": "Disable \"partially compliant\" result",
+	"disablePartiallyCompliantResultHelpText": "When enabled, \"partially compliant\" is no longer offered when setting a requirement assessment result. Existing values are preserved and still displayed.",
 	"compliant": "Compliant",
 	"notApplicable": "Not applicable",
 	"notAssessed": "Not assessed",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -836,6 +836,8 @@
 	"nonCompliantMinor": "Mineur non conforme",
 	"nonCompliantMajor": "Majeure non conforme",
 	"partiallyCompliant": "Partiellement conforme",
+	"disablePartiallyCompliantResult": "Désactiver le résultat « partiellement conforme »",
+	"disablePartiallyCompliantResultHelpText": "Lorsque cette option est activée, « partiellement conforme » n'est plus proposé lors de la définition du résultat d'une évaluation d'exigence. Les valeurs existantes sont conservées et restent affichées.",
 	"compliant": "Conforme",
 	"notApplicable": "Non applicable",
 	"notAssessed": "Non évaluée",

--- a/frontend/src/lib/components/Forms/ModelForm/GeneralSettingForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/GeneralSettingForm.svelte
@@ -307,23 +307,29 @@
 			</div>
 		</Accordion.ItemContent>
 	</Accordion.Item>
-	{#if $page.data.featureflags?.audit_tree_inheritance}
-		<Accordion.Item value="audits">
-			<Accordion.ItemTrigger class="flex w-full items-center cursor-pointer">
-				<i class="fa-solid fa-list-check mr-2"></i><span class="flex-1 text-left"
-					>{m.complianceAssessments()}</span
-				>
-				<Accordion.ItemIndicator
-					class="transition-transform duration-200 data-[state=open]:rotate-0 data-[state=closed]:-rotate-90"
-					><svg xmlns="http://www.w3.org/2000/svg" width="14px" height="14px" viewBox="0 0 448 512"
-						><path
-							d="M201.4 374.6c12.5 12.5 32.8 12.5 45.3 0l160-160c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L224 306.7 86.6 169.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l160 160z"
-						/></svg
-					></Accordion.ItemIndicator
-				>
-			</Accordion.ItemTrigger>
-			<Accordion.ItemContent>
-				<div class="p-4">
+	<Accordion.Item value="audits">
+		<Accordion.ItemTrigger class="flex w-full items-center cursor-pointer">
+			<i class="fa-solid fa-list-check mr-2"></i><span class="flex-1 text-left"
+				>{m.complianceAssessments()}</span
+			>
+			<Accordion.ItemIndicator
+				class="transition-transform duration-200 data-[state=open]:rotate-0 data-[state=closed]:-rotate-90"
+				><svg xmlns="http://www.w3.org/2000/svg" width="14px" height="14px" viewBox="0 0 448 512"
+					><path
+						d="M201.4 374.6c12.5 12.5 32.8 12.5 45.3 0l160-160c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L224 306.7 86.6 169.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l160 160z"
+					/></svg
+				></Accordion.ItemIndicator
+			>
+		</Accordion.ItemTrigger>
+		<Accordion.ItemContent>
+			<div class="p-4 space-y-4">
+				<Checkbox
+					{form}
+					field="disable_partially_compliant_result"
+					label={m.disablePartiallyCompliantResult()}
+					helpText={m.disablePartiallyCompliantResultHelpText()}
+				/>
+				{#if $page.data.featureflags?.audit_tree_inheritance}
 					<Select
 						{form}
 						field="audit_tree_aggregation_strategy"
@@ -337,10 +343,10 @@
 						label={m.auditTreeAggregationStrategy()}
 						helpText={m.auditTreeAggregationStrategyHelpText()}
 					/>
-				</div>
-			</Accordion.ItemContent>
-		</Accordion.Item>
-	{/if}
+				{/if}
+			</div>
+		</Accordion.ItemContent>
+	</Accordion.Item>
 	<Accordion.Item value="riskMatrix">
 		<Accordion.ItemTrigger class="flex w-full items-center cursor-pointer">
 			<i class="fa-solid fa-table-cells-large mr-2"></i><span class="flex-1 text-left"

--- a/frontend/src/lib/components/Forms/ModelForm/RequirementAssessmentForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/RequirementAssessmentForm.svelte
@@ -7,6 +7,8 @@
 	import type { ModelInfo, CacheLock } from '$lib/utils/types';
 	import { m } from '$paraglide/messages';
 	import AutocompleteSelect from '../AutocompleteSelect.svelte';
+	import { page } from '$app/state';
+	import { filterResultChoices } from '$lib/utils/helpers';
 
 	interface Props {
 		form: SuperValidated<any>;
@@ -58,7 +60,11 @@
 	/>
 	<Select
 		{form}
-		options={model.selectOptions['result']}
+		options={filterResultChoices(
+			model.selectOptions['result'],
+			page.data.settings?.disable_partially_compliant_result,
+			object?.result
+		)}
 		field="result"
 		label={m.result()}
 		cacheLock={cacheLocks['result']}

--- a/frontend/src/lib/utils/helpers.ts
+++ b/frontend/src/lib/utils/helpers.ts
@@ -1,4 +1,5 @@
 import { complianceResultColorMap } from '$lib/utils/constants';
+import { m } from '$paraglide/messages';
 
 export function formatStringToDate(inputString: string, locale = 'en') {
 	const date = new Date(inputString);
@@ -398,6 +399,40 @@ function aggregateComputeResults(resolved: string[]): string | null {
 	if (hasPartial || (hasCompliant && hasNonCompliant)) return 'partially_compliant';
 	if (hasNonCompliant) return 'non_compliant';
 	return 'compliant';
+}
+
+/**
+ * Whether "partially compliant" should be offered when setting a result.
+ * Dropped when `disablePartial`, unless it is already the assessment's persisted
+ * value, so existing data keeps rendering its selected state.
+ */
+function showPartiallyCompliant(disablePartial: boolean, currentResult: string | null): boolean {
+	return !disablePartial || currentResult === 'partially_compliant';
+}
+
+/** Build the {id,label} result options for the bulk result editors. */
+export function requirementResultOptions(
+	disablePartial = false,
+	currentResult: string | null = null
+): { id: string; label: string }[] {
+	const showPartial = showPartiallyCompliant(disablePartial, currentResult);
+	return [
+		{ id: 'not_assessed', label: m.notAssessed() },
+		{ id: 'non_compliant', label: m.nonCompliant() },
+		...(showPartial ? [{ id: 'partially_compliant', label: m.partiallyCompliant() }] : []),
+		{ id: 'compliant', label: m.compliant() },
+		{ id: 'not_applicable', label: m.notApplicable() }
+	];
+}
+
+/** Filter backend-provided {value,label} result choices the same way. */
+export function filterResultChoices<T extends { value: string }>(
+	options: T[],
+	disablePartial = false,
+	currentResult: string | null = null
+): T[] {
+	if (showPartiallyCompliant(disablePartial, currentResult)) return options;
+	return options.filter((o) => o.value !== 'partially_compliant');
 }
 
 /**

--- a/frontend/src/lib/utils/schemas.ts
+++ b/frontend/src/lib/utils/schemas.ts
@@ -600,6 +600,7 @@ export const GeneralSettingsSchema = z.object({
 		.default('none')
 		.optional(),
 	default_landing: z.enum(['analytics', 'respondent', 'portal']).default('analytics').optional(),
+	disable_partially_compliant_result: z.boolean().default(false).optional(),
 	personal_folders_parent: z.string().uuid().optional().nullable(),
 	currency: z.enum(CURRENCY_SYMBOLS).default('€'),
 	daily_rate: z.number().default(500).optional(),

--- a/frontend/src/routes/(app)/(internal)/compliance-assessments/[id=uuid]/flash-mode/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/compliance-assessments/[id=uuid]/flash-mode/+page.svelte
@@ -12,6 +12,7 @@
 		resultBadgeStyle
 	} from '$lib/utils/helpers';
 	import { safeTranslate } from '$lib/utils/i18n';
+	import { page } from '$app/state';
 
 	interface Props {
 		data: PageData;
@@ -33,7 +34,9 @@
 	const possible_options = [
 		{ id: 'not_assessed', label: m.notAssessed() },
 		{ id: 'non_compliant', label: m.nonCompliant() },
-		{ id: 'partially_compliant', label: m.partiallyCompliant() },
+		...(page.data.settings?.disable_partially_compliant_result
+			? []
+			: [{ id: 'partially_compliant', label: m.partiallyCompliant() }]),
 		{ id: 'compliant', label: m.compliant() },
 		{ id: 'not_applicable', label: m.notApplicable() }
 	];

--- a/frontend/src/routes/(app)/(internal)/compliance-assessments/[id=uuid]/flash-mode/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/compliance-assessments/[id=uuid]/flash-mode/+page.svelte
@@ -9,7 +9,8 @@
 		getFieldVisibility,
 		hasComputedResult,
 		computeRequirementScoreAndResult,
-		resultBadgeStyle
+		resultBadgeStyle,
+		requirementResultOptions
 	} from '$lib/utils/helpers';
 	import { safeTranslate } from '$lib/utils/i18n';
 	import { page } from '$app/state';
@@ -31,15 +32,12 @@
 	const showResult = $derived(fieldVis.showResult);
 	const showObservation = $derived(fieldVis.showObservation);
 
-	const possible_options = [
-		{ id: 'not_assessed', label: m.notAssessed() },
-		{ id: 'non_compliant', label: m.nonCompliant() },
-		...(page.data.settings?.disable_partially_compliant_result
-			? []
-			: [{ id: 'partially_compliant', label: m.partiallyCompliant() }]),
-		{ id: 'compliant', label: m.compliant() },
-		{ id: 'not_applicable', label: m.notApplicable() }
-	];
+	const possible_options = $derived(
+		requirementResultOptions(
+			page.data.settings?.disable_partially_compliant_result,
+			currentRequirementAssessment?.result
+		)
+	);
 
 	const requirementHashmap = Object.fromEntries(
 		data.requirements.map((requirement: Record<string, any>) => [requirement.id, requirement])

--- a/frontend/src/routes/(app)/(third-party)/auditee-assessments/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/auditee-assessments/[id=uuid]/+page.svelte
@@ -32,6 +32,7 @@
 		alignmentValueFromChoiceUrn,
 		choiceUrnFromAlignmentValue,
 		alignmentColorMap,
+		requirementResultOptions,
 		AUTO_ALIGNMENT_QUESTION_URN
 	} from '$lib/utils/helpers';
 	import { safeTranslate } from '$lib/utils/i18n';
@@ -51,15 +52,8 @@
 
 	let { data, form }: Props = $props();
 
-	const result_options = [
-		{ id: 'not_assessed', label: m.notAssessed() },
-		{ id: 'non_compliant', label: m.nonCompliant() },
-		...(page.data.settings?.disable_partially_compliant_result
-			? []
-			: [{ id: 'partially_compliant', label: m.partiallyCompliant() }]),
-		{ id: 'compliant', label: m.compliant() },
-		{ id: 'not_applicable', label: m.notApplicable() }
-	];
+	// Full list, used for the ToC result counts; the input radio filters per-row.
+	const result_options = requirementResultOptions();
 
 	const status_options = [
 		{ id: 'to_do', label: m.toDo() },
@@ -1021,7 +1015,10 @@
 										</span>
 									{:else}
 										<RadioGroup
-											possibleOptions={result_options}
+											possibleOptions={requirementResultOptions(
+												page.data.settings?.disable_partially_compliant_result,
+												requirementAssessment.result
+											)}
 											key="id"
 											labelKey="label"
 											field="result"

--- a/frontend/src/routes/(app)/(third-party)/auditee-assessments/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/auditee-assessments/[id=uuid]/+page.svelte
@@ -54,7 +54,9 @@
 	const result_options = [
 		{ id: 'not_assessed', label: m.notAssessed() },
 		{ id: 'non_compliant', label: m.nonCompliant() },
-		{ id: 'partially_compliant', label: m.partiallyCompliant() },
+		...(page.data.settings?.disable_partially_compliant_result
+			? []
+			: [{ id: 'partially_compliant', label: m.partiallyCompliant() }]),
 		{ id: 'compliant', label: m.compliant() },
 		{ id: 'not_applicable', label: m.notApplicable() }
 	];

--- a/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/table-mode/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/table-mode/+page.svelte
@@ -34,6 +34,7 @@
 		choiceUrnFromAlignmentValue,
 		alignmentColorMap,
 		resultBadgeStyle,
+		requirementResultOptions,
 		AUTO_ALIGNMENT_QUESTION_URN
 	} from '$lib/utils/helpers';
 	import { safeTranslate } from '$lib/utils/i18n';
@@ -68,15 +69,6 @@
 		invalidateAllBool = true
 	}: Props = $props();
 
-	const result_options = [
-		{ id: 'not_assessed', label: m.notAssessed() },
-		{ id: 'non_compliant', label: m.nonCompliant() },
-		...(page.data.settings?.disable_partially_compliant_result
-			? []
-			: [{ id: 'partially_compliant', label: m.partiallyCompliant() }]),
-		{ id: 'compliant', label: m.compliant() },
-		{ id: 'not_applicable', label: m.notApplicable() }
-	];
 	const status_options = [
 		{ id: 'to_do', label: m.toDo() },
 		{ id: 'in_progress', label: m.inProgress() },
@@ -605,7 +597,10 @@
 														</span>
 													{:else}
 														<RadioGroup
-															possibleOptions={result_options}
+															possibleOptions={requirementResultOptions(
+																page.data.settings?.disable_partially_compliant_result,
+																requirementAssessment.result
+															)}
 															key="id"
 															labelKey="label"
 															field="result"

--- a/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/table-mode/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/table-mode/+page.svelte
@@ -71,7 +71,9 @@
 	const result_options = [
 		{ id: 'not_assessed', label: m.notAssessed() },
 		{ id: 'non_compliant', label: m.nonCompliant() },
-		{ id: 'partially_compliant', label: m.partiallyCompliant() },
+		...(page.data.settings?.disable_partially_compliant_result
+			? []
+			: [{ id: 'partially_compliant', label: m.partiallyCompliant() }]),
 		{ id: 'compliant', label: m.compliant() },
 		{ id: 'not_applicable', label: m.notApplicable() }
 	];

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.svelte
@@ -40,7 +40,8 @@
 		computeRequirementScoreAndResult,
 		formatScoreValue,
 		displayScoreColor,
-		resultBadgeStyle
+		resultBadgeStyle,
+		filterResultChoices
 	} from '$lib/utils/helpers';
 
 	interface Props {
@@ -756,7 +757,11 @@
 							{:else}
 								<Select
 									{form}
-									options={page.data.model.selectOptions['result']}
+									options={filterResultChoices(
+										page.data.model.selectOptions['result'],
+										page.data.settings?.disable_partially_compliant_result,
+										data.requirementAssessment.result
+									)}
 									field="result"
 									label={m.result()}
 									helpText={m.requirementAssessmentResultHelpText()}

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.svelte
@@ -760,7 +760,7 @@
 									options={filterResultChoices(
 										page.data.model.selectOptions['result'],
 										page.data.settings?.disable_partially_compliant_result,
-										data.requirementAssessment.result
+										data.result
 									)}
 									field="result"
 									label={m.result()}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global setting to disable the “partially compliant” result option in requirement assessments (default: off).
  * Updated assessment screens (flash/table views and edit/bulk editors) to conditionally hide the “partially compliant” choice when enabled.
  * Added the setting checkbox to the General Settings UI.
* **Bug Fixes**
  * Existing records with “partially compliant” results remain selectable/viewable even when the option is disabled.
* **Documentation**
  * Added new English and French label/help text explaining the behavior when the setting is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->