### PR TITLE
fix(frontend): broken /undefined/<id> links on finding detail page

### DIFF
--- a/frontend/src/lib/utils/crud.ts
+++ b/frontend/src/lib/utils/crud.ts
@@ -2095,7 +2095,11 @@ export const URL_MODEL_MAP: ModelMap = {
 			{ field: 'folder', urlModel: 'folders' },
 			{ field: 'filtering_labels', urlModel: 'filtering-labels' },
 			{ field: 'perimeter', urlModel: 'perimeters' },
-			{ field: 'vulnerabilities', urlModel: 'vulnerabilities' }
+			{ field: 'vulnerabilities', urlModel: 'vulnerabilities' },
+			{ field: 'threats', urlModel: 'threats' },
+			{ field: 'reference_controls', urlModel: 'reference-controls' },
+			{ field: 'applied_controls', urlModel: 'applied-controls' },
+			{ field: 'evidences', urlModel: 'evidences' }
 		],
 		reverseForeignKeyFields: [
 			{


### PR DESCRIPTION
## Summary

On a finding's detail page, links to related applied controls, evidences, threats, and reference controls pointed to `/undefined/<uuid>` instead of the proper route — e.g. an applied control named "Business Impact Analysis" on a finding would render as `/undefined/12345678-...` and 404.

## Root cause

`DetailView.svelte` builds related-item hrefs via:

    `/${data.model?.foreignKeyFields?.find(i => i.field === key)?.urlModel}/${val.id}`

When the field isn't in `foreignKeyFields`, `?.urlModel` is `undefined` and the template literal interpolates it as the literal string `"undefined"`.

The `findings` entry in `crud.ts` only listed `findings_assessment`, `owner`, `folder`, `filtering_labels`, `perimeter`, and `vulnerabilities`, but `FindingReadSerializer` also exposes `threats`, `reference_controls`, `applied_controls`, and `evidences`. Any of those related collections rendered on the finding page hit the bug.

## Changes

- `frontend/src/lib/utils/crud.ts` — add `threats`, `reference_controls`, `applied_controls`, and `evidences` to `findings.foreignKeyFields`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded support for related record links on findings, so more associated items now resolve correctly.
  * Improved handling for additional linked objects, including threats, controls, and evidence, alongside vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->