### PR TITLE
fix(scim): feature flag position move from ce to en serializer

### DIFF
--- a/backend/global_settings/serializers.py
+++ b/backend/global_settings/serializers.py
@@ -372,9 +372,6 @@ class FeatureFlagsSerializer(serializers.ModelSerializer):
     outgoing_webhooks = serializers.BooleanField(
         source="value.outgoing_webhooks", required=False, default=False
     )
-    idp_groups = serializers.BooleanField(
-        source="value.idp_groups", required=False, default=False
-    )
     metrology = serializers.BooleanField(
         source="value.metrology", required=False, default=True
     )

--- a/enterprise/backend/enterprise_core/apps.py
+++ b/enterprise/backend/enterprise_core/apps.py
@@ -26,7 +26,7 @@ def startup(sender, **kwargs):
     if not isinstance(ff.value, dict):
         ff.value = {}
     if "idp_groups" not in ff.value:
-        ff.value["idp_groups"] = True
+        ff.value["idp_groups"] = False
         ff.save(update_fields=["value"])
 
     administrator_permissions = Permission.objects.filter(

--- a/enterprise/backend/enterprise_core/serializers.py
+++ b/enterprise/backend/enterprise_core/serializers.py
@@ -280,3 +280,6 @@ class FeatureFlagsSerializer(CommunityFeatureFlagSerializer):
     object_audit_trail = serializers.BooleanField(
         source="value.object_audit_trail", required=False, default=True
     )
+    idp_groups = serializers.BooleanField(
+        source="value.idp_groups", required=False, default=False
+    )


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits (squash-merged → title becomes the commit subject):
  feat | fix | chore | refactor | perf | docs | test | ci | build   (lowercase, scope optional, `!` for breaking)
  e.g. feat(lib): add NIS2 framework   |   fix(api): correct residual risk validation
Full guide: product-docs/contributing/code.md
-->

## What & why

<!-- What does this change do, and why? Link the issue if there is one. -->
move the idp_group management scim feature flag from CE to EN serializer

## Test plan

<!-- What you ran/clicked to verify. Attach screenshots for UI changes. -->

## Checklist

<!-- Keep the sections that apply, delete the rest. Tests and docs are part of "done" — tick them when relevant, or note why they aren't. -->

- [X] PR title follows Conventional Commits (`!` set if this is a breaking change)
- [X] One focused change, branched off `main`
- [ ] CLA accepted (first contribution only)

### Backend — if you touched `backend/`

- [X] `ruff format` run, no new linter errors
- [ ] Migrations generated with `makemigrations` and committed (or none needed)
- [ ] New dependencies checked for known vulnerabilities and called out above

### Frontend — if you touched `frontend/`

- [ ] Svelte 5 syntax; `pnpm run lint` and `pnpm run format` run
- [ ] New/changed UI strings added to `frontend/messages/en.json` (keep keys, preserve `{tokens}`)
- [ ] Clicked through the change in the dev server; screenshots attached for UI changes

### Other — libraries, CI, infra

- [ ] Library changes built via the `tools/` script
- [ ] CI / build changes run green

### Tests & documentation — definition of done

- [ ] Tests added or updated and passing locally — backend `uv run pytest`, frontend `pnpm run test` / `./tests/e2e-tests.sh` _(if relevant)_
- [ ] Regression test added for bug fixes _(if relevant)_
- [ ] `product-docs/` updated, new pages listed in `SUMMARY.md`, vocabulary terms added _(if relevant)_
- [X] No tests or docs needed for this change — why: Still allign with current docs and tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the **IDP groups** feature flag in enterprise global settings, enabling configuration where supported.
* **Bug Fixes**
  * Improved consistency in feature flag exposure and bootstrapping: when the **IDP groups** flag is missing from stored settings, it now defaults to **disabled** instead of being treated as enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->