### PR TITLE
fix: normalize urls to avoid comparison issue on default ports

### DIFF
--- a/frontend/src/lib/utils/constants.ts
+++ b/frontend/src/lib/utils/constants.ts
@@ -1,11 +1,18 @@
 import { env } from '$env/dynamic/public';
 import { m } from '$paraglide/messages';
 
-export const BASE_API_URL = `${
-	Object.hasOwn(env, 'PUBLIC_BACKEND_API_URL')
-		? env.PUBLIC_BACKEND_API_URL
-		: 'http://localhost:8000/api'
-}`;
+const rawBackendApiUrl = Object.hasOwn(env, 'PUBLIC_BACKEND_API_URL')
+	? env.PUBLIC_BACKEND_API_URL
+	: 'http://localhost:8000/api';
+
+// Strip default ports so this matches request.url in handleFetch's startsWith check (issue #4422).
+export const BASE_API_URL = (() => {
+	try {
+		return new URL(rawBackendApiUrl).href.replace(/\/$/, '');
+	} catch {
+		return rawBackendApiUrl;
+	}
+})();
 
 export const DEFAULT_LANGUAGE = `${
 	Object.hasOwn(env, 'PUBLIC_DEFAULT_LANGUAGE') ? env.PUBLIC_DEFAULT_LANGUAGE : 'en'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backend URL handling by normalizing the configured API address and removing trailing slashes when possible.
  * Added a safe fallback so the app continues using the provided API URL if parsing fails.
  * Helps reduce connection issues caused by inconsistent URL formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->