### PR TITLE
fix: proper color on subcontractor chain in dark mode

### DIFF
--- a/frontend/src/lib/components/Forms/ModelForm/SubcontractingChainEditor.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/SubcontractingChainEditor.svelte
@@ -192,19 +192,19 @@
 {#snippet nodeCard(node: TreeNode, isRoot: boolean)}
 	<div
 		class="flex items-center gap-3 rounded border p-3 {isRoot
-			? 'border-surface-300 bg-surface-100'
-			: 'border-surface-200'}"
+			? 'border-surface-300-700 bg-surface-100-900'
+			: 'border-surface-200-800'}"
 		data-testid={isRoot ? 'chain-direct-provider' : 'chain-row'}
 	>
 		<div
 			class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full {isRoot
 				? 'bg-primary-500 text-white'
-				: 'bg-surface-300 text-surface-700'}"
+				: 'bg-surface-300-700 text-surface-700-300'}"
 		>
 			<i class="fa-solid {isRoot ? 'fa-building' : 'fa-sitemap'}" aria-hidden="true"></i>
 		</div>
 		<div class="flex-1">
-			<div class="text-xs font-semibold tracking-wide text-surface-600 uppercase">
+			<div class="text-xs font-semibold tracking-wide text-surface-600-400 uppercase">
 				{#if isRoot}
 					{m.subcontractingDirectProvider()}
 				{:else}
@@ -281,8 +281,8 @@
 
 	<!-- Inline picker when adding a child to this node -->
 	{#if addingChildOf === node.entityId}
-		<div class="mt-2 rounded border border-dashed border-surface-300 p-3">
-			<div class="mb-2 text-xs font-semibold tracking-wide text-surface-600 uppercase">
+		<div class="mt-2 rounded border border-dashed border-surface-300-700 p-3">
+			<div class="mb-2 text-xs font-semibold tracking-wide text-surface-600-400 uppercase">
 				{m.addSubcontractorTo({ entity: displayLabel(node.entityId) })}
 			</div>
 			{#key chain.length + '-' + node.entityId}
@@ -305,7 +305,7 @@
 
 	<!-- Children -->
 	{#if node.children.length > 0}
-		<div class="ml-6 border-l-2 border-surface-300 pl-4 mt-2 space-y-2">
+		<div class="ml-6 border-l-2 border-surface-300-700 pl-4 mt-2 space-y-2">
 			{#each node.children as child (child.entityId)}
 				{@render nodeCard(child, false)}
 			{/each}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the subcontracting chain editor with refreshed surface, border, and text color styling for better contrast.
  * Improved spacing and layout around the inline picker and child item list for a cleaner, more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->