### PR TITLE
fix: align idp groups ff to standard pattern

### DIFF
--- a/enterprise/frontend/src/lib/components/SideBar/navData.ts
+++ b/enterprise/frontend/src/lib/components/SideBar/navData.ts
@@ -137,8 +137,7 @@ export const navData = {
 				{
 					name: 'idpGroups',
 					fa_icon: 'fa-solid fa-id-badge',
-					href: '/idp-groups',
-					featureFlag: 'idp_groups'
+					href: '/idp-groups'
 				},
 				{
 					name: 'roles',

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -5238,5 +5238,6 @@
 	"mfaDisabledSuccessfully": "MFA has been disabled for this user",
 	"errorDisablingMFA": "Could not disable MFA for this user",
 	"userHasNoMFAEnabled": "This user does not have MFA enabled",
-	"decisionNotes": "Decision notes"
+	"decisionNotes": "Decision notes",
+	"addIdpGroup": "Add IdP group"
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -5157,5 +5157,6 @@
 	"mfaDisabledSuccessfully": "La MFA a été désactivée pour cet utilisateur",
 	"errorDisablingMFA": "Impossible de désactiver la MFA pour cet utilisateur",
 	"userHasNoMFAEnabled": "Cet utilisateur n'a pas la MFA activée",
-	"decisionNotes": "Notes de décision"
+	"decisionNotes": "Notes de décision",
+	"addIdpGroup": "Ajouter un groupe IdP"
 }

--- a/frontend/src/lib/components/SideBar/SideBarNavigation.svelte
+++ b/frontend/src/lib/components/SideBar/SideBarNavigation.svelte
@@ -9,17 +9,11 @@
 	import { driverInstance } from '$lib/utils/stores';
 
 	const user = page.data.user;
-	const featureflags = (page.data.featureflags ?? {}) as Record<string, boolean>;
 
 	const items = navData.items
 		.map((item) => {
 			// Check and filter the sub-items based on user permissions
 			const filteredSubItems = item.items.filter((subItem) => {
-				// Feature-flag gate: a flagged nav item is hidden unless its flag is enabled.
-				const featureFlag = (subItem as { featureFlag?: string }).featureFlag;
-				if (featureFlag && !featureflags[featureFlag]) {
-					return false;
-				}
 				if (subItem.exclude) {
 					return user?.roles?.some((role: string) => !subItem.exclude.includes(role)) ?? false;
 				} else if (subItem.permissions) {

--- a/frontend/src/lib/utils/sidebar-config.ts
+++ b/frontend/src/lib/utils/sidebar-config.ts
@@ -36,6 +36,7 @@ type SidebarBackendKeys = {
 	security_advisories: boolean;
 	cwes: boolean;
 	custom_portals: boolean;
+	idp_groups: boolean;
 };
 
 type SidebarFrontendKeys = {
@@ -74,6 +75,7 @@ type SidebarFrontendKeys = {
 	securityAdvisories: boolean;
 	cwes: boolean;
 	managePortals: boolean;
+	idpGroups: boolean;
 };
 
 export function getSidebarVisibleItems(
@@ -114,6 +116,7 @@ export function getSidebarVisibleItems(
 		presets: featureFlags?.journeys ?? true,
 		securityAdvisories: featureFlags?.security_advisories ?? true,
 		cwes: featureFlags?.cwes ?? true,
-		managePortals: featureFlags?.custom_portals ?? false
+		managePortals: featureFlags?.custom_portals ?? false,
+		idpGroups: featureFlags?.idp_groups ?? false
 	};
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “Add IdP group” button label with English and French translations.
  * Extended sidebar visibility support for identity provider groups.
* **Enhancements**
  * Updated sidebar navigation to no longer hide sub-items using feature-flag gating; visibility now follows existing permission/exclusion/model checks.
* **Configuration**
  * Improved sidebar feature-flag mapping to include `idpGroups` derived from `idp_groups`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->