### PR TITLE
fix: preset editor edit page

### DIFF
--- a/frontend/src/routes/(app)/(internal)/experimental/preset-editor/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/experimental/preset-editor/[id=uuid]/+page.svelte
@@ -56,9 +56,9 @@
 		'incidents',
 		'metric-instances'
 	];
-	const ALL_MODELS = [
-		...new Set(['', ...NAV_ONLY_MODELS, ...Object.values(TYPE_TO_MODEL)])
-	].sort((a, b) => a.localeCompare(b));
+	const ALL_MODELS = [...new Set(['', ...NAV_ONLY_MODELS, ...Object.values(TYPE_TO_MODEL)])].sort(
+		(a, b) => a.localeCompare(b)
+	);
 
 	const FINDINGS_CATEGORIES = ['pentest', 'audit', 'review', 'other'];
 	const ASSET_TYPES = [

--- a/frontend/src/routes/(app)/(internal)/experimental/preset-editor/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(internal)/experimental/preset-editor/[id=uuid]/+page.svelte
@@ -56,9 +56,9 @@
 		'incidents',
 		'metric-instances'
 	];
-	const ALL_MODELS = ['', ...NAV_ONLY_MODELS, ...Object.values(TYPE_TO_MODEL)].sort((a, b) =>
-		a.localeCompare(b)
-	);
+	const ALL_MODELS = [
+		...new Set(['', ...NAV_ONLY_MODELS, ...Object.values(TYPE_TO_MODEL)])
+	].sort((a, b) => a.localeCompare(b));
 
 	const FINDINGS_CATEGORIES = ['pentest', 'audit', 'review', 'other'];
 	const ASSET_TYPES = [


### PR DESCRIPTION
## What and Why

This PR fixes a bug when we try to edit a custom journey.
```
Uncaught Svelte error: each_key_duplicate
Keyed each block has duplicate key `incidents` at indexes 11 and 12
https://svelte.dev/e/each_key_duplicate
```

**To reproduce**:
1. Create a custom journey
2. Add a new step
3. Add a Model as a pointer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the preset editor’s model list so duplicate entries are removed before display.
  * Model options are now shown in a consistent alphabetical order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->