### PR TITLE
fix(pro): edge cases with doc report templates override

### DIFF
--- a/backend/core/generators.py
+++ b/backend/core/generators.py
@@ -535,12 +535,36 @@ def gen_audit_context(id, doc, tree, lang):
             "opportunity_for_improvement": "Opportunité d'amélioration",
             "good_practice": "Bonne pratique",
         },
+        "nl": {
+            "compliant": "Compliant",
+            "partially_compliant": "Gedeeltelijk compliant",
+            "non_compliant": "Niet compliant",
+            "not_applicable": "Niet van toepassing",
+            "not_assessed": "Niet beoordeeld",
+            "to_do": "Te doen",
+            "on_hold": "In de wacht",
+            "in_progress": "In uitvoering",
+            "deprecated": "Verouderd",
+            "active": "Actief",
+            "policy": "Beleid",
+            "process": "Proces",
+            "technical": "Technisch",
+            "physical": "Fysiek",
+            "procedure": "Procedure",
+            "in_review": "In beoordeling",
+            "done": "Gedaan",
+            "major_nonconformity": "Ernstige niet-naleving",
+            "minor_nonconformity": "Kleine niet-naleving",
+            "observation_sensitive_point": "Observatie / aandachtspunt",
+            "opportunity_for_improvement": "Verbetermogelijkheid",
+            "good_practice": "Goede praktijk",
+        },
     }
 
     def safe_translate(lang: str, key: str) -> str:
         if key is None or key == "--":
             return "-"
-        return i18n_dict[lang].get(key, key)
+        return i18n_dict.get(lang, i18n_dict["en"]).get(key, key)
 
     donut_data = [
         {

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -13605,18 +13605,14 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
         """
         Word report generation (Exec)
         """
-        lang = "en"
-        if request.user.preferences.get("lang") is not None:
-            lang = request.user.preferences.get("lang")
-            if lang not in ["fr", "en"]:
-                lang = "en"
+        user_lang = request.user.preferences.get("lang") or "en"
 
-        # Check for custom Word template override
+        # Custom overrides support any language; auto-generated strings only en/fr.
         doc = None
         try:
             custom = CustomWordTemplate.objects.filter(
                 template_key="audit_report",
-                language=lang,
+                language=user_lang,
                 is_active=True,
             ).first()
             if custom and custom.file:
@@ -13629,12 +13625,10 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
             )
 
         if doc is None:
-            template_path = (
-                Path(__file__).resolve().parent
-                / "templates"
-                / "core"
-                / f"audit_report_template_{lang}.docx"
-            )
+            core_templates = Path(__file__).resolve().parent / "templates" / "core"
+            template_path = core_templates / f"audit_report_template_{user_lang}.docx"
+            if not template_path.exists():
+                template_path = core_templates / "audit_report_template_en.docx"
             doc = DocxTemplate(template_path)
         audit_obj = self.get_object()
         _framework = audit_obj.framework
@@ -13654,7 +13648,7 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
         # children in place but the returned dict drops them).
         filter_graph_by_implementation_groups(tree, implementation_groups)
         annotate_tree_with_aggregated_scores(tree, audit_obj)
-        context = gen_audit_context(pk, doc, tree, lang)
+        context = gen_audit_context(pk, doc, tree, user_lang)
         doc.render(context, jinja_env=SandboxedEnvironment())
         buffer_doc = io.BytesIO()
         doc.save(buffer_doc)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Dutch language support for audit reports, including localized compliance labels and domain terminology.
  * Reports now use the language selected in user preferences when choosing templates and translations.

* **Bug Fixes**
  * Improved language fallback behavior so reports remain usable when a translation or language-specific template is unavailable.
  * English templates and labels are now used automatically as a fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->