### PR TITLE
fix(backend): remove unreferenced decimals parameters from DORA RoI parameters.csv

### DIFF
--- a/backend/tprm/dora_export.py
+++ b/backend/tprm/dora_export.py
@@ -1708,15 +1708,14 @@ def generate_parameters(
         f"iso4217:{main_entity.currency}" if main_entity.currency else "iso4217:EUR"
     )
 
-    # Write parameters (7 parameters per OneGate XBRL Protocol v1.2, section 3.2)
+    # EBA XBRL-CSV filing rules only allow parameters referenced by the taxonomy;
+    # strict portals such as BaFin MVP reject unreferenced parameters as fatal errors.
     parameters = [
         ("entityID", entity_id),
         ("refPeriod", _compute_ref_period()),
         ("baseCurrency", base_currency),
         ("decimalsInteger", "0"),
         ("decimalsMonetary", "-3"),
-        ("decimalsPercentage", "4"),
-        ("decimalsDecimal", "2"),
     ]
 
     for name, value in parameters:

--- a/backend/tprm/test/test_dora_export.py
+++ b/backend/tprm/test/test_dora_export.py
@@ -2446,13 +2446,13 @@ class TestParameters(DoraExportTestMixin, TestCase):
         params = self._params_dict(buf)
         self.assertEqual(params["decimalsInteger"], "0")
         self.assertEqual(params["decimalsMonetary"], "-3")
-        self.assertEqual(params["decimalsPercentage"], "4")
-        self.assertEqual(params["decimalsDecimal"], "2")
+        self.assertNotIn("decimalsPercentage", params)
+        self.assertNotIn("decimalsDecimal", params)
 
-    def test_seven_parameter_rows(self):
+    def test_five_parameter_rows(self):
         buf = self._generate(dora_export.generate_parameters, self.entity)
         rows = self._read_csv(buf, "reports/parameters.csv")
-        self.assertEqual(len(self._data_rows(rows)), 7)
+        self.assertEqual(len(self._data_rows(rows)), 5)
 
 
 class TestReportPackageJson(DoraExportTestMixin, TestCase):


### PR DESCRIPTION
## What & why

Uploading the generated DORA Register of Information to the BaFin MVP portal fails with two FATAL_ERRORs: `Report parameter 'decimalsPercentage' has not been referenced by any dimension, decimals or property group`, and the same for `decimalsDecimal`. BaFin validates against strict EBA XBRL-CSV filing rules, where any report parameter not referenced by the taxonomy module is fatal. The DORA 4.0 taxonomy references no percentage or plain-decimal facts, so `generate_parameters()` in `backend/tprm/dora_export.py` was writing two parameters to `reports/parameters.csv` that no decimals property group ever references.

This removes the two unreferenced parameters, leaving the five the taxonomy actually references (`entityID`, `refPeriod`, `baseCurrency`, `decimalsInteger`, `decimalsMonetary`), and replaces the "7 parameters per OneGate XBRL Protocol" comment with the actual constraint: only taxonomy-referenced parameters may appear.

Closes #4474

## Test plan

Updated `TestParameters` in `backend/tprm/test/test_dora_export.py`:

- `test_decimals` now asserts `decimalsPercentage` and `decimalsDecimal` are absent from `reports/parameters.csv` (regression coverage for the BaFin rejection)
- `test_seven_parameter_rows` renamed to `test_five_parameter_rows`, asserting exactly 5 data rows

Ran `ruff format --check` and `ruff check` on both touched files: no formatting changes, no new linter errors (the 4 F401s in `dora_export.py` are pre-existing on `main` and untouched here).

## Checklist

- [x] PR title follows Conventional Commits
- [x] One focused change, branched off `main`
- [x] CLA accepted (first contribution only)

### Backend — if you touched `backend/`

- [x] `ruff format` run, no new linter errors
- [x] Migrations generated with `makemigrations` and committed (or none needed — this change touches only the CSV exporter and its tests)
- [x] New dependencies checked for known vulnerabilities and called out above (none added)

### Frontend — if you touched `frontend/`

N/A — no frontend files touched.

### Other — libraries, CI, infra

N/A — no library, CI, or infra changes.

### Tests & documentation — definition of done

- [x] Tests added or updated and passing locally — backend `uv run pytest tprm/test/test_dora_export.py -k TestParameters`
- [x] Regression test added for bug fixes (`decimalsPercentage`/`decimalsDecimal` absence assertions)
- [ ] `product-docs/` updated — not relevant: behavior change is removal of invalid CSV output, no documented behavior changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated DORA exports to comply with stricter XBRL-CSV filing requirements.
  * Removed unsupported decimal parameters from generated filing data, reducing the risk of portal rejection.

* **Tests**
  * Updated export validation to confirm that exactly five parameter rows are generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->