### PR TITLE
fix: exclude paraglide files in tsconfig.json

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -9,7 +9,17 @@
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true
-	}
+	},
+	"exclude": [
+		"node_modules/**",
+		"src/service-worker.js",
+		"src/service-worker/**/*.js",
+		"src/service-worker.ts",
+		"src/service-worker/**/*.ts",
+		"src/service-worker.d.ts",
+		"src/service-worker/**/*.d.ts",
+		"src/paraglide/**"
+	]
 	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
 	//
 	// If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes


### PR DESCRIPTION
# Why this PR exists

(LoC means "lines of code")

On my local machine the `frontend/src` directory of the repository contains 1001 files.
In total this resresent 711082 LoC.

The `src/paraglide` directory contain `558633` LoC despite being composed of only 32 files.

This means 78.5% of our LoC are inside `src/paraglide`:

```py
   11043    58039   393169 src/paraglide/messages/cs.js
    9372    52569   368766 src/paraglide/messages/ur.js
    9441    50407   345914 src/paraglide/messages/sv.js
   11028    57319   429062 src/paraglide/messages/uk.js
    9399    50180   351699 src/paraglide/messages/hu.js
   15521    80918   515136 src/paraglide/messages/es.js
   16945    84502   539965 src/paraglide/messages/hr.js
    9384    50594   365174 src/paraglide/messages/ar.js
   15101    76236   498803 src/paraglide/messages/nl.js
   11670    60370   404524 src/paraglide/messages/pl.js
   18337    90203   588965 src/paraglide/messages/lt.js
   13143    68136   443071 src/paraglide/messages/it.js
   11543    59595   446566 src/paraglide/messages/el.js
   15537    69451   482801 src/paraglide/messages/zh.js
  228187  1529318 12444917 src/paraglide/messages/_index.js
    9306    51295   399920 src/paraglide/messages/hi.js
    9453    51486   349222 src/paraglide/messages/pt.js
   19867    99975   614572 src/paraglide/messages/en.js
   17479    85625   564295 src/paraglide/messages/ko.js
    9447    51255   348778 src/paraglide/messages/ro.js
   15085    74988   498895 src/paraglide/messages/de.js
   19111    92660   597565 src/paraglide/messages/et.js
   10305    54236   367161 src/paraglide/messages/da.js
   11655    59891   403610 src/paraglide/messages/tr.js
    9954    53188   359274 src/paraglide/messages/id.js
   19812   103064   645582 src/paraglide/messages/fr.js
       3       18      150 src/paraglide/.prettierignore
       3       21      150 src/paraglide/messages.js
     188      928     7767 src/paraglide/server.js
       3       18      150 src/paraglide/.gitignore
      30       91      867 src/paraglide/registry.js
    1281     5040    42869 src/paraglide/runtime.js
  558633  3221616 23819359 total
```

These LoC are not meant to be modified/read by us.
Despite that the `frontend/tsconfig.json` include these files anyway.

This PR aims to exclude `src/paraglide` from the typescript compiler scope.
This reduces the number of LoC interpreted by the typescript compiler from 711082 to 152449 (21.44% of the current LoC will remain).

I am doing this PR because my IDE suffers from it :(.

# The solution

The `frontend/.svelte-kit/tsconfig.json` file is generated by sveltekit based on the `frontend/svelte.config.js` file.

To fix this issue i just copied the `"exclude"` field of the `frontend/.svelte-kit/tsconfig.json` config file into `frontend/tsconfig.json`.
And i added the `src/paraglide/**` exclude pattern to it.

We need to copy all the `"exclude"` patterns as the behavior of `"extends"` makes it so the `"exclude"` parameter of `frontend/tsconfig.json` [overwrites the one in](https://www.typescriptlang.org/tsconfig/#extends) `frontend/.svelte-kit/tsconfig.json`.

You can see the effective configuration diff by using `npx tsc --showConfig` on both the `main` branch and this PR's branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript project configuration by excluding generated service worker files, dependency directories, and localization artifacts from compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->