### PR TITLE
chores: experiment to move to Docker Hardened Images (DHI)

### DIFF
--- a/.github/mirror-images.json
+++ b/.github/mirror-images.json
@@ -6,5 +6,10 @@
   { "source": "docker.io/library/caddy:2.11.4", "target": "caddy:2.11.4", "platforms": "linux/amd64" },
   { "source": "docker.io/library/node:24-slim", "target": "node:24-slim" },
   { "source": "docker.io/library/python:3.14-slim", "target": "python:3.14-slim" },
-  { "source": "docker.io/library/python:3.12-slim", "target": "python:3.12-slim" }
+  { "source": "docker.io/library/python:3.12-slim", "target": "python:3.12-slim" },
+  { "source": "dhi.io/node:24-dev", "target": "dhi-node:24-dev" },
+  { "source": "dhi.io/node:24", "target": "dhi-node:24" },
+  { "source": "dhi.io/python:3.14-dev", "target": "dhi-python:3.14-dev" },
+  { "source": "dhi.io/python:3.12-dev", "target": "dhi-python:3.12-dev" },
+  { "source": "dhi.io/caddy:2", "target": "dhi-caddy:2" }
 ]

--- a/.github/workflows/startup-tests.yml
+++ b/.github/workflows/startup-tests.yml
@@ -153,7 +153,8 @@ jobs:
       # Pull build-time and runtime base images from our GHCR mirror instead of
       # Docker Hub to avoid anonymous pull rate limits. See .github/mirror-images.json.
       PYTHON_IMAGE: ghcr.io/intuitem/ciso-assistant-community/mirror/python:3.14-slim
-      NODE_IMAGE: ghcr.io/intuitem/ciso-assistant-community/mirror/node:24-slim
+      NODE_BUILD_IMAGE: ghcr.io/intuitem/ciso-assistant-community/mirror/dhi-node:24-dev
+      NODE_RUNTIME_IMAGE: ghcr.io/intuitem/ciso-assistant-community/mirror/dhi-node:24
       QDRANT_IMAGE: ghcr.io/intuitem/ciso-assistant-community/mirror/qdrant:v1.14.0
       CADDY_IMAGE: ghcr.io/intuitem/ciso-assistant-community/mirror/caddy:2.11.4
     steps:

--- a/.github/workflows/startup-tests.yml
+++ b/.github/workflows/startup-tests.yml
@@ -152,7 +152,7 @@ jobs:
       COMPOSE_TEST: True
       # Pull build-time and runtime base images from our GHCR mirror instead of
       # Docker Hub to avoid anonymous pull rate limits. See .github/mirror-images.json.
-      PYTHON_IMAGE: ghcr.io/intuitem/ciso-assistant-community/mirror/python:3.14-slim
+      PYTHON_IMAGE: ghcr.io/intuitem/ciso-assistant-community/mirror/dhi-python:3.14-dev
       NODE_BUILD_IMAGE: ghcr.io/intuitem/ciso-assistant-community/mirror/dhi-node:24-dev
       NODE_RUNTIME_IMAGE: ghcr.io/intuitem/ciso-assistant-community/mirror/dhi-node:24
       QDRANT_IMAGE: ghcr.io/intuitem/ciso-assistant-community/mirror/qdrant:v1.14.0
@@ -350,8 +350,9 @@ jobs:
     env:
       COMPOSE_TEST: True
       # Pull base/runtime images from our GHCR mirror instead of Docker Hub. See .github/mirror-images.json.
-      PYTHON_IMAGE: ghcr.io/intuitem/ciso-assistant-community/mirror/python:3.14-slim
-      NODE_IMAGE: ghcr.io/intuitem/ciso-assistant-community/mirror/node:24-slim
+      PYTHON_IMAGE: ghcr.io/intuitem/ciso-assistant-community/mirror/dhi-python:3.14-dev
+      NODE_BUILD_IMAGE: ghcr.io/intuitem/ciso-assistant-community/mirror/dhi-node:24-dev
+      NODE_RUNTIME_IMAGE: ghcr.io/intuitem/ciso-assistant-community/mirror/dhi-node:24
       CADDY_IMAGE: ghcr.io/intuitem/ciso-assistant-community/mirror/caddy:2.11.4
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,6 +7,7 @@ ENV PYTHONUNBUFFERED=1 \
   PYTHONDONTWRITEBYTECODE=1 \
   UV_LINK_MODE=copy \
   UV_NO_SYNC=1 \
+  UV_PYTHON_DOWNLOADS=never \
   PATH="/code/.venv/bin:$PATH"
 
 COPY --from=ghcr.io/astral-sh/uv:0.11.6 /uv /bin/
@@ -18,7 +19,8 @@ RUN apt-get update && apt-get install -y \
   libyaml-cpp-dev \
   libffi-dev \
   libglib2.0-0 \
-  pango-1.0 \
+  libpango-1.0-0 \
+  libpangoft2-1.0-0 \
   libcairo2 \
   locales \
   tzdata \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_IMAGE=python:3.14-slim
+ARG PYTHON_IMAGE=dhi.io/python:3.14-dev
 FROM ${PYTHON_IMAGE}
 
 # UV_NO_SYNC=1: prevent `uv run` from auto-syncing at runtime (caused startup-docker-compose-test CI to fail);
@@ -14,6 +14,7 @@ COPY --from=ghcr.io/astral-sh/uv:0.11.6 /uv /bin/
 WORKDIR /code
 
 RUN apt-get update && apt-get install -y \
+  curl \
   libyaml-cpp-dev \
   libffi-dev \
   libglib2.0-0 \
@@ -73,7 +74,10 @@ ENV HF_HUB_OFFLINE=1 \
 #watch out for local files during dev and maintenance of .dockerignore
 COPY . .
 
-RUN groupadd -g 1001 app && useradd -u 1001 -g 1001 -m -s /bin/bash app
+# DHI base ships no shadow-utils (groupadd/useradd); append the entries directly
+RUN echo "app:x:1001:" >> /etc/group \
+  && echo "app:x:1001:1001::/home/app:/bin/bash" >> /etc/passwd \
+  && mkdir -p /home/app && chown 1001:1001 /home/app
 # USER app  # not activated by default to keep compatibility
 
 EXPOSE 8000

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -5,7 +5,7 @@ services:
       context: ./backend
       dockerfile: Dockerfile
       args:
-        PYTHON_IMAGE: ${PYTHON_IMAGE:-python:3.14-slim}
+        PYTHON_IMAGE: ${PYTHON_IMAGE:-dhi.io/python:3.14-dev}
     restart: always
     environment:
       - ALLOWED_HOSTS=backend,localhost
@@ -34,7 +34,7 @@ services:
       context: ./backend
       dockerfile: Dockerfile
       args:
-        PYTHON_IMAGE: ${PYTHON_IMAGE:-python:3.14-slim}
+        PYTHON_IMAGE: ${PYTHON_IMAGE:-dhi.io/python:3.14-dev}
     depends_on:
       - backend
     restart: always

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -86,7 +86,8 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
       args:
-        NODE_IMAGE: ${NODE_IMAGE:-node:24-slim}
+        NODE_BUILD_IMAGE: ${NODE_BUILD_IMAGE:-dhi.io/node:24-dev}
+        NODE_RUNTIME_IMAGE: ${NODE_RUNTIME_IMAGE:-dhi.io/node:24}
     depends_on:
       - backend
     restart: always

--- a/enterprise/backend/Dockerfile
+++ b/enterprise/backend/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_IMAGE=python:3.14-slim
+ARG PYTHON_IMAGE=dhi.io/python:3.14-dev
 FROM ${PYTHON_IMAGE}
 
 # UV_NO_SYNC=1: prevent `uv run` from auto-syncing at runtime; the venv is built once at image build (uv sync --locked --no-dev)
@@ -14,6 +14,7 @@ COPY --from=ghcr.io/astral-sh/uv:0.11.6 /uv /bin/
 WORKDIR /code
 
 RUN apt-get update && apt-get install -y \
+  curl \
   libyaml-cpp-dev \
   libffi-dev \
   libglib2.0-0 \
@@ -78,7 +79,10 @@ COPY . /code/
 COPY --from=enterprise_backend /enterprise_core /code/enterprise_core
 COPY startup.sh /code/
 
-RUN groupadd -g 1001 app && useradd -u 1001 -g 1001 -m -s /bin/bash app
+# DHI base ships no shadow-utils (groupadd/useradd); append the entries directly
+RUN echo "app:x:1001:" >> /etc/group \
+  && echo "app:x:1001:1001::/home/app:/bin/bash" >> /etc/passwd \
+  && mkdir -p /home/app && chown 1001:1001 /home/app
 # USER app  # not activated by default to keep compatibility
 
 EXPOSE 8000

--- a/enterprise/backend/Dockerfile
+++ b/enterprise/backend/Dockerfile
@@ -6,6 +6,7 @@ ENV PYTHONUNBUFFERED=1 \
   PYTHONDONTWRITEBYTECODE=1 \
   UV_LINK_MODE=copy \
   UV_NO_SYNC=1 \
+  UV_PYTHON_DOWNLOADS=never \
   PATH="/code/.venv/bin:$PATH" \
   DJANGO_SETTINGS_MODULE=enterprise_core.settings
 
@@ -18,7 +19,8 @@ RUN apt-get update && apt-get install -y \
   libyaml-cpp-dev \
   libffi-dev \
   libglib2.0-0 \
-  pango-1.0 \
+  libpango-1.0-0 \
+  libpangoft2-1.0-0 \
   libcairo2 \
   locales \
   tzdata \
@@ -26,8 +28,6 @@ RUN apt-get update && apt-get install -y \
   fontconfig \
   fonts-freefont-ttf \
   build-essential \
-  python3-dev \
-  python3-numpy \
   libjpeg-dev \
   zlib1g-dev \
   libmagic1 \

--- a/enterprise/docker-compose-build.yml
+++ b/enterprise/docker-compose-build.yml
@@ -7,7 +7,7 @@ services:
       additional_contexts:
         enterprise_backend: ./backend
       args:
-        PYTHON_IMAGE: ${PYTHON_IMAGE:-python:3.14-slim}
+        PYTHON_IMAGE: ${PYTHON_IMAGE:-dhi.io/python:3.14-dev}
     restart: always
     environment:
       - ALLOWED_HOSTS=backend,localhost
@@ -27,7 +27,7 @@ services:
       additional_contexts:
         enterprise_backend: ./backend
       args:
-        PYTHON_IMAGE: ${PYTHON_IMAGE:-python:3.14-slim}
+        PYTHON_IMAGE: ${PYTHON_IMAGE:-dhi.io/python:3.14-dev}
     restart: always
     environment:
       - ALLOWED_HOSTS=backend,localhost
@@ -56,7 +56,8 @@ services:
       additional_contexts:
         enterprise_frontend: ./frontend
       args:
-        NODE_IMAGE: ${NODE_IMAGE:-node:24-slim}
+        NODE_BUILD_IMAGE: ${NODE_BUILD_IMAGE:-dhi.io/node:24-dev}
+        NODE_RUNTIME_IMAGE: ${NODE_RUNTIME_IMAGE:-dhi.io/node:24}
     depends_on:
       - backend
     restart: always

--- a/enterprise/frontend/Dockerfile
+++ b/enterprise/frontend/Dockerfile
@@ -1,5 +1,6 @@
-ARG NODE_IMAGE=node:24-slim
-FROM ${NODE_IMAGE} AS builder
+ARG NODE_BUILD_IMAGE=dhi.io/node:24-dev
+ARG NODE_RUNTIME_IMAGE=dhi.io/node:24
+FROM ${NODE_BUILD_IMAGE} AS builder
 ENV NODE_OPTIONS="--max-old-space-size=10240"
 WORKDIR /app
 
@@ -15,19 +16,16 @@ RUN pnpm install --frozen-lockfile
 RUN pnpm run build
 RUN pnpm prune
 
-ARG NODE_IMAGE=node:24-slim
-FROM ${NODE_IMAGE}
+# DHI runtime image: distroless (no shell/package manager), runs as uid 1000
+FROM ${NODE_RUNTIME_IMAGE}
 ENV NODE_OPTIONS="--max-old-space-size=10240"
 WORKDIR /app
-COPY --from=builder /app/build build/
-COPY --from=builder /app/server server/
-COPY --from=builder /app/node_modules node_modules/
-COPY package.json .
+COPY --from=builder --chown=1000:1000 /app/build build/
+COPY --from=builder --chown=1000:1000 /app/server server/
+COPY --from=builder --chown=1000:1000 /app/node_modules node_modules/
+COPY --chown=1000:1000 package.json .
 EXPOSE 3000
 ENV NODE_ENV=production
 ENV BODY_SIZE_LIMIT=25000000
-
-RUN groupadd -g 1001 app && useradd -u 1001 -g 1001 -m -s /bin/bash app
-# USER app  # not activated by default to keep compatibility
 
 CMD [ "node", "server" ]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,6 @@
-ARG NODE_IMAGE=node:24-slim
-FROM ${NODE_IMAGE} AS builder
+ARG NODE_BUILD_IMAGE=dhi.io/node:24-dev
+ARG NODE_RUNTIME_IMAGE=dhi.io/node:24
+FROM ${NODE_BUILD_IMAGE} AS builder
 ENV NODE_OPTIONS="--max-old-space-size=10240"
 WORKDIR /app
 
@@ -12,19 +13,16 @@ RUN pnpm install --frozen-lockfile
 RUN pnpm run build
 RUN pnpm prune
 
-ARG NODE_IMAGE=node:24-slim
-FROM ${NODE_IMAGE}
+# DHI runtime image: distroless (no shell/package manager), runs as uid 1000
+FROM ${NODE_RUNTIME_IMAGE}
 ENV NODE_OPTIONS="--max-old-space-size=10240"
 WORKDIR /app
-COPY --from=builder /app/build build/
-COPY --from=builder /app/server server/
-COPY --from=builder /app/node_modules node_modules/
-COPY package.json .
+COPY --from=builder --chown=1000:1000 /app/build build/
+COPY --from=builder --chown=1000:1000 /app/server server/
+COPY --from=builder --chown=1000:1000 /app/node_modules node_modules/
+COPY --chown=1000:1000 package.json .
 EXPOSE 3000
 ENV NODE_ENV=production
 ENV BODY_SIZE_LIMIT=25000000
-
-RUN groupadd -g 1001 app && useradd -u 1001 -g 1001 -m -s /bin/bash app
-# USER app  # not activated by default to keep compatibility
 
 CMD [ "node", "server" ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated mirrored container image mappings and adjusted Node.js/Python base defaults to use the mirrored `dhi.io` images.
  * Updated startup and compose build configurations to use separate build-time vs runtime Node images.
  * Refreshed container build/runtime Docker settings (including runtime base selection and build artifact ownership).
* **Security**
  * Hardened frontend runtime by using a no-shell/distroless-style base and applying consistent artifact ownership instead of runtime user/group creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->