### PR TITLE
feat: support cyfun 2025 excel import

### DIFF
--- a/backend/data_wizard/cyfun_helpers.py
+++ b/backend/data_wizard/cyfun_helpers.py
@@ -81,7 +81,7 @@ def process_cyfun_file(file_content: bytes) -> dict:
         sheet = workbook[sheet_name]
         cols = _detect_columns(sheet)
         if cols is None:
-            continue
+            raise ValueError("UnrecognizedCyfunWorkbook")
         if level is None:
             marker = str(sheet.cell(1, cols["doc_score"]).value or "").strip().lower()
             if marker in LEVELS:

--- a/backend/data_wizard/cyfun_helpers.py
+++ b/backend/data_wizard/cyfun_helpers.py
@@ -1,0 +1,128 @@
+import io
+import re
+
+import openpyxl
+
+CYFUN_LIBRARY_URN = "urn:intuitem:risk:library:ccb-cyfun2025"
+CYFUN_FRAMEWORK_URN = "urn:intuitem:risk:framework:ccb-cyfun2025"
+
+FUNCTION_SHEETS = ("GOVERN", "IDENTIFY", "PROTECT", "DETECT", "RESPOND", "RECOVER")
+LEVELS = ("basic", "important", "essential")
+LEVEL_TO_GROUP = {"basic": "B", "important": "I", "essential": "E"}
+
+REF_ID_PATTERN = re.compile(r"^[A-Z]{2}\.[A-Z]{2}-\d+(\.\d+)?$")
+
+# The framework zero-pads subcategory numbers (ID.AM-05) but some workbook
+# editions don't (ID.AM-5.1 in the BASIC tool).
+SUBCATEGORY_PAD_PATTERN = re.compile(r"-(\d)(?=\.|$)")
+
+HEADER_ROW = 2
+DATA_START_ROW = 3
+
+
+def _detect_columns(sheet):
+    """Map header labels to column indices; the BASIC edition has no
+    'Assurance level' column, shifting everything after 'Subcategory' left."""
+    headers = {}
+    for cell in sheet[HEADER_ROW]:
+        if cell.value:
+            headers[str(cell.value).strip().lower()] = cell.column
+    required = ("requirement", "documentation score", "implementation score")
+    if not all(key in headers for key in required):
+        return None
+    return {
+        "level": headers.get("assurance level"),
+        "requirement": headers["requirement"],
+        "doc_score": headers["documentation score"],
+        "impl_score": headers["implementation score"],
+        "comments": headers.get("comments and/or additional information"),
+        "assessor_comments": headers.get("assessor comments"),
+    }
+
+
+def _parse_score(value):
+    """Returns (score, is_na)."""
+    if value is None or value == "":
+        return None, False
+    if isinstance(value, str):
+        if value.strip().upper() in ("N/A", "NA"):
+            return None, True
+        try:
+            return int(float(value)), False
+        except ValueError:
+            return None, False
+    if isinstance(value, (int, float)):
+        return int(value), False
+    return None, False
+
+
+def _cell(row, col):
+    if not col or len(row) < col:
+        return None
+    return row[col - 1]
+
+
+def _cell_text(row, col):
+    return str(_cell(row, col) or "").strip()
+
+
+def process_cyfun_file(file_content: bytes) -> dict:
+    workbook = openpyxl.load_workbook(io.BytesIO(file_content), data_only=True)
+    sheet_names = set(workbook.sheetnames)
+    if any(name.endswith("Details") for name in sheet_names):
+        raise ValueError("CyFun2023WorkbookNotSupported")
+    if not all(name in sheet_names for name in FUNCTION_SHEETS):
+        raise ValueError("UnrecognizedCyfunWorkbook")
+
+    level = None
+    levels_seen = set()
+    records = []
+    for sheet_name in FUNCTION_SHEETS:
+        sheet = workbook[sheet_name]
+        cols = _detect_columns(sheet)
+        if cols is None:
+            continue
+        if level is None:
+            marker = str(sheet.cell(1, cols["doc_score"]).value or "").strip().lower()
+            if marker in LEVELS:
+                level = marker
+        for row in sheet.iter_rows(min_row=DATA_START_ROW, values_only=True):
+            ref_id = (
+                _cell_text(row, cols["requirement"]).split(":")[0].strip().rstrip(".")
+            )
+            if not REF_ID_PATTERN.match(ref_id):
+                continue
+            ref_id = SUBCATEGORY_PAD_PATTERN.sub(r"-0\1", ref_id)
+            row_level = _cell_text(row, cols["level"]).lower()
+            if row_level in LEVELS:
+                levels_seen.add(row_level)
+
+            record = {"ref_id": ref_id, "assessable": True}
+            doc_score, doc_na = _parse_score(_cell(row, cols["doc_score"]))
+            impl_score, impl_na = _parse_score(_cell(row, cols["impl_score"]))
+            if doc_na or impl_na:
+                record["compliance_result"] = "not_applicable"
+            else:
+                if doc_score is not None:
+                    record["documentation_score"] = doc_score
+                if impl_score is not None:
+                    record["implementation_score"] = impl_score
+
+            observations = _cell_text(row, cols["comments"])
+            assessor_comments = _cell_text(row, cols["assessor_comments"])
+            if assessor_comments:
+                assessor_comments = f"Assessor comments: {assessor_comments}"
+                observations = (
+                    f"{observations}\n\n{assessor_comments}"
+                    if observations
+                    else assessor_comments
+                )
+            if observations:
+                record["observations"] = observations
+            records.append(record)
+
+    if not records:
+        raise ValueError("EmptyCyfunWorkbook")
+    if level not in LEVELS:
+        level = next((lvl for lvl in reversed(LEVELS) if lvl in levels_seen), None)
+    return {"assurance_level": level, "records": records}

--- a/backend/data_wizard/tests/test_cyfun.py
+++ b/backend/data_wizard/tests/test_cyfun.py
@@ -179,6 +179,17 @@ class TestProcessCyfunFile:
         )
         assert parsed["records"][1]["compliance_result"] == "not_applicable"
 
+    def test_rejects_workbook_with_unrecognized_sheet_headers(self):
+        content = build_workbook(
+            {"GOVERN": [{6: "GV.RM-01.1: Objectives.", 7: 1, 8: 1}]}
+        )
+        wb = openpyxl.load_workbook(io.BytesIO(content))
+        wb["PROTECT"].cell(2, 6, "Exigence")
+        buf = io.BytesIO()
+        wb.save(buf)
+        with pytest.raises(ValueError, match="UnrecognizedCyfunWorkbook"):
+            process_cyfun_file(buf.getvalue())
+
     def test_rejects_2023_workbook(self):
         wb = openpyxl.Workbook()
         wb.active.title = "BASIC Details"
@@ -261,6 +272,7 @@ class TestCyfunEndpoint:
         assert ca.scoring_enabled
         assert ca.show_documentation_score
         assert ca.min_score == 1 and ca.max_score == 5
+        assert ca.score_calculation_method == "average_of_averages"
 
         scored = RequirementAssessment.objects.get(
             compliance_assessment=ca, requirement__ref_id="GV.OC-01.1"

--- a/backend/data_wizard/tests/test_cyfun.py
+++ b/backend/data_wizard/tests/test_cyfun.py
@@ -1,0 +1,286 @@
+import io
+from pathlib import Path
+
+import openpyxl
+import pytest
+
+from core.models import (
+    ComplianceAssessment,
+    LoadedLibrary,
+    RequirementAssessment,
+    StoredLibrary,
+)
+from data_wizard.cyfun_helpers import (
+    CYFUN_FRAMEWORK_URN,
+    CYFUN_LIBRARY_URN,
+    FUNCTION_SHEETS,
+    process_cyfun_file,
+)
+
+URL = "/api/data-wizard/load-file/"
+
+HEADERS = [
+    "Category",
+    "Controls linked to the management aspects",
+    "Key Measure",
+    "Subcategory",
+    "Assurance level",
+    "Requirement",
+    "Documentation Score",
+    "Implementation Score",
+    "Subcategory Documentation Maturity Score",
+    "Subcategory Implementation Maturity Score",
+    "Category Documentation Maturity Score",
+    "Category Implementation Maturity Score",
+    "Comments and/or additional information",
+    "Assessor comments",
+]
+
+
+# The BASIC edition has no "Assurance level" column: requirement/scores/comments
+# all sit one column left, and the level marker is above "Documentation Score".
+HEADERS_BASIC = [h for h in HEADERS if h != "Assurance level"]
+
+
+def build_basic_workbook(rows_by_sheet: dict, level: str = "BASIC") -> bytes:
+    wb = openpyxl.Workbook()
+    wb.remove(wb.active)
+    for name in FUNCTION_SHEETS:
+        ws = wb.create_sheet(name)
+        ws.cell(1, 6, level)
+        for col, header in enumerate(HEADERS_BASIC, 1):
+            ws.cell(2, col, header)
+        for row_idx, row in enumerate(rows_by_sheet.get(name, []), 3):
+            for col, value in row.items():
+                ws.cell(row_idx, col, value)
+    buf = io.BytesIO()
+    wb.save(buf)
+    return buf.getvalue()
+
+
+def build_workbook(rows_by_sheet: dict, level: str = "ESSENTIAL") -> bytes:
+    wb = openpyxl.Workbook()
+    wb.remove(wb.active)
+    for name in FUNCTION_SHEETS:
+        ws = wb.create_sheet(name)
+        ws.cell(1, 7, level)
+        for col, header in enumerate(HEADERS, 1):
+            ws.cell(2, col, header)
+        for row_idx, row in enumerate(rows_by_sheet.get(name, []), 3):
+            for col, value in row.items():
+                ws.cell(row_idx, col, value)
+    buf = io.BytesIO()
+    wb.save(buf)
+    return buf.getvalue()
+
+
+class TestProcessCyfunFile:
+    def test_parses_scores_and_comments(self):
+        content = build_workbook(
+            {
+                "GOVERN": [
+                    {
+                        5: "Important",
+                        6: "GV.OC-01.1: The organisation's mission shall be established.",
+                        7: 3,
+                        8: 2,
+                        13: "our comment",
+                        14: "assessor note",
+                    }
+                ],
+                "PROTECT": [
+                    {
+                        5: "Essential",
+                        6: "PR.AA-01.1: Identities are managed.",
+                        7: 4,
+                        8: 4,
+                    }
+                ],
+            }
+        )
+        parsed = process_cyfun_file(content)
+        assert parsed["assurance_level"] == "essential"
+        assert len(parsed["records"]) == 2
+        record = parsed["records"][0]
+        assert record["ref_id"] == "GV.OC-01.1"
+        assert record["documentation_score"] == 3
+        assert record["implementation_score"] == 2
+        assert (
+            record["observations"] == "our comment\n\nAssessor comments: assessor note"
+        )
+
+    def test_na_maps_to_not_applicable(self):
+        content = build_workbook(
+            {"GOVERN": [{6: "GV.OC-02.1: Stakeholders.", 7: "N/A", 8: "N/A"}]}
+        )
+        record = process_cyfun_file(content)["records"][0]
+        assert record["compliance_result"] == "not_applicable"
+        assert "implementation_score" not in record
+        assert "documentation_score" not in record
+
+    def test_skips_non_requirement_rows(self):
+        content = build_workbook(
+            {
+                "GOVERN": [
+                    {6: "NO REQUIREMENT / Guidance to be considered"},
+                    {6: None},
+                    {6: "GV.RM-01.1: Objectives.", 7: 1, 8: 1},
+                ]
+            }
+        )
+        parsed = process_cyfun_file(content)
+        assert [r["ref_id"] for r in parsed["records"]] == ["GV.RM-01.1"]
+
+    def test_level_falls_back_to_rows_when_g1_missing(self):
+        content = build_workbook(
+            {
+                "GOVERN": [
+                    {5: "Basic", 6: "GV.OC-03.1: Legal requirements.", 7: 2, 8: 2},
+                    {5: "Important", 6: "GV.OC-01.1: Mission.", 7: 2, 8: 2},
+                ]
+            },
+            level="",
+        )
+        assert process_cyfun_file(content)["assurance_level"] == "important"
+
+    def test_parses_basic_edition_layout(self):
+        content = build_basic_workbook(
+            {
+                "GOVERN": [
+                    {
+                        5: "GV.OC-03.1: Legal requirements shall be identified.",
+                        6: 2,
+                        7: 3,
+                        12: "tracked in legal register",
+                        13: "verify register completeness",
+                    },
+                    {5: "GV.RM-03.1: Risk strategy.", 6: "N/A", 7: "N/A"},
+                ],
+                "IDENTIFY": [
+                    {
+                        5: "ID.AM-5.1: Unpadded ref as in the real BASIC tool.",
+                        6: 1,
+                        7: 2,
+                    }
+                ],
+            }
+        )
+        parsed = process_cyfun_file(content)
+        assert parsed["assurance_level"] == "basic"
+        assert len(parsed["records"]) == 3
+        assert parsed["records"][2]["ref_id"] == "ID.AM-05.1"
+        record = parsed["records"][0]
+        assert record["ref_id"] == "GV.OC-03.1"
+        assert record["documentation_score"] == 2
+        assert record["implementation_score"] == 3
+        assert (
+            record["observations"]
+            == "tracked in legal register\n\nAssessor comments: verify register completeness"
+        )
+        assert parsed["records"][1]["compliance_result"] == "not_applicable"
+
+    def test_rejects_2023_workbook(self):
+        wb = openpyxl.Workbook()
+        wb.active.title = "BASIC Details"
+        wb.create_sheet("Introduction")
+        buf = io.BytesIO()
+        wb.save(buf)
+        with pytest.raises(ValueError, match="CyFun2023WorkbookNotSupported"):
+            process_cyfun_file(buf.getvalue())
+
+    def test_rejects_unknown_workbook(self):
+        wb = openpyxl.Workbook()
+        wb.active.title = "Sheet1"
+        buf = io.BytesIO()
+        wb.save(buf)
+        with pytest.raises(ValueError, match="UnrecognizedCyfunWorkbook"):
+            process_cyfun_file(buf.getvalue())
+
+
+@pytest.fixture
+def cyfun_stored_library(db):
+    if not StoredLibrary.objects.filter(urn=CYFUN_LIBRARY_URN).exists():
+        path = (
+            Path(__file__).resolve().parents[2]
+            / "library"
+            / "libraries"
+            / "cyfun2025.yaml"
+        )
+        stored, error = StoredLibrary.store_library_content(path.read_bytes())
+        assert error is None
+        assert stored is not None
+
+
+@pytest.mark.django_db
+class TestCyfunEndpoint:
+    def _post(self, client, content: bytes, folder_id, name=None):
+        headers = {
+            "HTTP_X_MODEL_TYPE": "CyFunAssessment",
+            "HTTP_X_FOLDER_ID": str(folder_id),
+            "HTTP_CONTENT_DISPOSITION": "attachment; filename=cyfun.xlsx",
+            "content_type": "application/octet-stream",
+        }
+        if name:
+            headers["HTTP_X_NAME"] = name
+        return client.post(URL, data=content, **headers)
+
+    def test_import_creates_scored_assessment(
+        self, knox_admin_client, domain_folder, cyfun_stored_library
+    ):
+        content = build_workbook(
+            {
+                "GOVERN": [
+                    {
+                        5: "Important",
+                        6: "GV.OC-01.1: The organisation's mission shall be established.",
+                        7: 3,
+                        8: 2,
+                        13: "our comment",
+                    },
+                    {
+                        5: "Essential",
+                        6: "GV.OC-02.1: Stakeholders.",
+                        7: "N/A",
+                        8: "N/A",
+                    },
+                ]
+            }
+        )
+        resp = self._post(
+            knox_admin_client, content, domain_folder.id, name="CyFun test"
+        )
+        assert resp.status_code == 200, resp.json()
+        results = resp.json()["results"]
+        assert results["successful"] == 2
+        assert results["failed"] == 0
+
+        assert LoadedLibrary.objects.filter(urn=CYFUN_LIBRARY_URN).exists()
+        ca = ComplianceAssessment.objects.get(name="CyFun test")
+        assert ca.framework.urn == CYFUN_FRAMEWORK_URN
+        assert ca.selected_implementation_groups == ["E"]
+        assert ca.scoring_enabled
+        assert ca.show_documentation_score
+        assert ca.min_score == 1 and ca.max_score == 5
+
+        scored = RequirementAssessment.objects.get(
+            compliance_assessment=ca, requirement__ref_id="GV.OC-01.1"
+        )
+        assert scored.documentation_score == 3
+        assert scored.score == 2
+        assert scored.is_scored
+        assert scored.observation == "our comment"
+
+        na = RequirementAssessment.objects.get(
+            compliance_assessment=ca, requirement__ref_id="GV.OC-02.1"
+        )
+        assert na.result == "not_applicable"
+
+    def test_unknown_workbook_reports_error(self, knox_admin_client, domain_folder):
+        wb = openpyxl.Workbook()
+        buf = io.BytesIO()
+        wb.save(buf)
+        resp = self._post(knox_admin_client, buf.getvalue(), domain_folder.id)
+        assert resp.status_code == 200
+        results = resp.json()["results"]
+        assert results["failed"] == 1
+        assert results["errors"][0]["error"] == "UnrecognizedCyfunWorkbook"

--- a/backend/data_wizard/views.py
+++ b/backend/data_wizard/views.py
@@ -20,11 +20,14 @@ from core.models import (
     ComplianceAssessment,
     Evidence,
     Folder,
+    Framework,
+    LoadedLibrary,
     Perimeter,
     RequirementAssessment,
     RequirementNode,
     RiskAssessment,
     RiskMatrix,
+    StoredLibrary,
     AppliedControl,
     FindingsAssessment,
     RiskScenario,
@@ -81,7 +84,14 @@ from .egerie_xml_helpers import (
     map_egerie_status,
 )
 from core.models import Terminology
+from core.utils import AUDITOR_ONLY
 from data_wizard.arm_helpers import process_arm_file
+from data_wizard.cyfun_helpers import (
+    CYFUN_FRAMEWORK_URN,
+    CYFUN_LIBRARY_URN,
+    LEVEL_TO_GROUP,
+    process_cyfun_file,
+)
 from tprm.models import Entity, Solution, Contract, Representative
 from tprm.serializers import (
     EntityWriteSerializer,
@@ -443,6 +453,7 @@ class ModelType(enum.StrEnum):
     PERIMETER = "Perimeter"
     USER = "User"
     COMPLIANCE_ASSESSMENT = "ComplianceAssessment"
+    CYFUN_ASSESSMENT = "CyFunAssessment"
     FINDINGS_ASSESSMENT = "FindingsAssessment"
     RISK_ASSESSMENT = "RiskAssessment"
     ELEMENTARY_ACTION = "ElementaryAction"
@@ -3442,6 +3453,11 @@ class LoadFileView(APIView):
                             .process_records(df.to_dict(orient="records"))
                             .to_dict()
                         )
+                # Special handling for the official CyFun self-assessment workbook
+                case ModelType.CYFUN_ASSESSMENT:
+                    res = self._process_cyfun_assessment(
+                        request, record_file, folder_id, perimeter_id
+                    )
                 # Special handling for Processing multi-sheet import (record + sub-objects)
                 case ModelType.PROCESSING:
                     if is_excel_file(record_file):
@@ -3759,6 +3775,74 @@ class LoadFileView(APIView):
             )
 
         return results
+
+    def _process_cyfun_assessment(self, request, record_file, folder_id, perimeter_id):
+        results = {"successful": 0, "failed": 0, "errors": []}
+
+        def fail(code):
+            results["failed"] += 1
+            results["errors"].append({"error": code})
+            return results
+
+        try:
+            parsed = process_cyfun_file(record_file.getvalue())
+        except ValueError as e:
+            return fail(e.args[0] if e.args else "UnrecognizedCyfunWorkbook")
+
+        if not LoadedLibrary.objects.filter(urn=CYFUN_LIBRARY_URN).exists():
+            stored_library = StoredLibrary.objects.filter(urn=CYFUN_LIBRARY_URN).first()
+            if stored_library is None:
+                return fail("CyfunLibraryNotFound")
+            error = stored_library.load()
+            if error is not None:
+                logger.error("CyFun library import failed", error=error)
+                return fail("CyfunLibraryImportFailed")
+        framework = Framework.objects.get(urn=CYFUN_FRAMEWORK_URN)
+
+        perimeter = None
+        if perimeter_id is not None:
+            try:
+                perimeter = Perimeter.objects.get(id=perimeter_id)
+            except Perimeter.DoesNotExist:
+                return fail(f"Perimeter with ID {perimeter_id} does not exist")
+        if perimeter is not None:
+            folder_id = perimeter.folder.id
+        elif folder_id is None:
+            results["failed"] += 1
+            results["errors"].append(
+                {"error": "A folder must be specified when there's no perimeter!"}
+            )
+            return results
+
+        assessment_data = {
+            "name": resolve_container_name(request, "CyFun_Assessment"),
+            "perimeter": perimeter_id,
+            "framework": framework.id,
+            "folder": folder_id,
+            "field_visibility": {
+                "score": dict(AUDITOR_ONLY),
+                "is_scored": dict(AUDITOR_ONLY),
+                "documentation_score": dict(AUDITOR_ONLY),
+            },
+        }
+        level = parsed["assurance_level"]
+        if level:
+            assessment_data["selected_implementation_groups"] = [LEVEL_TO_GROUP[level]]
+
+        serializer = ComplianceAssessmentWriteSerializer(
+            data=assessment_data, context={"request": request}
+        )
+        serializer.is_valid(raise_exception=True)
+        compliance_assessment = serializer.save()
+        compliance_assessment.create_requirement_assessments()
+        logger.info(
+            "Created CyFun compliance assessment",
+            id=compliance_assessment.id,
+            assurance_level=level,
+        )
+        return self._reconcile_compliance_requirements(
+            request, parsed["records"], compliance_assessment, framework.id, results
+        )
 
     @staticmethod
     def _resolve_summary_row_template(

--- a/backend/data_wizard/views.py
+++ b/backend/data_wizard/views.py
@@ -3797,7 +3797,10 @@ class LoadFileView(APIView):
             if error is not None:
                 logger.error("CyFun library import failed", error=error)
                 return fail("CyfunLibraryImportFailed")
-        framework = Framework.objects.get(urn=CYFUN_FRAMEWORK_URN)
+        try:
+            framework = Framework.objects.get(urn=CYFUN_FRAMEWORK_URN)
+        except Framework.DoesNotExist:
+            return fail("CyfunFrameworkNotFound")
 
         perimeter = None
         if perimeter_id is not None:
@@ -3819,6 +3822,7 @@ class LoadFileView(APIView):
             "perimeter": perimeter_id,
             "framework": framework.id,
             "folder": folder_id,
+            "score_calculation_method": ComplianceAssessment.CalculationMethod.AVG_OF_AVG,
             "field_visibility": {
                 "score": dict(AUDITOR_ONLY),
                 "is_scored": dict(AUDITOR_ONLY),
@@ -3832,9 +3836,13 @@ class LoadFileView(APIView):
         serializer = ComplianceAssessmentWriteSerializer(
             data=assessment_data, context={"request": request}
         )
-        serializer.is_valid(raise_exception=True)
-        compliance_assessment = serializer.save()
-        compliance_assessment.create_requirement_assessments()
+        try:
+            serializer.is_valid(raise_exception=True)
+            compliance_assessment = serializer.save()
+            compliance_assessment.create_requirement_assessments()
+        except Exception as e:
+            logger.error("Failed to create CyFun compliance assessment", error=e)
+            return fail("CyfunAssessmentCreationFailed")
         logger.info(
             "Created CyFun compliance assessment",
             id=compliance_assessment.id,

--- a/cli/README.md
+++ b/cli/README.md
@@ -131,6 +131,7 @@ Supported Data Wizard commands:
 | `import-folders` | Folder | — |
 | `import-perimeters` | Perimeter | `--folder` |
 | `import-compliance-assessments` | ComplianceAssessment | `--perimeter`, `--framework` |
+| `import-cyfun-assessment` | CyFunAssessment | `--folder` or `--perimeter` |
 | `import-findings-assessments` | FindingsAssessment | `--perimeter` |
 | `import-risk-assessment` | RiskAssessment | `--perimeter`, `--matrix` |
 | `import-elementary-actions` | ElementaryAction | `--folder` |

--- a/cli/clica.py
+++ b/cli/clica.py
@@ -375,6 +375,23 @@ DATA_WIZARD_COMMANDS = [
         "supports_conflict": False,
     },
     {
+        "command": "import_cyfun_assessment",
+        "model_type": "CyFunAssessment",
+        "help": (
+            "Import an official CyFun 2025 self-assessment workbook (Excel).\n"
+            "Creates a new assessment on the CyFun 2025 framework (auto-loaded if missing)\n"
+            "with documentation/implementation scores and comments.\n"
+            "\nNote: always creates a new assessment; conflict management is not applicable."
+        ),
+        "requires_folder": False,
+        "requires_perimeter": False,
+        "requires_framework": False,
+        "requires_matrix": False,
+        "supports_conflict": False,
+        "show_folder_option": True,
+        "show_perimeter_option": True,
+    },
+    {
         "command": "import_findings_assessments",
         "model_type": "FindingsAssessment",
         "help": (
@@ -663,6 +680,7 @@ def register_data_wizard_command(config: Dict[str, object]) -> None:
     show_matrix_option = config.get("show_matrix_option", requires_matrix)
     supports_name_option = model_type in {
         "ComplianceAssessment",
+        "CyFunAssessment",
         "RiskAssessment",
         "FindingsAssessment",
         "EbiosRMStudyARM",

--- a/enterprise/frontend/src/routes/(app)/(internal)/extra/data-wizard/+page.svelte
+++ b/enterprise/frontend/src/routes/(app)/(internal)/extra/data-wizard/+page.svelte
@@ -56,6 +56,7 @@
 	// Composite models: perimeter optional, domain derived from it when set.
 	const ASSESSMENT_MODELS = [
 		'ComplianceAssessment',
+		'CyFunAssessment',
 		'RiskAssessment',
 		'FindingsAssessment',
 		'BusinessImpactAnalysis'
@@ -78,6 +79,11 @@
 		{ id: 'Folder', label: m.domains(), description: '' },
 		{ id: 'Perimeter', label: m.perimeters(), description: '' },
 		{ id: 'ComplianceAssessment', label: m.complianceAssessment(), description: '' },
+		{
+			id: 'CyFunAssessment',
+			label: m.cyFunAssessment(),
+			description: m.dataWizardCyFunDescription()
+		},
 		{
 			id: 'BusinessImpactAnalysis',
 			label: m.businessImpactAnalysis(),

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -482,6 +482,8 @@
 	"exportExecutiveSummaryDesc": "Cover page, spider chart, framework tree, scored requirements",
 	"exportCyFunAssessment": "CyFun self-assessment",
 	"exportCyFunAssessmentDesc": "Excel template mapped to CyFun categories",
+	"cyFunAssessment": "CyFun self-assessment",
+	"dataWizardCyFunDescription": "Import an official CyFun 2025 self-assessment workbook; the CyFun 2025 framework is loaded automatically if missing",
 	"exportBundleWithEvidences": "Bundle with evidences",
 	"exportBundleWithEvidencesDesc": "HTML snapshot bundled with all attached evidence files",
 	"exportSoaBuilder": "SoA builder",

--- a/product-docs/configuration/data-import.md
+++ b/product-docs/configuration/data-import.md
@@ -456,6 +456,12 @@ Elementary actions are useful to model a killchain during the 4th workshop of an
 
 
 
+## CyFun self-assessment
+
+The official self-assessment Excel workbook published by Belgium's Centre for Cybersecurity for the **CyFun 2025** framework — BASIC, IMPORTANT, and ESSENTIAL editions are all accepted. The import creates a new audit, loads the CyFun 2025 framework automatically if needed, sets the implementation group from the detected assurance level, and carries over documentation/implementation scores, `N/A` markers, and comments. See [CCB CyFun](../features/framework-specific/cyfun.md) for details.
+
+Selected in the wizard as **CyFun self-assessment**; on the CLI: `import-cyfun-assessment`.
+
 ## EBIOS RM Studies
 
 Importing a full EBIOS RM study creates the study itself plus the objects across workshops 1–4 (assets, feared events, RO/TO couples, stakeholders, strategic and operational scenarios, attack paths, elementary actions, operating modes). Three input formats are supported. All three require a **risk matrix** to be selected in the wizard — the probability and impact labels in the source are resolved against that matrix.

--- a/product-docs/features/framework-specific/README.md
+++ b/product-docs/features/framework-specific/README.md
@@ -9,7 +9,7 @@ Most of CISO Assistant is framework-agnostic — the same audit, applied-control
 This section catalogues those capabilities:
 
 - [ISO 27001](iso.md) — Statement of Applicability report; organisation issues and objectives (context of the organisation).
-- [CCB CyFun](cyfun.md) — self-assessment Excel export in the format expected by Belgium's Centre for Cybersecurity.
+- [CCB CyFun](cyfun.md) — self-assessment Excel import and export in the format published by Belgium's Centre for Cybersecurity.
 - [DORA](dora.md) — Register of Information report and structured incident reports aligned with the Digital Operational Resilience Act.
 - [MonServiceSécurisé](monservicesecurise.md) — controls export in the format expected by the French ANSSI portal.
 

--- a/product-docs/features/framework-specific/cyfun.md
+++ b/product-docs/features/framework-specific/cyfun.md
@@ -1,35 +1,66 @@
 ---
-description: Excel self-assessment export aligned with Belgium's Centre for Cybersecurity
+description: Excel self-assessment import and export aligned with Belgium's Centre for Cybersecurity
 ---
 
 # CCB CyFun
 
-The [Centre for Cybersecurity Belgium](https://atwork.safeonweb.be/tools-resources/cyberfundamentals-framework) (CCB) publishes the **CyberFundamentals** framework as a self-assessment Excel workbook with a specific layout: one sheet per NIST CSF function (GOVERN, IDENTIFY, PROTECT, DETECT, RESPOND, RECOVER), rows pre-populated with controls, and answer cells where the responder records their posture.
+The [Centre for Cybersecurity Belgium](https://atwork.safeonweb.be/tools-resources/cyberfundamentals-framework) (CCB) publishes the **CyberFundamentals** framework as a self-assessment Excel workbook with a specific layout: one sheet per NIST CSF function (GOVERN, IDENTIFY, PROTECT, DETECT, RESPOND, RECOVER), rows pre-populated with controls, and answer cells where the responder records their documentation and implementation maturity scores.
 
-CISO Assistant can export an existing CyFun audit directly into that workbook so you can submit the file to the CCB without retyping any data.
+CISO Assistant works with that workbook in both directions:
 
-## How it works
+- **Export** an existing CyFun audit into the official template, ready to submit to the CCB without retyping any data.
+- **Import** a filled self-assessment workbook to create a fully scored audit — useful when a customer or entity hands you their completed CyFun spreadsheet.
 
-1. Load the **CCB CyFun 2025** framework library (essential, important, or key, depending on your scope).
+## Importing a filled workbook
+
+The import accepts the official **CyFun 2025** self-assessment tools, in any of the three editions — **BASIC**, **IMPORTANT**, or **ESSENTIAL**. Nothing is inferred from the file name: the workbook is recognised by its sheets and headers, so renamed or re-saved copies work fine. The older CyFun 2023 workbook is not supported and is rejected with a clear error.
+
+One import creates one new audit:
+
+1. The **CyFun 2025** framework library is loaded automatically if it isn't already.
+2. The assurance level is detected from the workbook content, and the audit's implementation group is set to match (basic, important, or essential), so the audit scopes to exactly the requirements of that edition.
+3. For every requirement row, the **Documentation Score** and **Implementation Score** land on the matching requirement assessment, and scoring — including the documentation score — is switched on for the audit automatically. Global and per-category maturity scores are then computed by the platform as usual.
+4. Rows marked `N/A` in the workbook become **Not applicable** results.
+5. The **Comments and/or additional information** and **Assessor comments** cells are carried into the requirement's observation.
+
+### From the Data Wizard (Pro)
+
+Open **Extra** → **Data Wizard** in the sidebar, pick **CyFun self-assessment** as the model, select the target **Domain** (or a **Perimeter**), and upload the workbook. No framework selection is needed — it is derived from the file.
+
+### From the CLI
+
+```bash
+uv run clica.py import-cyfun-assessment \
+  --file CyFun2025_Self-Assessment_tool.xlsx \
+  --folder "My domain" \
+  --name "ACME CyFun self-assessment"
+```
+
+`--perimeter` can be used instead of `--folder`; `--name` is optional and defaults to a timestamped name. See the [data import wizard](../../configuration/data-import.md) page for CLI setup.
+
+## Exporting an audit to the workbook
+
+1. Load the **CCB CyFun 2025** framework library.
 2. Run an audit against that framework as usual — assess each requirement, attach evidence, link applied controls.
 3. From the audit's **Export** menu, choose **CyFun self-assessment**. The platform fills the official CCB template using the assessment data and downloads it.
 
 The **CyFun self-assessment** option only appears when the audit is based on the **CyFun 2025** framework — for any other framework it isn't offered, so you can't accidentally produce a malformed workbook.
 
-## Before you export
+### Before you export
 
-The export writes each requirement's **score** into the official template, so two audit settings have to line up first — both on the audit's edit form under **More** (see [Customize your audit](../../guides/customize-audit.md)):
+The export writes each requirement's **score** into the official template, so two audit settings have to line up first — both on the audit's edit form under **More** (see [Customize your audit](../../guides/customize-audit.md)). Audits created by the CyFun import already have these set; this only matters for audits created manually:
 
 - **Make the score visible.** The **Score** field defaults to _Hidden_ in [field visibility](../../guides/customize-audit.md#field-visibility). Switch it on (and **Documentation score** if you use it) so the score is recorded and lands in the workbook.
 - **Use _Average of averages_ scoring.** Set the [score calculation method](../../guides/customize-audit.md#score-calculation-method) to **Average of averages** — that's the roll-up logic the CyFun framework expects, grouping requirements by category and averaging the category averages.
 
-## What lands in the workbook
+### What lands in the workbook
 
-- Each CyFun requirement's status and score are written to the appropriate sheet and row.
-- Free-text notes from requirement assessments populate the comments column.
+- Each requirement's **documentation score** and **implementation score** are written to the appropriate sheet and row; **Not applicable** results are written as `N/A`.
+- Observations from requirement assessments populate the comments column.
 - The official template scaffolding (cover page, formulas, summary sheet) is preserved untouched.
 
 ## Related
 
 - [CyFun framework on the CCB website](https://atwork.safeonweb.be/tools-resources/cyberfundamentals-framework)
+- [Data import wizard](../../configuration/data-import.md)
 - [Audits concept](../../concepts/audits.md)


### PR DESCRIPTION
- **feat: cyfun 2025 excel importer**
- **update docs**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for importing official CyFun 2025 self-assessment Excel workbooks (BASIC, IMPORTANT, ESSENTIAL).
  * Automatically creates CyFun assessments, loads the CyFun framework when missing, and sets the implementation group from the detected assurance level.
  * Imports documentation/implementation scores, maps “N/A” to not applicable, and carries over workbook comments/observations.
  * Added UI and CLI options for CyFun assessment imports.

* **Bug Fixes**
  * Improved handling and validation of supported workbook layouts; unsupported workbooks are rejected with clear error reporting.

* **Documentation**
  * Updated CyFun import/export documentation and configuration guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->