### PR TITLE
hotfix: migration issue with custom libraries and postgresql

### DIFF
--- a/backend/core/migrations/0176_librarydraft.py
+++ b/backend/core/migrations/0176_librarydraft.py
@@ -411,6 +411,12 @@ def wrap_editing_drafts(apps, schema_editor):
     _wrap_matrix_drafts(apps, root)
     _wrap_preset_drafts(apps, root)
 
+    # The writes above queue deferred FK-constraint trigger events on the
+    # very tables the RemoveField DDL below ALTERs; Postgres refuses to
+    # ALTER a table with pending trigger events, so fire them now.
+    if schema_editor.connection.vendor == "postgresql":
+        schema_editor.execute("SET CONSTRAINTS ALL IMMEDIATE")
+
 
 class Migration(migrations.Migration):
     dependencies = [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of in-progress library content during the transition from legacy editors.
  * Preserved published or actively used content without interruption.
  * Kept unpublished content editable as drafts until it is ready to be released.
  * Prevented draft content from being incorrectly treated as live content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->