### PR TITLE
chores(ci): second pass to move to v1.0.1

### DIFF
--- a/automation/powerbi/CONTRIBUTING.md
+++ b/automation/powerbi/CONTRIBUTING.md
@@ -129,7 +129,13 @@ line of `CisoAssistant.pq` — semver, aligned with the compatibility policy:
 Release: bump `[Version]` (and `contract.json`/docs if the surface changed),
 merge, then tag `powerbi-v<x.y.z>`. CI refuses tags that don't match the
 `.pq` version, then builds, packs, signs (if the signing secrets are
-present), uploads artifacts, and attaches `CisoAssistant.mez` +
-`CisoAssistant.pqx` to the GitHub Release. Customer upgrade = replace the
+present), uploads artifacts, and creates the GitHub Release with
+`CisoAssistant.mez` + `CisoAssistant.pqx` attached atomically (releases are
+immutable once published — assets cannot be added afterwards).
+
+> **Warning**: deleting a published (immutable) release **permanently
+> reserves its tag name** — GitHub blocks re-creating that tag forever
+> (learned the hard way with `powerbi-v1.0.0`). A botched release is never
+> re-cut under the same version: fix, bump patch, tag the next number. Customer upgrade = replace the
 file, restart Power BI (reports and credentials bind to the data source
 kind, not the file or version).

--- a/automation/powerbi/connector/CisoAssistant.pq
+++ b/automation/powerbi/connector/CisoAssistant.pq
@@ -1,4 +1,4 @@
-[Version = "1.0.0"]
+[Version = "1.0.1"]
 section CisoAssistant;
 
 //


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the Power Query connector version to 1.0.1.

- **Documentation**
  - Clarified the release process, including atomic asset publication and release immutability.
  - Added guidance for recovering from deleted releases by using a patch version and new tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->