### PR TITLE
chores: drop cis benchmarks for now on enterprise builds

### DIFF
--- a/enterprise/backend/Dockerfile.dockerignore
+++ b/enterprise/backend/Dockerfile.dockerignore
@@ -1,0 +1,21 @@
+# BuildKit uses this file INSTEAD of backend/.dockerignore for the enterprise
+# backend build (Dockerfile-specific ignore file). Keep the community entries
+# below in sync with backend/.dockerignore.
+*.pyc
+**/.DS_Store
+*~$*
+.git*
+.pytest*
+.idea*
+.venv
+.dockerignore
+Dockerfile
+db
+**/__pycache__/
+**/.pytest_cache/
+**/.ruff_cache/
+static/
+pytest-report.html
+
+# Libraries excluded from the enterprise image (still shipped in community)
+library/libraries/cis-benchmark-*.yaml


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved enterprise backend container builds by excluding development files, caches, local environments, test artifacts, and unrelated build outputs.
  * Reduced unnecessary files included in the enterprise backend image build context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->