### PR TITLE
fix(pro): ensure global license accounting even under focus mode

### DIFF
--- a/backend/iam/models.py
+++ b/backend/iam/models.py
@@ -1022,11 +1022,16 @@ class User(ActorSyncMixin, AbstractBaseUser, AbstractBaseModel, FolderMixin):
 
     @classmethod
     def get_editors(cls) -> List["User"]:
-        return [
-            user
-            for user in cls.objects.all()
-            if user.is_editor and not user.is_third_party
-        ]
+        # License accounting is global, even when the current request is focused on a domain.
+        token = focus_folder_id_var.set(None)
+        try:
+            return [
+                user
+                for user in cls.objects.filter(is_third_party=False)
+                if user.is_editor
+            ]
+        finally:
+            focus_folder_id_var.reset(token)
 
     @property
     def is_sso(self) -> bool:

--- a/enterprise/backend/enterprise_core/serializers.py
+++ b/enterprise/backend/enterprise_core/serializers.py
@@ -6,6 +6,7 @@ from core.serializers import (
     FolderWriteSerializer as CommunityFolderWriteSerializer,
     UserWriteSerializer as CommunityUserWriteSerializer,
 )
+from core.context import focus_folder_id_var
 from core.serializer_fields import FieldsRelatedField
 from iam.models import RoleAssignment, User, Role
 from iam.cache_builders import get_folder_path, CacheNotReadyError
@@ -72,11 +73,18 @@ class EditorPermissionMixin:
         editors = User.get_editors()
         seats = settings.LICENSE_SEATS
 
-        perms = [
-            p
-            for p in RoleAssignment.get_permissions(group)
-            if p not in User.NON_SEAT_PERMISSIONS
-        ]
+        # License accounting must be global, even when the current request
+        # is focused on a domain (a group's assignments outside the focus
+        # subtree would otherwise be invisible to get_permissions()).
+        token = focus_folder_id_var.set(None)
+        try:
+            perms = [
+                p
+                for p in RoleAssignment.get_permissions(group)
+                if p not in User.NON_SEAT_PERMISSIONS
+            ]
+        finally:
+            focus_folder_id_var.reset(token)
         if any(perm.startswith(prefix) for prefix in editor_prefixes for perm in perms):
             logger.info("Adding editor permissions to user", user=instance, group=group)
             if instance not in editors and len(editors) >= seats:


### PR DESCRIPTION

<!--
PR title must follow Conventional Commits (squash-merged → title becomes the commit subject):
  feat | fix | chore | refactor | perf | docs | test | ci | build   (lowercase, scope optional, `!` for breaking)
  e.g. feat(lib): add NIS2 framework   |   fix(api): correct residual risk validation
Full guide: product-docs/contributing/code.md
-->

## What & why

Under Focus mode the editor accounting could be bypass 

<!-- What does this change do, and why? Link the issue if there is one. -->

Closes #

## Test plan

<!-- What you ran/clicked to verify. Attach screenshots for UI changes. -->

## Checklist

<!-- Keep the sections that apply, delete the rest. Tests and docs are part of "done" — tick them when relevant, or note why they aren't. -->

- [X] PR title follows Conventional Commits (`!` set if this is a breaking change)
- [X] One focused change, branched off `main`
- [ ] CLA accepted (first contribution only)

### Backend — if you touched `backend/`

- [X] `ruff format` run, no new linter errors
- [ ] Migrations generated with `makemigrations` and committed (or none needed)
- [ ] New dependencies checked for known vulnerabilities and called out above

### Frontend — if you touched `frontend/`

- [ ] Svelte 5 syntax; `pnpm run lint` and `pnpm run format` run
- [ ] New/changed UI strings added to `frontend/messages/en.json` (keep keys, preserve `{tokens}`)
- [ ] Clicked through the change in the dev server; screenshots attached for UI changes

### Other — libraries, CI, infra

- [ ] Library changes built via the `tools/` script
- [ ] CI / build changes run green

### Tests & documentation — definition of done

- [ ] Tests added or updated and passing locally — backend `uv run pytest`, frontend `pnpm run test` / `./tests/e2e-tests.sh` _(if relevant)_
- [ ] Regression test added for bug fixes _(if relevant)_
- [ ] `product-docs/` updated, new pages listed in `SUMMARY.md`, vocabulary terms added _(if relevant)_
- [ ] No tests or docs needed for this change — why:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editor permission and license-seat validation for consistent results across folder contexts.
  * Third-party accounts are no longer included in editor eligibility calculations.
  * Corrected editor listings and permission checks to use global license scope when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->