### PR TITLE
fix!: prune old invalid Implementation Groups consistently when updating a framework

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -983,6 +983,69 @@ class LibraryUpdater:
                 },
             )
 
+    @staticmethod
+    def prune_stale_implementation_groups(framework, compliance_assessments):
+        """Drop selected IG ref_ids that the updated framework no longer defines.
+
+        A renamed ref_id is indistinguishable from a removed one, so both are dropped;
+        the selection has to be made again by the user.
+        """
+        from automation.models import PostureAssessment
+
+        valid_implementation_groups = {
+            group.get("ref_id")
+            for group in framework.implementation_groups_definition or []
+            if isinstance(group, dict) and group.get("ref_id")
+        }
+
+        for model, objects in (
+            (ComplianceAssessment, compliance_assessments),
+            (PostureAssessment, PostureAssessment.objects.filter(framework=framework)),
+        ):
+            stale_objects = []
+            for obj in objects:
+                selected_groups = obj.selected_implementation_groups or []
+                cleaned_groups = [
+                    group
+                    for group in selected_groups
+                    if group in valid_implementation_groups
+                ]
+                if cleaned_groups != selected_groups:
+                    obj.selected_implementation_groups = cleaned_groups
+                    stale_objects.append(obj)
+
+            if stale_objects:
+                model.objects.bulk_update(
+                    stale_objects,
+                    ["selected_implementation_groups"],
+                    batch_size=100,
+                )
+
+        # Campaign entries are {"value": <ref_id>, "framework": <framework id>} and
+        # span several frameworks, so only this framework's entries are pruned.
+        framework_id = str(framework.id)
+        stale_campaigns = []
+        for campaign in Campaign.objects.filter(frameworks=framework):
+            selected_groups = campaign.selected_implementation_groups or []
+            cleaned_groups = [
+                group
+                for group in selected_groups
+                if not (
+                    isinstance(group, dict) and group.get("framework") == framework_id
+                )
+                or group.get("value") in valid_implementation_groups
+            ]
+            if cleaned_groups != selected_groups:
+                campaign.selected_implementation_groups = cleaned_groups
+                stale_campaigns.append(campaign)
+
+        if stale_campaigns:
+            Campaign.objects.bulk_update(
+                stale_campaigns,
+                ["selected_implementation_groups"],
+                batch_size=100,
+            )
+
     def update_frameworks(self):
         """
         Update frameworks with score change handling.
@@ -1059,36 +1122,9 @@ class LibraryUpdater:
                     ).select_related("folder", "perimeter")
                 ]
 
-                # Drop selected IGs that the updated framework no longer defines.
-                valid_implementation_groups = {
-                    group.get("ref_id")
-                    for group in new_framework.implementation_groups_definition or []
-                    if isinstance(group, dict) and group.get("ref_id")
-                }
-                assessments_with_stale_implementation_groups = []
-                for compliance_assessment in compliance_assessments:
-                    selected_groups = (
-                        compliance_assessment.selected_implementation_groups or []
-                    )
-                    cleaned_groups = [
-                        group
-                        for group in selected_groups
-                        if group in valid_implementation_groups
-                    ]
-                    if cleaned_groups != selected_groups:
-                        compliance_assessment.selected_implementation_groups = (
-                            cleaned_groups
-                        )
-                        assessments_with_stale_implementation_groups.append(
-                            compliance_assessment
-                        )
-
-                if assessments_with_stale_implementation_groups:
-                    ComplianceAssessment.objects.bulk_update(
-                        assessments_with_stale_implementation_groups,
-                        ["selected_implementation_groups"],
-                        batch_size=100,
-                    )
+                self.prune_stale_implementation_groups(
+                    new_framework, compliance_assessments
+                )
 
                 existing_requirement_node_objects = {
                     rn.urn.lower(): rn

--- a/backend/scripts/convert_library_v2.py
+++ b/backend/scripts/convert_library_v2.py
@@ -30,7 +30,7 @@ import openpyxl
 from copy import deepcopy
 from typing import Any, Dict, List
 from pathlib import Path
-from collections import Counter
+from collections import Counter, defaultdict
 
 SCRIPT_VERSION = "2.1"
 
@@ -1370,6 +1370,27 @@ def _handle_framework(obj, library, object_blocks, prefix_to_urn, compat_mode, v
             requirement_nodes.append(node)
 
         framework["requirement_nodes"] = requirement_nodes
+
+        # An implementation group that the definition doesn't declare can never be
+        # selected, so its requirements silently drop out of every scoped audit.
+        defined_igs = {
+            str(ig.get("ref_id", "")).strip()
+            for ig in framework.get("implementation_groups_definition") or []
+        }
+        orphan_igs = defaultdict(list)
+        for node in requirement_nodes:
+            for ig in node.get("implementation_groups") or []:
+                if ig not in defined_igs:
+                    orphan_igs[ig].append(node.get("ref_id") or node.get("urn"))
+        if orphan_igs:
+            details = "; ".join(
+                f"'{ig}' used by {nodes[:3]}{' ...' if len(nodes) > 3 else ''}"
+                for ig, nodes in sorted(orphan_igs.items())
+            )
+            raise ValueError(
+                "(framework) implementation groups used by requirements but missing "
+                f"from the implementation groups definition {sorted(defined_igs)}: {details}"
+            )
 
     library["objects"]["framework"] = framework
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed selections that reference implementation groups no longer present after framework updates, keeping compliance assessments, posture assessments, and campaigns aligned with current framework definitions.
  * Added a library-conversion integrity check that detects and fails fast when requirement nodes reference “orphan” implementation groups not declared by the framework.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->