### PR TITLE
chores(ci): fix release versions now that we have multiple releases streams

### DIFF
--- a/.github/workflows/docker-build-and-push-dummy.yml
+++ b/.github/workflows/docker-build-and-push-dummy.yml
@@ -30,9 +30,10 @@ jobs:
 
       - name: Get version and Create .meta file
         run: |
-          echo "VERSION=$(git describe --tags --always)" >> $GITHUB_ENV
+          VERSION="$(git describe --tags --always --match 'v[0-9]*')"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "BUILD=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-          echo "CISO_ASSISTANT_VERSION=$(git describe --tags --always)" > .meta
+          echo "CISO_ASSISTANT_VERSION=$VERSION" > .meta
           echo "CISO_ASSISTANT_BUILD=$(git rev-parse --short HEAD)" >> .meta
           cp .meta ./backend/
           cp .meta ./backend/ciso_assistant/

--- a/.github/workflows/docker-build-and-push-ee.yml
+++ b/.github/workflows/docker-build-and-push-ee.yml
@@ -32,7 +32,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "version=$(git describe --tags --always)" >> "$GITHUB_OUTPUT"
+          # On a tag push the pushed tag IS the version: git describe breaks
+          # ties between tags on the same commit alphabetically, so a
+          # powerbi-v* tag cut on the same commit would win over v*.
+          if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            version="$GITHUB_REF_NAME"
+          else
+            version="$(git describe --tags --always --match 'v[0-9]*')"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "build=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
   build-frontend:

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -31,7 +31,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "version=$(git describe --tags --always)" >> "$GITHUB_OUTPUT"
+          # On a tag push the pushed tag IS the version: git describe breaks
+          # ties between tags on the same commit alphabetically, so a
+          # powerbi-v* tag cut on the same commit would win over v*.
+          if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            version="$GITHUB_REF_NAME"
+          else
+            version="$(git describe --tags --always --match 'v[0-9]*')"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "build=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
   build-frontend:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release version detection during automated builds.
  * Tag-triggered builds now use the pushed version tag directly.
  * Non-tag builds consistently derive versions from matching version tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->