### PR TITLE
fix(lib): further align capitalisation in BIO2 implementation groups

### DIFF
--- a/backend/library/libraries/bio2.yaml
+++ b/backend/library/libraries/bio2.yaml
@@ -264,7 +264,7 @@ objects:
 
         This overview shall be updated at least annually.'
       implementation_groups:
-      - "Ketenhygi\xEBne"
+      - "ketenhygi\xEBne"
       translations:
         nl:
           description: 'De organisatie heeft uitgewerkt welke functionarissen met
@@ -282,7 +282,7 @@ objects:
         that risks are identified and appropriately managed, and that security requirements
         are properly defined.
       implementation_groups:
-      - "Ketenhygi\xEBne"
+      - "ketenhygi\xEBne"
       translations:
         nl:
           description: "Bij nieuwe informatiesystemen en bij significante wijzigingen\
@@ -1243,7 +1243,7 @@ objects:
         \ in accordance with mutual agreements, to the relevant colleagues within\
         \ the government\u2019s security domain."
       implementation_groups:
-      - "Ketenhygi\xEBne"
+      - "ketenhygi\xEBne"
       translations:
         nl:
           description: "In geval van concrete beveiligingsrisico\u2019s worden waarschuwingen,\


### PR DESCRIPTION
Updates missed capitalisation fixes in BIO2 implementation groups

The commit in PR https://github.com/intuitem/ciso-assistant-community/pull/4591 was incomplete. This PR fixes that.


- [x] PR title follows Conventional Commits (`!` set if this is a breaking change)
- [x] One focused change, branched off `main`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected BIO2 requirement group references to ensure they consistently match the defined identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->