### PR TITLE
fix(export): xlsx export crash on illegal control characters

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -451,6 +451,16 @@ def escape_csv_row(row):
     ]
 
 
+ILLEGAL_XLSX_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f]")
+
+
+def sanitize_xlsx_value(value):
+    """Strip ASCII control characters openpyxl refuses to write (tab/LF/CR are allowed)."""
+    if isinstance(value, str):
+        return ILLEGAL_XLSX_CHARS_RE.sub("", value)
+    return value
+
+
 def create_xlsx_response(entries, filename, wrap_columns=None):
     """
     DRY helper to create XLSX response with consistent formatting.
@@ -466,6 +476,9 @@ def create_xlsx_response(entries, filename, wrap_columns=None):
     if wrap_columns is None:
         wrap_columns = ["name", "description"]
 
+    entries = [
+        {k: sanitize_xlsx_value(v) for k, v in entry.items()} for entry in entries
+    ]
     df = pd.DataFrame(entries)
     buffer = io.BytesIO()
 
@@ -3971,7 +3984,7 @@ class RiskAssessmentViewSet(BaseModelViewSet):
                 "\n".join([ra.get("str") for ra in item.get("owner")]),
                 "\n".join([ra.get("str") for ra in item.get("risk_scenarios")]),
             ]
-            ws.append(row)
+            ws.append([sanitize_xlsx_value(value) for value in row])
 
         for row_idx, row in enumerate(ws.iter_rows(min_row=2), 2):  # Skip header row
             max_lines = 1
@@ -11569,7 +11582,7 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
                     if evidence.get("filename")
                 ),
             }
-            entries.append(entry)
+            entries.append({k: sanitize_xlsx_value(v) for k, v in entry.items()})
 
         df = pd.DataFrame(entries)
         buffer = io.BytesIO()


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits (squash-merged → title becomes the commit subject):
  feat | fix | chore | refactor | perf | docs | test | ci | build   (lowercase, scope optional, `!` for breaking)
  e.g. feat(lib): add NIS2 framework   |   fix(api): correct residual risk validation
Full guide: product-docs/contributing/code.md
-->

## What & why

**Problem:** `action_plan_xlsx` (and the two other xlsx export paths sharing the same pattern) crashed with an unhandled `openpyxl.utils.exceptions.IllegalCharacterError` whenever an exported field contained an ASCII control character outside `[\x00-\x08\x0b\x0c\x0e-\x1f]`,  most commonly `\x0b` (vertical tab) from pasting rich text from Word/Outlook into a description field. Backend returned 500, frontend masked it as a generic 400 "Error fetching the action plan XLSX file". Confirm from a live instance 

**Fix:** added `sanitize_xlsx_value()`, stripping openpyxl's exact illegal-character range from every string value before it's written to a cell. Applied at export time in all three affected paths, so no data migration is needed 
- `action_plan_xlsx`
- `create_xlsx_response` (shared xlsx export helper)
- risk-assessment action plan xlsx export



<!-- What does this change do, and why? Link the issue if there is one. -->

## Test plan

<!-- What you ran/clicked to verify. Attach screenshots for UI changes. -->
reproduced the crash locally with the client's actual (illegal-char-containing) applied-control descriptions, confirmed the fix resolves it end-to-end

## Checklist

<!-- Keep the sections that apply, delete the rest. Tests and docs are part of "done" — tick them when relevant, or note why they aren't. -->

- [X] PR title follows Conventional Commits (`!` set if this is a breaking change)
- [X] One focused change, branched off `main`
- [ ] CLA accepted (first contribution only)

### Backend — if you touched `backend/`

- [X] `ruff format` run, no new linter errors
- [ ] Migrations generated with `makemigrations` and committed (or none needed)
- [ ] New dependencies checked for known vulnerabilities and called out above

### Frontend — if you touched `frontend/`

- [ ] Svelte 5 syntax; `pnpm run lint` and `pnpm run format` run
- [ ] New/changed UI strings added to `frontend/messages/en.json` (keep keys, preserve `{tokens}`)
- [ ] Clicked through the change in the dev server; screenshots attached for UI changes

### Other — libraries, CI, infra

- [ ] Library changes built via the `tools/` script
- [ ] CI / build changes run green

### Tests & documentation — definition of done

- [ ] Tests added or updated and passing locally — backend `uv run pytest`, frontend `pnpm run test` / `./tests/e2e-tests.sh` _(if relevant)_
- [ ] Regression test added for bug fixes _(if relevant)_
- [ ] `product-docs/` updated, new pages listed in `SUMMARY.md`, vocabulary terms added _(if relevant)_
- [ ] No tests or docs needed for this change — why:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed XLSX exports that could fail when text contained unsupported control characters.
  * Preserved valid tabs, line breaks, and carriage returns in exported content.
  * Applied the fix across standard exports and assessment action-plan data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->