### PR TITLE
doc: properly point to the default roles explanation

### DIFF
--- a/product-docs/configuration/organization/iam-model.md
+++ b/product-docs/configuration/organization/iam-model.md
@@ -56,12 +56,9 @@ Each object type has granular **CRUD permissions** (create, read, update, delete
 
 #### Predefined Roles <a href="#ember940" id="ember940"></a>
 
-Permissions are grouped into a small set of **standard roles**:
+Permissions are grouped into a small set of **standard roles** — Administrator, Domain manager, Analyst, Reader, Approver, Respondent, Third-party respondent and Technical tester.
 
-* **Administrator** – full access to all objects and settings
-* **Analyst** – full access to most objects, but cannot modify access control
-* **Viewer** – read-only access
-* **Approver** – strictly limited to **approving risk acceptance requests**
+See [User groups → Roles](user-groups.md#roles) for what each of them can and cannot do.
 
 #### Hierarchical Domains <a href="#ember943" id="ember943"></a>
 

--- a/product-docs/configuration/organization/user-groups.md
+++ b/product-docs/configuration/organization/user-groups.md
@@ -6,20 +6,24 @@ description: >-
 
 # User Groups
 
-For now, it is not possible to create custom role assignments so you need to use built-in user groups. They are linking a domain with a role which contains precise permissions, that will be given to users in this group.
+Built-in user groups link a domain with a role, which carries a precise set of permissions. Every user in the group receives those permissions on that domain and its sub-domains. If the built-in roles are not granular enough, the PRO edition also lets you define [custom roles](custom-roles.md).
 
 ### Roles
 
-Let's give some details on the 5 built-in roles:
+There are 8 built-in roles. The table below gives the high-level shape of each one — the underlying permission matrix has more than 200 entries, so this is deliberately a summary, not an exhaustive list.
 
-| Role           | Permissions                                                                                                                       |
-| -------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| Administrator  | full access (except approval), and specifically management of domains, users and users rights                                     |
-| Domain manager | full access to selected domains (except approval), in particular managing rights for these domains. Read access to global objects |
-| Analyst        | read-write access to selected perimeters/domains. Read access to global and domain objects                                        |
-| Reader         | read access to selected perimeters/domains                                                                                        |
-| Approver       | like reader, but with additional capability to approve risk acceptances                                                           |
-| Respondent     | see [assignments.md](../../features/assignments.md "mention") for more details                                                    |
+| Role                   | Can                                                                                                                                                                                | Cannot                                                                                                                        |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Administrator          | Everything, on the whole instance: all business objects, plus domains, users, user groups, roles, libraries, instance settings and backups. Also approves risk acceptances.          | — this is the only role that can change instance-wide configuration.                                                             |
+| Domain manager         | Everything an Analyst can, on its own domains, plus creating sub-domains and managing the user groups of those domains. Read access to global objects.                               | Approve risk acceptances. Manage users, roles, libraries or instance settings.                                                   |
+| Analyst                | Create, update and delete the operational objects of its domains — audits, risk assessments, applied controls, assets, evidences, tasks, findings… Read global and domain objects.   | Touch access control (domains, user groups, roles, users). Approve risk acceptances.                                             |
+| Reader                 | Read everything in its domains: assessments, controls, assets, third-party module, dashboards and metrics.                                                                            | Create, update or delete anything.                                                                                               |
+| Approver               | Read the objects of its domains, and approve or reject risk acceptances and validation flow steps.                                                                                   | Create or update business objects. Its read scope is slightly narrower than Reader — no third-party module, dashboards or metrics. |
+| Respondent             | Answer the requirements assigned to it: set compliance results, attach or create applied controls and evidences, comment. See [assignments.md](../../features/assignments.md "mention"). | Create audits or assessments. Reach the risk, governance or administration modules.                                              |
+| Third-party respondent | The same answering capability as a Respondent, restricted to the questionnaire of the entity assessment the user was invited to. See [tprm.md](../../guides/tprm.md "mention").      | See or do anything outside that questionnaire. Create or update applied controls.                                                |
+| Technical tester       | Create and run [technical postures](../../concepts/technical-postures.md) and their results, and manage the findings assessments and findings that follow up on them.                | Everything else — read-only on assets, frameworks and perimeters, no access to audits or risk assessments.                        |
+
+The _Technical tester_ role is only useful once the `posture_assessments` feature flag is on (default off) — see [Technical postures](../../concepts/technical-postures.md). Its user group is created on every domain regardless.
 
 {% hint style="info" %}
 Django superuser is given administrator rights automatically on startup.
@@ -46,8 +50,11 @@ They are created for each domain you add. For example, if you create a domain _R
 * R\&D - Reader
 * R\&D - Approver
 * R\&D - Respondent
+* R\&D - Technical tester
 
 They give corresponding permissions on the domain scope so on every object inside _R\&D_.
+
+The _Third-party respondent_ group is the exception: it is not created upfront on domains, but on the dedicated enclave of an entity assessment, when you invite third-party contacts to answer its questionnaire.
 
 ### Managing group members
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated role documentation to include Administrator, Domain manager, Analyst, Reader, Approver, Respondent, Third-party respondent, and Technical tester.
  * Clarified that custom roles are supported in the PRO edition.
  * Documented Technical tester feature-flag requirements and Third-party respondent group creation.
  * Added links to detailed role information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->