### PR TITLE
feat: generate PDF report for audit

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -147,7 +147,7 @@ from rest_framework.exceptions import (
 )
 
 
-from weasyprint import HTML
+from weasyprint import CSS, HTML
 
 from core.helpers import *
 from core.models import (
@@ -11677,6 +11677,50 @@ class ComplianceAssessmentViewSet(BaseModelViewSet):
             return response
         else:
             return Response({"error": "Permission denied"})
+
+    @action(detail=True, methods=["get"], name="Get audit report PDF")
+    def report_pdf(self, request, pk):
+        """
+        The audit report — same content as the export bundle's index.html
+        (requirements, questions and answers, results, observations,
+        evidence names, applied controls) rendered as a single PDF.
+        """
+        object_ids_view = RoleAssignment.get_viewable_object_ids(
+            request.user, ComplianceAssessment
+        )
+        if UUID(pk) not in object_ids_view:
+            return Response(
+                {"error": "Permission denied"}, status=status.HTTP_403_FORBIDDEN
+            )
+
+        compliance_assessment: ComplianceAssessment = self.get_object()
+        user_lang = request.user.preferences.get("lang") or "en"
+        # Referential translations (question/choice texts) resolve through
+        # get_language(); follow the in-app preference the user reads the
+        # audit in rather than the HTTP Accept-Language header.
+        translation.activate(user_lang)
+
+        index_content, _ = generate_html(compliance_assessment)
+        page_layout = CSS(
+            string="""
+            @page {
+                size: A4 portrait;
+                margin: 1.2cm;
+                @bottom-right {
+                    content: counter(page) " / " counter(pages);
+                    font-size: 8pt;
+                    color: #71717a;
+                }
+            }
+            """
+        )
+        pdf_file = HTML(string=index_content).write_pdf(stylesheets=[page_layout])
+        response = HttpResponse(pdf_file, content_type="application/pdf")
+        safe_name = slugify(compliance_assessment.name) or "audit"
+        response["Content-Disposition"] = (
+            f'attachment; filename="{safe_name}_report.pdf"'
+        )
+        return response
 
     @action(
         detail=True,

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -501,6 +501,8 @@
 	"exportControlsWorkbookDesc": "Formatted workbook of applied controls",
 	"exportStatusGroupedReport": "Status-grouped report",
 	"exportStatusGroupedReportDesc": "Controls grouped by status, sorted by ETA",
+	"exportAuditReportPdf": "Audit report",
+	"exportAuditReportPdfDesc": "The bundle's report as a printable PDF: requirements, answers, results and observations",
 	"exportIncidentReport": "Incident report",
 	"exportIncidentReportDesc": "Incident details and full timeline, ready to edit",
 	"exportIncidentReportPrintable": "Printable incident report",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -643,6 +643,8 @@
 	"exportControlsWorkbookDesc": "Mesures appliquées en classeur mis en forme",
 	"exportStatusGroupedReport": "Rapport par statut",
 	"exportStatusGroupedReportDesc": "Mesures regroupées par statut et triées par échéance",
+	"exportAuditReportPdf": "Rapport d'audit",
+	"exportAuditReportPdfDesc": "Le rapport de l'archive en PDF imprimable : exigences, réponses, résultats et observations",
 	"exportIncidentReport": "Rapport d'incident",
 	"exportIncidentReportDesc": "Détails de l'incident et chronologie complète, modifiables",
 	"exportIncidentReportPrintable": "Rapport d'incident imprimable",

--- a/frontend/src/routes/(app)/(internal)/compliance-assessments/[id=uuid]/export/report-pdf/+server.ts
+++ b/frontend/src/routes/(app)/(internal)/compliance-assessments/[id=uuid]/export/report-pdf/+server.ts
@@ -1,0 +1,22 @@
+import { BASE_API_URL } from '$lib/utils/constants';
+
+import { error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+export const GET: RequestHandler = async ({ fetch, params }) => {
+	const URLModel = 'compliance-assessments';
+	const endpoint = `${BASE_API_URL}/${URLModel}/${params.id}/report_pdf/`;
+
+	const res = await fetch(endpoint);
+	if (!res.ok) {
+		error(400, 'Error fetching the PDF file');
+	}
+
+	const fileName = `audit-report-${params.id}-${new Date().toISOString()}.pdf`;
+
+	return new Response(await res.blob(), {
+		headers: {
+			'Content-Type': 'application/pdf',
+			'Content-Disposition': `attachment; filename="${fileName}"`
+		}
+	});
+};

--- a/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/+page.svelte
+++ b/frontend/src/routes/(app)/(third-party)/compliance-assessments/[id=uuid]/+page.svelte
@@ -441,6 +441,13 @@
 				href: `/compliance-assessments/${id}/export/word`,
 				testId: 'export-option-word'
 			},
+			{
+				titleKey: 'exportAuditReportPdf',
+				descriptionKey: 'exportAuditReportPdfDesc',
+				format: 'PDF' as const,
+				href: `/compliance-assessments/${id}/export/report-pdf`,
+				testId: 'export-option-report-pdf'
+			},
 			isInternal &&
 				isCyFun && {
 					titleKey: 'exportCyFunAssessment',


### PR DESCRIPTION
use the report already done in the zip file

<!--
PR title must follow Conventional Commits (squash-merged → title becomes the commit subject):
  feat | fix | chore | refactor | perf | docs | test | ci | build   (lowercase, scope optional, `!` for breaking)
  e.g. feat(lib): add NIS2 framework   |   fix(api): correct residual risk validation
Full guide: product-docs/contributing/code.md
-->

## What & why

<!-- What does this change do, and why? Link the issue if there is one. -->

Closes #

## Test plan

<!-- What you ran/clicked to verify. Attach screenshots for UI changes. -->

## Checklist

<!-- Keep the sections that apply, delete the rest. Tests and docs are part of "done" — tick them when relevant, or note why they aren't. -->

- [ ] PR title follows Conventional Commits (`!` set if this is a breaking change)
- [ ] One focused change, branched off `main`
- [ ] CLA accepted (first contribution only)

### Backend — if you touched `backend/`

- [ ] `ruff format` run, no new linter errors
- [ ] Migrations generated with `makemigrations` and committed (or none needed)
- [ ] New dependencies checked for known vulnerabilities and called out above

### Frontend — if you touched `frontend/`

- [ ] Svelte 5 syntax; `pnpm run lint` and `pnpm run format` run
- [ ] New/changed UI strings added to `frontend/messages/en.json` (keep keys, preserve `{tokens}`)
- [ ] Clicked through the change in the dev server; screenshots attached for UI changes

### Other — libraries, CI, infra

- [ ] Library changes built via the `tools/` script
- [ ] CI / build changes run green

### Tests & documentation — definition of done

- [ ] Tests added or updated and passing locally — backend `uv run pytest`, frontend `pnpm run test` / `./tests/e2e-tests.sh` _(if relevant)_
- [ ] Regression test added for bug fixes _(if relevant)_
- [ ] `product-docs/` updated, new pages listed in `SUMMARY.md`, vocabulary terms added _(if relevant)_
- [ ] No tests or docs needed for this change — why:
