### PR TITLE
fix: custom get query set to avoid N+1 on Data breach view

### DIFF
--- a/backend/privacy/views.py
+++ b/backend/privacy/views.py
@@ -836,6 +836,21 @@ class DataBreachViewSet(BaseModelViewSet):
         "evidences",
     ]
 
+    def get_queryset(self):
+        return (
+            super()
+            .get_queryset()
+            .select_related("folder", "incident")
+            .prefetch_related(
+                "assigned_to",
+                "authorities",
+                "affected_processings",
+                "affected_personal_data",
+                "remediation_measures",
+                "evidences",
+            )
+        )
+
     @action(detail=False, name="Get breach type choices")
     def breach_type(self, request):
         return Response(dict(DataBreach.BREACH_TYPE_CHOICES))


### PR DESCRIPTION
## What & why

`GET /api/privacy/data-breaches/` was slow due to an N+1 query pattern: `DataBreachViewSet` had no custom `get_queryset()`, so it fell back to the generic one in `BaseModelViewSet`, which only `select_related`s `parent_folder` — a field that doesn't exist on `DataBreach` (it's `folder`). The read serializer also serializes 5 M2M relations (`assigned_to`, `authorities`, `affected_processings`, `affected_personal_data`, `remediation_measures`, `evidences`) plus the `incident` FK, none of them prefetched.

Added a `get_queryset()` override with `select_related`/`prefetch_related`, matching the pattern already used across the codebase (e.g. `AssetViewSet`, `EvidenceViewSet`, and `PersonalDataViewSet` in this same file).

Closes #

## Test plan

Verified with `APIClient` inside a rolled-back DB transaction (no data persisted), comparing query counts before/after on `GET /api/privacy/data-breaches/` with 15 data breaches:
- Before: 121 SQL queries
- After: 22 SQL queries

Response payload (fields, values) unchanged — confirmed via a diff of the serialized output. `python manage.py check` passes.

## Checklist

- [x] PR title follows Conventional Commits (`!` set if this is a breaking change)
- [x] One focused change, branched off `main`
- [X] CLA accepted (first contribution only) — N/A if not first contribution

### Backend — if you touched `backend/`

- [x] Migrations generated with `makemigrations` and committed (or none needed) — no model changes
- [x] New dependencies checked for known vulnerabilities and called out above — none added

### Tests & documentation — definition of done

- [ ] No tests or docs needed for this change — why: pure query-optimization, no behavior/API contract change; verified manually via query-count comparison (see Test plan). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Improved loading performance for data breach records and their related details, resulting in more responsive views and fewer delays when reviewing breach information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->