### PR TITLE
fix: improve CLI error explanation on missing .clica.env

### DIFF
--- a/cli/clica.py
+++ b/cli/clica.py
@@ -51,7 +51,12 @@ def _friendly_excepthook(exc_type, exc_value, exc_tb):
     """Turn common misconfiguration errors (missing/invalid API_URL, unreachable
     server) into a readable message instead of a raw traceback."""
     if issubclass(
-        exc_type, (requests.exceptions.MissingSchema, requests.exceptions.InvalidURL)
+        exc_type,
+        (
+            requests.exceptions.MissingSchema,
+            requests.exceptions.InvalidURL,
+            requests.exceptions.InvalidSchema,
+        ),
     ):
         print(
             "API_URL is missing or invalid. Copy .clica.env.template to .clica.env "

--- a/cli/clica.py
+++ b/cli/clica.py
@@ -47,36 +47,6 @@ else:
     ic.disable()
 
 
-def _friendly_excepthook(exc_type, exc_value, exc_tb):
-    """Turn common misconfiguration errors (missing/invalid API_URL, unreachable
-    server) into a readable message instead of a raw traceback."""
-    if issubclass(
-        exc_type,
-        (
-            requests.exceptions.MissingSchema,
-            requests.exceptions.InvalidURL,
-            requests.exceptions.InvalidSchema,
-        ),
-    ):
-        print(
-            "API_URL is missing or invalid. Copy .clica.env.template to .clica.env "
-            "in the cli/ directory and set API_URL, e.g. API_URL=http://localhost:8000/api",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-    if issubclass(exc_type, requests.exceptions.ConnectionError):
-        print(
-            f"Could not reach the CISO Assistant API at {API_URL!r}. "
-            "Check that API_URL is correct and the server is running.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-    sys.__excepthook__(exc_type, exc_value, exc_tb)
-
-
-sys.excepthook = _friendly_excepthook
-
-
 def ids_map(model, folder=None):
     if not TOKEN:
         print(
@@ -1390,4 +1360,23 @@ def import_domain(file, name, load_missing_libraries, create_missing_asset_class
 
 
 if __name__ == "__main__":
-    cli()
+    try:
+        cli()
+    except requests.exceptions.ConnectionError:
+        print(
+            f"Could not reach the CISO Assistant API at {API_URL!r}. "
+            "Check that API_URL is correct and the server is running.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    except (
+        requests.exceptions.MissingSchema,
+        requests.exceptions.InvalidURL,
+        requests.exceptions.InvalidSchema,
+    ):
+        print(
+            "API_URL is missing or invalid. Copy .clica.env.template to .clica.env "
+            "in the cli/ directory and set API_URL, e.g. API_URL=http://localhost:8000/api",
+            file=sys.stderr,
+        )
+    sys.exit(1)

--- a/cli/clica.py
+++ b/cli/clica.py
@@ -47,6 +47,31 @@ else:
     ic.disable()
 
 
+def _friendly_excepthook(exc_type, exc_value, exc_tb):
+    """Turn common misconfiguration errors (missing/invalid API_URL, unreachable
+    server) into a readable message instead of a raw traceback."""
+    if issubclass(
+        exc_type, (requests.exceptions.MissingSchema, requests.exceptions.InvalidURL)
+    ):
+        print(
+            "API_URL is missing or invalid. Copy .clica.env.template to .clica.env "
+            "in the cli/ directory and set API_URL, e.g. API_URL=http://localhost:8000/api",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if issubclass(exc_type, requests.exceptions.ConnectionError):
+        print(
+            f"Could not reach the CISO Assistant API at {API_URL!r}. "
+            "Check that API_URL is correct and the server is running.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    sys.__excepthook__(exc_type, exc_value, exc_tb)
+
+
+sys.excepthook = _friendly_excepthook
+
+
 def ids_map(model, folder=None):
     if not TOKEN:
         print(

--- a/cli/clica.py
+++ b/cli/clica.py
@@ -1379,4 +1379,4 @@ if __name__ == "__main__":
             "in the cli/ directory and set API_URL, e.g. API_URL=http://localhost:8000/api",
             file=sys.stderr,
         )
-    sys.exit(1)
+        sys.exit(1)


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits (squash-merged → title becomes the commit subject):
  feat | fix | chore | refactor | perf | docs | test | ci | build   (lowercase, scope optional, `!` for breaking)
  e.g. feat(lib): add NIS2 framework   |   fix(api): correct residual risk validation
Full guide: product-docs/contributing/code.md
-->

## What & why

`clica.py` crashed with a raw Python traceback (`requests.exceptions.MissingSchema`) whenever `API_URL` was missing or empty — e.g. `.clica.env` not created from `.clica.env.template`, or the variable simply not exported. An unreachable/misconfigured server produced the same kind of ugly `ConnectionError` traceback.

Added a global `sys.excepthook` that catches these two error classes and prints a short, readable message pointing the user to `.clica.env.template`, then exits with status 1 — no more stack trace for a simple config issue.

Fixes CA-1628.


## Test plan

- Reproduced the original bug: `TOKEN=fake_token API_URL= python3 clica.py get-matrices` → now prints a clean message instead of the `MissingSchema` traceback.
- Reproduced the unreachable-server case (`API_URL` pointing to a closed port) → clean message instead of a `ConnectionError` traceback.
- `clica.py --help` and `clica.py get-folders --help` still work with no config at all (no regression).
- Normal path with a valid `.clica.env` and missing `TOKEN` still shows the pre-existing clean message ("No authentication token available...").
- Ran `cli/tests/test_cli.py` before and after the change: same result (one pre-existing, unrelated failure on `main`).

<img width="1270" height="98" alt="Capture d’écran 2026-09-02 à 15 33 49" src="https://github.com/user-attachments/assets/7e0a33cb-0a0b-42d1-b156-aef49b3cc7d5" />

## Checklist


- [x] PR title follows Conventional Commits (`!` set if this is a breaking change)
- [x] One focused change, branched off `main`
- [x] CLA accepted (first contribution only)

### Backend — if you touched `backend/`

- [x] `ruff format` run, no new linter errors

pyte
### Tests & documentation — definition of done

- [x] No tests or docs needed for this change — why: it only changes how an existing error is *displayed* (a global exception hook), no new behavior/API surface to cover; verified manually against both the original bug and the help/normal-path cases above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved command-line error messages for missing or invalid API URL configurations, including unsupported URL schemes.
  - The CLI directs users to configure `API_URL` in `.clica.env` when applicable.
  - Unexpected errors now follow the CLI’s standard error flow.
  - Successful CLI commands now exit with status code 0, improving compatibility with scripts that rely on exit statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->