### PR TITLE
docs(adr): add Security considerations section to template

### DIFF
--- a/documentation/architecture/decisions/template.md
+++ b/documentation/architecture/decisions/template.md
@@ -17,6 +17,10 @@ What we chose, stated actively: "We will ...". One paragraph.
 
 What becomes easier, what becomes harder, what is now forbidden or required. This is the section future readers act on, so make constraints explicit and imperative.
 
+## Security considerations
+
+What this decision changes for security: what new things can be attacked, what data is exposed, who gains access to what. List the risks we accept and what must be done to reduce them.
+
 ## Alternatives considered
 
 Each option we didn't pick, with a one-line reason. Written down so nobody has to redo this discussion next year.


### PR DESCRIPTION
## What & why

Adds a "Security considerations" section to the ADR template so decisions record their security impact: what becomes attackable, what data is exposed, accepted risks and required mitigations.

## Checklist

- [x] PR title follows Conventional Commits (`!` set if this is a breaking change)
- [x] One focused change, branched off `main`

### Tests & documentation — definition of done

- [x] No tests or docs needed for this change — why: documentation template only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Security considerations section to the architecture decision record template.
  * The section prompts authors to document security impacts, exposed data, access changes, accepted risks, and required mitigations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->