### PR TITLE
fix: task export as excel

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -17459,10 +17459,12 @@ class TaskTemplateViewSet(CommitmentActionsMixin, ExportMixin, BaseModelViewSet)
                 ),
             },
             "labels": {
-                "source": "filtering_labels",
+                "source": "task_template.filtering_labels",
                 "label": "labels",
-                "format": lambda qs: ",".join(
-                    escape_excel_formula(o.label) for o in qs.all()
+                "format": lambda qs: (
+                    ",".join(escape_excel_formula(o.label) for o in qs.all())
+                    if qs
+                    else ""
                 ),
             },
         },
@@ -17843,6 +17845,7 @@ class TaskTemplateViewSet(CommitmentActionsMixin, ExportMixin, BaseModelViewSet)
                     "task_template__compliance_assessments",
                     "task_template__risk_assessments",
                     "task_template__findings_assessment",
+                    "task_template__filtering_labels",
                 )
                 .order_by("due_date")
             )


### PR DESCRIPTION
- [x] fix Excel report
- [ ] better way to access previous tasks
- [x] improve importer to cover daily granularity
- [ ] be able to create expected evidence on the fly
- [ ] importer to autocreate/link evidences if set
- [x] analytics page for all tasks or filtered (from table)
- [ ] include evidences importer
- [ ] missing strings on data wizard import options
- [ ] visual inconsistency / glitches for markdown fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved Excel exports so filtering labels are retrieved correctly from task templates.
- Exports now show a blank value when no filtering labels are available, rather than an empty separator.
- Improved export performance by preloading filtering label data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->