### PR TITLE
fix(frontend): treat rowless-source tables as local everywhere

### DIFF
--- a/frontend/src/lib/components/ModelTable/ModelTable.svelte
+++ b/frontend/src/lib/components/ModelTable/ModelTable.svelte
@@ -372,14 +372,14 @@
 
 	const hiddenRowCount = $derived(typeof expectedCount === 'number' ? expectedCount : 0);
 
-	$tableHandlers[baseEndpoint] = handler;
-
-	const toastStore = getToastStore();
-
 	// A table handed its rows up front has no model or endpoint ("/undefined"): the
 	// remote handler would poll it and clear the seeded rows. A bare baseEndpoint is
 	// still remote.
 	const hasRemoteSource = Boolean(URLModel) || baseEndpoint !== '/undefined';
+
+	if (hasRemoteSource) $tableHandlers[baseEndpoint] = handler;
+
+	const toastStore = getToastStore();
 
 	if (hasRemoteSource)
 		handler.onChange((state: State) =>
@@ -437,7 +437,7 @@
 	const filters = $derived(source?.filters ?? tableFilters);
 	const filteredFields = $derived(Object.keys(filters));
 	// Only persist filters on standalone list pages, not embedded sub-tables
-	const isStandaloneTable = baseEndpoint === `/${URLModel}`;
+	const isStandaloneTable = hasRemoteSource && baseEndpoint === `/${URLModel}`;
 	const filterStoreKey = `${page.url.pathname}::${baseEndpoint}`;
 	const storedFilters = isStandaloneTable ? ($tableFilterStates[filterStoreKey] ?? {}) : {};
 	// Check if any filter-related URL params exist

--- a/frontend/tests/functional/detailed/library-preview-tables.test.ts
+++ b/frontend/tests/functional/detailed/library-preview-tables.test.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '../../utils/test-utils.js';
+
+// Regression test for the /undefined request: the preview tables on a library
+// detail page are fed from the library payload and get no URLModel, so
+// ModelTable used to build the endpoint `/undefined`, fetch it, fail with a 404
+// and replace the rows it had been given with an empty list.
+test('library preview table renders its rows without any remote request', async ({
+	logedPage,
+	page
+}) => {
+	const strayRequests: string[] = [];
+	page.on('request', (request) => {
+		if (request.url().includes('/undefined')) strayRequests.push(request.url());
+	});
+
+	// A library whose only listed objects are reference controls: its detail page
+	// renders exactly one preview table, so the row count is unambiguous.
+	const libraries = await page.request
+		.get('/stored-libraries?limit=1000')
+		.then((res) => res.json());
+	const library = (libraries.results ?? []).find((lib: Record<string, any>) => {
+		const meta = lib.objects_meta ?? {};
+		return meta.reference_controls > 0 && Object.keys(meta).length === 1;
+	});
+	test.skip(!library, 'no stored library exposing only reference controls in this database');
+
+	await page.goto(`/stored-libraries/${library.id}`);
+	await expect(page).toHaveURL(/.*stored-libraries.*/);
+	// The rows were briefly there before being replaced, so let the page settle
+	// first: the assertion below has to describe the state that lasts.
+	await page.waitForLoadState('networkidle');
+
+	expect(strayRequests).toEqual([]);
+	await expect(page.locator('table tbody tr')).toHaveCount(library.objects_meta.reference_controls);
+});


### PR DESCRIPTION
## What & why

Library detail pages render up to four preview tables (risk matrices, reference controls, threats, metric definitions) from the library payload. They deliberately pass no `URLModel`, since these objects have no list endpoint: on a stored library they only exist inside `StoredLibrary.content`, and on a loaded library the existing endpoints return every object of that type instance-wide rather than the library's own.

`ModelTable` builds its endpoint as `/${URLModel}`, so with no model that string became the literal `"/undefined"`. It then registered the remote load callback and the filter-sync effect invalidated it on mount, producing `GET /undefined?offset=0&limit=0` → 404. The error path (`handler.ts`) calls `setTotalRows(0)` and returns `[]`, which replaced the rows the caller had already provided — so the table rendered empty while its section header still announced the real count. It affected 28 stored libraries plus the loaded-library pages, not just the one it was reported on.

**#4689 already fixes the core of this upstream** with `hasRemoteSource`, whose condition is broader than what this branch originally proposed (it also treats an explicit `baseEndpoint` without a model as remote). That fix is kept as-is here. What this PR adds is the same flag applied to the two places it was still missing:

- `$tableHandlers[baseEndpoint] = handler` — local tables registered themselves under the `/undefined` key, so the four previews on one page overwrote each other in the global store
- `isStandaloneTable` — compared `baseEndpoint === '/${URLModel}'`, both sides being `/undefined`, so local previews were treated as standalone list pages and persisted filters under `…::/undefined`

Plus the regression test that was missing, which now guards the upstream fix.

Closes CA-1846

## Test plan

- Added `library-preview-tables.test.ts`: discovers via the API a stored library whose only objects are reference controls (so exactly one preview table, unambiguous row count), opens its page, then asserts no request to `/undefined` was issued and that the table holds exactly `objects_meta.reference_controls` rows.
- Verified the test genuinely catches the bug: run against the pre-#4689 base with the guard removed, it fails on the captured request `http://localhost:4173/undefined?offset=0&limit=0`. It also exposed a flaw in its own first draft — the row-count assertion passed despite the bug, because the rows exist at construction and are wiped ~10 ms later; it now waits for `networkidle` so it describes the state that lasts.
- `./tests/e2e-tests.sh detailed/library-preview-tables.test.ts` on the rebased state: 1 passed. Earlier run together with `detailed/compliance-assessments.test.ts` (a heavy `ModelTable` consumer, to check the shared component): 2 passed.
- `pnpm run test`: 181 passed.
- Diagnosis done in the browser, which is how the scope was established: the CyFun page showed a "218 Reference controls" header above a table with 0 rows; neutralising the failing request made all 218 rows appear with correct columns and no console error — proving the payload was valid and the code was discarding it. Reproduced identically on ISO/IEC 27001:2022 and on Mitre D3FEND (no framework at all), and confirmed absent on a framework-only library, which renders a tree and no table.

## Checklist

- [x] PR title follows Conventional Commits (`!` set if this is a breaking change)
- [x] One focused change, rebased onto `main` (88e199e24)
- [ ] CLA accepted (first contribution only) — n/a if already signed

### Frontend — if you touched `frontend/`

- [x] Svelte 5 syntax; `pnpm run format` run (`prettier --check` clean). `pnpm run lint` (eslint) could not be run — pre-existing environment issue in this checkout (`@eslint/eslintrc` missing from `node_modules`), unrelated to this change
- [x] No new/changed UI strings
- [x] Checked in the dev server — see test plan. No screenshots attached: the visible change (empty tables becoming populated) comes from #4689; the two lines in this PR fix latent state-keying bugs with no user-visible effect

### Tests & documentation — definition of done

- [x] Tests added or updated and passing locally — `./tests/e2e-tests.sh detailed/library-preview-tables.test.ts` (1 passed), `pnpm run test` (181 passed). Backend `uv run pytest` not run: nothing under `backend/` is touched
- [x] Regression test added for bug fixes — verified red without the guard, green with it
- [ ] No tests or docs needed for this change — n/a, test added above

Deux points sur lesquels j'ai été explicite plutôt que de cocher en bloc, parce qu'ils se verront en review de toute façon :

- La paternité de la correction principale est attribuée à #4689 dès le troisième paragraphe. Sans ça, un reviewer qui connaît cette PR se demanderait pourquoi tu réintroduis son travail.
- Pas de capture d'écran, et la raison est écrite : ce PR n'a aucun effet visible, l'amélioration visuelle vient d'amont. Cocher « screenshots attached » aurait été faux, et laisser la case vide sans explication aurait fait douter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed library preview tables so they display stored rows without making invalid remote requests.
  * Prevented tables without a model or remote endpoint from triggering unnecessary filtering or polling.
  * Improved standalone-table detection to require a valid remote source and endpoint.

* **Tests**
  * Added coverage verifying library detail-page preview tables render correctly without remote requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->