### PR TITLE
docs(workflows): quote front matter descriptions so GitBook can parse them

### DIFF
--- a/product-docs/concepts/workflows.md
+++ b/product-docs/concepts/workflows.md
@@ -1,5 +1,5 @@
 ---
-description: Automation that reacts to what happens in the platform, on a schedule, on an event or on a webhook, and notifies, reads, creates or updates objects on your behalf
+description: "Automation that reacts to what happens in the platform, on a schedule, on an event or on a webhook, and notifies, reads, creates or updates objects on your behalf"
 ---
 
 # Workflows

--- a/product-docs/features/workflows/README.md
+++ b/product-docs/features/workflows/README.md
@@ -1,5 +1,5 @@
 ---
-description: The canvas where workflows are designed, published and watched: header, palette, inspector, panels and run view
+description: "The canvas where workflows are designed, published and watched: header, palette, inspector, panels and run view"
 ---
 
 # Workflow builder

--- a/product-docs/features/workflows/actions.md
+++ b/product-docs/features/workflows/actions.md
@@ -1,5 +1,5 @@
 ---
-description: Every action type with its settings, outputs and the permission it requires
+description: "Every action type with its settings, outputs and the permission it requires"
 ---
 
 # Action reference

--- a/product-docs/features/workflows/expressions.md
+++ b/product-docs/features/workflows/expressions.md
@@ -1,5 +1,5 @@
 ---
-description: The {{ }} syntax for referencing variables, payloads, step outputs, loop items and secrets
+description: "The {{ }} syntax for referencing variables, payloads, step outputs, loop items and secrets"
 ---
 
 # Expressions

--- a/product-docs/features/workflows/permissions-and-security.md
+++ b/product-docs/features/workflows/permissions-and-security.md
@@ -1,5 +1,5 @@
 ---
-description: Who a run acts as, what it can reach, what it may never write, and how webhooks and secrets are protected
+description: "Who a run acts as, what it can reach, what it may never write, and how webhooks and secrets are protected"
 ---
 
 # Permissions and security

--- a/product-docs/features/workflows/publish-checks.md
+++ b/product-docs/features/workflows/publish-checks.md
@@ -1,5 +1,5 @@
 ---
-description: Every message the publish step can raise, and how to fix it
+description: "Every message the publish step can raise, and how to fix it"
 ---
 
 # Publish checks

--- a/product-docs/features/workflows/runs.md
+++ b/product-docs/features/workflows/runs.md
@@ -1,5 +1,5 @@
 ---
-description: Starting runs, reading the Runs panel and the run log, time limits, and what to do when a run fails
+description: "Starting runs, reading the Runs panel and the run log, time limits, and what to do when a run fails"
 ---
 
 # Runs

--- a/product-docs/features/workflows/sharing.md
+++ b/product-docs/features/workflows/sharing.md
@@ -1,5 +1,5 @@
 ---
-description: Export and import workflows as files, and install ready-made ones from the library catalog
+description: "Export and import workflows as files, and install ready-made ones from the library catalog"
 ---
 
 # Sharing workflows

--- a/product-docs/features/workflows/steps.md
+++ b/product-docs/features/workflows/steps.md
@@ -1,5 +1,5 @@
 ---
-description: Action, Condition, Loop and Stop run: what each step does and how wires route a run
+description: "Action, Condition, Loop and Stop run: what each step does and how wires route a run"
 ---
 
 # Steps

--- a/product-docs/features/workflows/templates.md
+++ b/product-docs/features/workflows/templates.md
@@ -1,5 +1,5 @@
 ---
-description: The ready-made workflows that ship as libraries, by domain, and which one to start from
+description: "The ready-made workflows that ship as libraries, by domain, and which one to start from"
 ---
 
 # Template catalog

--- a/product-docs/features/workflows/triggers.md
+++ b/product-docs/features/workflows/triggers.md
@@ -1,5 +1,5 @@
 ---
-description: What starts a run: Manual, Webhook, Schedule and On event triggers, their settings, their state and the Triggers panel
+description: "What starts a run: Manual, Webhook, Schedule and On event triggers, their settings, their state and the Triggers panel"
 ---
 
 # Triggers

--- a/product-docs/features/workflows/troubleshooting.md
+++ b/product-docs/features/workflows/troubleshooting.md
@@ -1,5 +1,5 @@
 ---
-description: Symptoms and fixes: triggers that do not fire, failed runs, empty expressions, refused publishes
+description: "Symptoms and fixes: triggers that do not fire, failed runs, empty expressions, refused publishes"
 ---
 
 # Troubleshooting

--- a/product-docs/features/workflows/variables-and-secrets.md
+++ b/product-docs/features/workflows/variables-and-secrets.md
@@ -1,5 +1,5 @@
 ---
-description: Declaring variables, where their values come from, and how secrets are stored and used
+description: "Declaring variables, where their values come from, and how secrets are stored and used"
 ---
 
 # Variables and secrets

--- a/product-docs/guides/first-workflow.md
+++ b/product-docs/guides/first-workflow.md
@@ -1,5 +1,5 @@
 ---
-description: Enable the feature, build a workflow that finds overdue applied controls, run it, publish it and put it on a schedule
+description: "Enable the feature, build a workflow that finds overdue applied controls, run it, publish it and put it on a schedule"
 ---
 
 # Building your first workflow


### PR DESCRIPTION
## What & why

GitBook failed to sync after #4757: four workflow pages had a `description:` containing a colon, which YAML parses as a nested key. Every description on the workflow pages is now double-quoted, and all front matters in `product-docs/` parse.

## Test plan

Parsed every front matter in `product-docs/` with a YAML parser: 0 invalid.

## Checklist

- [x] PR title follows Conventional Commits (`!` set if this is a breaking change)
- [x] One focused change, branched off `main`

### Tests & documentation — definition of done

- [x] No tests or docs needed for this change — why: documentation front matter only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Standardized description metadata formatting across workflow concepts, guides, and feature documentation.
  - Documentation text and instructional content remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->