### PR TITLE
fix: regression preventing adding a metric sample

### DIFF
--- a/backend/metrology/serializers.py
+++ b/backend/metrology/serializers.py
@@ -52,9 +52,12 @@ def coerce_sample_value(value):
     if not isinstance(value, str):
         return value
     try:
-        return json.loads(value)
+        decoded = json.loads(value)
     except json.JSONDecodeError, TypeError:
         return value
+    # Only a dict is a legacy encoding; anything else stays a string so the
+    # value schema rejects it instead of slipping past the field's allow_null.
+    return decoded if isinstance(decoded, dict) else value
 
 
 # MetricDefinition serializers

--- a/backend/metrology/serializers.py
+++ b/backend/metrology/serializers.py
@@ -1,3 +1,5 @@
+import json
+
 import jsonschema
 from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import gettext_lazy as _
@@ -43,6 +45,16 @@ VALUE_SCHEMA_BY_CATEGORY = {
     MetricDefinition.Category.QUALITATIVE: QUALITATIVE_VALUE_SCHEMA,
     MetricDefinition.Category.QUANTITATIVE: QUANTITATIVE_VALUE_SCHEMA,
 }
+
+
+def coerce_sample_value(value):
+    """Clients before 3.21.5 sent (and stored) the value as a JSON string."""
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError, TypeError:
+        return value
 
 
 # MetricDefinition serializers
@@ -162,6 +174,9 @@ class CustomMetricSampleWriteSerializer(BaseModelSerializer):
             validated_data["folder"] = validated_data["metric_instance"].folder
         return super().create(validated_data)
 
+    def validate_value(self, value):
+        return coerce_sample_value(value)
+
     def validate_timestamp(self, value):
         """Prevent creating samples with future timestamps"""
         from django.utils import timezone
@@ -178,7 +193,7 @@ class CustomMetricSampleWriteSerializer(BaseModelSerializer):
         if "value" in attrs:
             value = attrs["value"]
         elif self.instance is not None:
-            value = self.instance.value
+            value = coerce_sample_value(self.instance.value)
         else:
             value = CustomMetricSample._meta.get_field("value").get_default()
         if value is None:

--- a/backend/metrology/tests/test_metric_definition_serializer.py
+++ b/backend/metrology/tests/test_metric_definition_serializer.py
@@ -276,6 +276,19 @@ class TestCustomMetricSampleWriteSerializerValidatesValueShape:
         assert serializer.is_valid(), serializer.errors
         assert serializer.validated_data["value"] == {"choice_index": 1}
 
+    @pytest.mark.parametrize("bad_value", ["null", "99.9", "[]", "false", '"null"'])
+    def test_rejects_legacy_json_string_that_does_not_decode_to_an_object(
+        self, metric_instance, bad_value
+    ):
+        errors = self._errors_for_value(metric_instance, bad_value)
+
+        assert "value" in errors
+
+    def test_rejects_legacy_json_string_null_on_the_value_schema(self, metric_instance):
+        errors = self._errors_for_value(metric_instance, "null")
+
+        assert "is not of type 'object'" in str(errors["value"][0])
+
     def test_accepts_partial_update_of_legacy_string_valued_sample(
         self, metric_instance
     ):

--- a/backend/metrology/tests/test_metric_definition_serializer.py
+++ b/backend/metrology/tests/test_metric_definition_serializer.py
@@ -251,3 +251,40 @@ class TestCustomMetricSampleWriteSerializerValidatesValueShape:
 
         assert not serializer.is_valid()
         assert "value" in serializer.errors
+
+    def test_accepts_legacy_json_string_result(self, metric_instance):
+        serializer = CustomMetricSampleWriteSerializer(
+            data={
+                "metric_instance": str(metric_instance.pk),
+                "timestamp": "2024-01-01T00:00:00Z",
+                "value": '{"result": 1.0}',
+            }
+        )
+
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["value"] == {"result": 1.0}
+
+    def test_accepts_legacy_json_string_choice_index(self, qualitative_instance):
+        serializer = CustomMetricSampleWriteSerializer(
+            data={
+                "metric_instance": str(qualitative_instance.pk),
+                "timestamp": "2024-01-01T00:00:00Z",
+                "value": '{"choice_index": 1}',
+            }
+        )
+
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["value"] == {"choice_index": 1}
+
+    def test_accepts_partial_update_of_legacy_string_valued_sample(
+        self, metric_instance
+    ):
+        sample = _sample_with_value(metric_instance, '{"result": 1.0}')
+
+        serializer = CustomMetricSampleWriteSerializer(
+            instance=sample,
+            data={"observation": "still fine"},
+            partial=True,
+        )
+
+        assert serializer.is_valid(), serializer.errors

--- a/frontend/src/lib/components/Forms/ModelForm/CustomMetricSampleForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/CustomMetricSampleForm.svelte
@@ -154,6 +154,7 @@
 		<label for="value-select" class="text-sm font-semibold block mb-2">{m.value()}</label>
 		<select
 			id="value-select"
+			data-testid="form-input-value"
 			class="select w-full"
 			value={selectedChoiceIndex}
 			onchange={(e) => handleQualitativeChange(e.currentTarget.value)}
@@ -174,6 +175,7 @@
 		</label>
 		<input
 			id="value-input"
+			data-testid="form-input-value"
 			type="number"
 			step="any"
 			class="input w-full"

--- a/frontend/src/lib/components/Forms/ModelForm/CustomMetricSampleForm.svelte
+++ b/frontend/src/lib/components/Forms/ModelForm/CustomMetricSampleForm.svelte
@@ -6,6 +6,7 @@
 	import type { SuperValidated } from 'sveltekit-superforms';
 	import type { ModelInfo, CacheLock } from '$lib/utils/types';
 	import { m } from '$paraglide/messages';
+	import { safeTranslate } from '$lib/utils/i18n';
 
 	interface Props {
 		form: SuperValidated<any>;
@@ -27,7 +28,7 @@
 		object = {}
 	}: Props = $props();
 
-	const { value: valueFieldProxy } = formFieldProxy(form, 'value');
+	const { value: valueFieldProxy, errors: valueErrors } = formFieldProxy(form, 'value');
 
 	// Get full metric instance data from autocomplete cache (includes nested fields like metric_definition, evidences)
 	const metricInstanceCache = $derived.by(() => {
@@ -89,7 +90,7 @@
 	});
 
 	function handleQualitativeChange(selectedIndex: string) {
-		$valueFieldProxy = JSON.stringify({ choice_index: parseInt(selectedIndex) });
+		$valueFieldProxy = { choice_index: parseInt(selectedIndex) };
 	}
 
 	// For quantitative metrics, parse the numeric value
@@ -108,7 +109,7 @@
 		const value = (event.target as HTMLInputElement).value;
 		const numValue = parseFloat(value);
 		if (!isNaN(numValue)) {
-			$valueFieldProxy = JSON.stringify({ result: numValue });
+			$valueFieldProxy = { result: numValue };
 		}
 	}
 
@@ -179,6 +180,14 @@
 			value={quantitativeValue}
 			oninput={handleQuantitativeChange}
 		/>
+	</div>
+{/if}
+
+{#if $valueErrors}
+	<div>
+		{#each $valueErrors as error}
+			<p class="text-error-500 text-xs font-medium">{safeTranslate(error)}</p>
+		{/each}
 	</div>
 {/if}
 

--- a/frontend/tests/functional/detailed/metrics.test.ts
+++ b/frontend/tests/functional/detailed/metrics.test.ts
@@ -1,0 +1,71 @@
+import { test, expect, TestContent } from '../../utils/test-utils.js';
+
+const vars = TestContent.generateTestVars();
+
+// Regression guard for #4752: the form used to post `value` as a JSON string, which the
+// serializer's object schema rejected — the sample was silently never created.
+const sampleValue = 42;
+const sampleTimestamp = '2024-07-17T16:19';
+
+test('user can add a custom metric sample to a metric instance', async ({
+	logedPage,
+	foldersPage,
+	metricDefinitionsPage,
+	metricInstancesPage,
+	customMetricSamplesPage,
+	page
+}) => {
+	await test.step('create required folder', async () => {
+		await foldersPage.goto();
+		await foldersPage.hasUrl();
+		await foldersPage.createItem({
+			name: vars.folderName,
+			description: vars.description
+		});
+		// NOTE: creating one more folder not to trip up the autocomplete test utils
+		await foldersPage.createItem({
+			name: vars.folderName + ' foo',
+			description: vars.description
+		});
+	});
+
+	await test.step('create metric definition', async () => {
+		await metricDefinitionsPage.goto();
+		await metricDefinitionsPage.hasUrl();
+		await metricDefinitionsPage.createItem({
+			name: vars.metricDefinitionName,
+			description: vars.description,
+			folder: vars.folderName,
+			category: 'quantitative'
+		});
+	});
+
+	await test.step('create metric instance', async () => {
+		await metricInstancesPage.goto();
+		await metricInstancesPage.hasUrl();
+		await metricInstancesPage.createItem({
+			name: vars.metricInstanceName,
+			description: vars.description,
+			folder: vars.folderName,
+			metric_definition: vars.metricDefinitionName
+		});
+	});
+
+	await test.step('add a custom metric sample', async () => {
+		await metricInstancesPage.viewItemDetail(vars.metricInstanceName);
+		await customMetricSamplesPage.createItem(
+			{
+				timestamp: sampleTimestamp,
+				value: sampleValue
+			},
+			undefined,
+			page
+		);
+	});
+
+	await test.step('check that the sample is listed with its value', async () => {
+		const row = customMetricSamplesPage.getRow(sampleValue.toString());
+		await expect(row).toBeVisible();
+		await expect(row).toContainText(sampleValue.toString());
+	});
+});

--- a/frontend/tests/utils/test-data.ts
+++ b/frontend/tests/utils/test-data.ts
@@ -17,6 +17,8 @@ export default {
 	threatName: 'Test threat',
 	description: 'Test description',
 	biaName: 'Test BIA',
+	metricDefinitionName: 'Test metric definition',
+	metricInstanceName: 'Test metric instance',
 	file: new URL('../utils/test_image.png', import.meta.url).pathname,
 	file2: new URL('../utils/test_file.txt', import.meta.url).pathname,
 	favicon: new URL('../utils/test_favicon.ico', import.meta.url).pathname,

--- a/frontend/tests/utils/test-utils.ts
+++ b/frontend/tests/utils/test-utils.ts
@@ -42,6 +42,9 @@ type Fixtures = {
 	solutionsPage: PageContent;
 	representativesPage: PageContent;
 	entityAssessmentsPage: PageContent;
+	metricDefinitionsPage: PageContent;
+	metricInstancesPage: PageContent;
+	customMetricSamplesPage: PageContent;
 	settingsPage: PageContent;
 	logedPage: LoginPage;
 	thirdPartyAuthenticatedPage: LoginPage;
@@ -421,6 +424,38 @@ export const test = base.extend<Fixtures>({
 			{ name: 'conclusion', type: type.SELECT }
 		]);
 		await use(ePage);
+	},
+
+	metricDefinitionsPage: async ({ page }, use) => {
+		const mPage = new PageContent(page, '/metric-definitions', 'Metric definitions', [
+			{ name: 'name', type: type.TEXT },
+			{ name: 'description', type: type.TEXT },
+			{ name: 'folder', type: type.SELECT_AUTOCOMPLETE },
+			{ name: 'category', type: type.SELECT },
+			{ name: 'unit', type: type.SELECT_AUTOCOMPLETE }
+		]);
+		await use(mPage);
+	},
+
+	metricInstancesPage: async ({ page }, use) => {
+		const mPage = new PageContent(page, '/metric-instances', 'Metric instances', [
+			{ name: 'name', type: type.TEXT },
+			{ name: 'description', type: type.TEXT },
+			{ name: 'folder', type: type.SELECT_AUTOCOMPLETE },
+			{ name: 'metric_definition', type: type.SELECT_AUTOCOMPLETE },
+			{ name: 'status', type: type.SELECT },
+			{ name: 'target_value', type: type.NUMBER }
+		]);
+		await use(mPage);
+	},
+
+	customMetricSamplesPage: async ({ page }, use) => {
+		const cPage = new PageContent(page, '/custom-metric-samples', 'Custom metric samples', [
+			{ name: 'metric_instance', type: type.SELECT_AUTOCOMPLETE },
+			{ name: 'timestamp', type: type.DATE },
+			{ name: 'value', type: type.NUMBER }
+		]);
+		await use(cPage);
 	},
 
 	usersPage: async ({ page }, use) => {


### PR DESCRIPTION
as result of #4676


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Custom metric sample values entered through the form are now processed correctly, allowing samples to be saved successfully.
  * Existing values stored as JSON strings remain compatible with validation and partial updates.
  * Validation errors for sample values are now displayed directly below the relevant input.

* **Tests**
  * Added coverage for creating custom metric samples and handling legacy JSON-formatted values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->