### PR TITLE
fix: version pnpm alignment regression

### DIFF
--- a/enterprise/frontend/Dockerfile
+++ b/enterprise/frontend/Dockerfile
@@ -14,7 +14,10 @@ COPY project.inlang .
 COPY . .
 COPY --from=enterprise_frontend / .
 
-RUN npm install -g pnpm
+# Install the exact pnpm version pinned by packageManager: a mismatched pnpm
+# delegates to the pinned version via @pnpm/exe, a native binary that needs
+# libatomic.so.1, which the DHI image doesn't ship.
+RUN npm install -g "pnpm@$(node -p "require('./package.json').packageManager.split('@')[1]")"
 RUN pnpm install --frozen-lockfile
 RUN pnpm run build
 RUN pnpm prune

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,7 +11,10 @@ ENV PUBLIC_BACKEND_API_URL=foo
 
 COPY package*.json ./
 COPY . .
-RUN npm install -g pnpm
+# Install the exact pnpm version pinned by packageManager: a mismatched pnpm
+# delegates to the pinned version via @pnpm/exe, a native binary that needs
+# libatomic.so.1, which the DHI image doesn't ship.
+RUN npm install -g "pnpm@$(node -p "require('./package.json').packageManager.split('@')[1]")"
 RUN pnpm install --frozen-lockfile
 RUN pnpm run build
 RUN pnpm prune

--- a/frontend/tests/Dockerfile
+++ b/frontend/tests/Dockerfile
@@ -5,7 +5,9 @@ WORKDIR /app
 ENV PUBLIC_BACKEND_API_URL=foo
 
 COPY ../package*.json .
-RUN npm install -g pnpm
+# Install the exact pnpm version pinned by packageManager so a newer global
+# pnpm doesn't delegate through its own version manager.
+RUN npm install -g "pnpm@$(node -p "require('./package.json').packageManager.split('@')[1]")"
 RUN pnpm install --frozen-lockfile
 RUN npx playwright install --with-deps
 COPY .. .


### PR DESCRIPTION
## What & why

Package building is broken due to pnpm 12 released an improper pinning in our configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker-based builds and tests now use the pnpm version specified by the project, improving consistency across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->