### PR TITLE
fix: show actors by name and full observations in findings PDF report

### DIFF
--- a/backend/app_tests/api/test_api_findings.py
+++ b/backend/app_tests/api/test_api_findings.py
@@ -517,3 +517,62 @@ class TestBatchAction:
         for finding in findings:
             finding.refresh_from_db()
             assert finding.folder == setup["other_domain"]
+
+
+class TestFindingsAssessmentPdf:
+    """The PDF report renders actors by name and does not cut observations short."""
+
+    @pytest.fixture
+    def report(self, setup):
+        from django.template.loader import render_to_string
+
+        author = User.objects.create_user(
+            "author@tests.com", first_name="Ada", last_name="Author"
+        )
+        reviewer = User.objects.create_user(
+            "reviewer@tests.com", first_name="Rey", last_name="Reviewer"
+        )
+        owner = User.objects.create_user(
+            "owner@tests.com", first_name="Olu", last_name="Owner"
+        )
+        binder = setup["binder"]
+        binder.authors.add(author.actor)
+        binder.reviewers.add(reviewer.actor)
+        long_observation = "word " * 60
+        finding = Finding.objects.create(
+            name="Weak password policy",
+            findings_assessment=binder,
+            folder=binder.folder,
+            observation=long_observation,
+        )
+        finding.owner.add(owner.actor)
+
+        html = render_to_string(
+            "core/findings_assessment_pdf.html",
+            {
+                "findings_assessment": binder,
+                "findings": Finding.objects.filter(findings_assessment=binder),
+                "metrics": binder.get_findings_metrics(),
+                "processed_status_distribution": [],
+                "finding_status_choices": dict(Finding.Status.choices),
+            },
+        )
+        return {"html": html, "observation": long_observation.strip()}
+
+    def test_authors_and_reviewers_are_named(self, report):
+        assert "Ada Author" in report["html"]
+        assert "Rey Reviewer" in report["html"]
+
+    def test_finding_owners_are_named(self, report):
+        assert "Olu Owner" in report["html"]
+
+    def test_observation_is_not_truncated(self, report):
+        assert "…" not in report["html"]
+        assert report["observation"] in report["html"]
+
+    def test_pdf_endpoint_renders(self, setup):
+        res = setup["client"].get(
+            f"/api/findings-assessments/{setup['binder'].id}/pdf/"
+        )
+        assert res.status_code == 200
+        assert res["Content-Type"] == "application/pdf"

--- a/backend/core/templates/core/findings_assessment_pdf.html
+++ b/backend/core/templates/core/findings_assessment_pdf.html
@@ -16,14 +16,11 @@
                 <p><strong>Domain:</strong> {{ findings_assessment.folder.name|default:"N/A" }}</p>
             </div>
             <div class="w-1/2">
-                {% if findings_assessment.owner.exists %}
-                <p><strong>Owners:</strong> {% for owner in findings_assessment.owner.all %}{{ owner.email }}{% if not forloop.last %}, {% endif %}{% endfor %}</p>
-                {% endif %}
                 {% if findings_assessment.authors.exists %}
-                <p><strong>Authors:</strong> {% for author in findings_assessment.authors.all %}{{ author.email }}{% if not forloop.last %}, {% endif %}{% endfor %}</p>
+                <p><strong>Authors:</strong> {% for author in findings_assessment.authors.all %}{{ author }}{% if not forloop.last %}, {% endif %}{% endfor %}</p>
                 {% endif %}
                 {% if findings_assessment.reviewers.exists %}
-                <p><strong>Reviewers:</strong> {% for reviewer in findings_assessment.reviewers.all %}{{ reviewer.email }}{% if not forloop.last %}, {% endif %}{% endfor %}</p>
+                <p><strong>Reviewers:</strong> {% for reviewer in findings_assessment.reviewers.all %}{{ reviewer }}{% if not forloop.last %}, {% endif %}{% endfor %}</p>
                 {% endif %}
                 {% if findings_assessment.observation %}
                 <p><strong>Observation:</strong> {{ findings_assessment.observation|linebreaksbr }}</p>
@@ -140,7 +137,7 @@
                     <td class="border p-2 text-sm">{{ finding.name }}</td>
                     <td class="border p-2 text-sm capitalize">{{ finding.get_severity_display }}</td>
                     <td class="border p-2 text-sm capitalize">{{ finding.get_status_display }}</td>
-                    <td class="border p-2 text-sm">{{ finding.observation|default:"N/A"|truncatechars:100|linebreaksbr }}</td>
+                    <td class="border p-2 text-sm">{{ finding.observation|default:"N/A"|linebreaksbr }}</td>
                 </tr>
                 {% endfor %}
             </tbody>
@@ -185,7 +182,7 @@
                     <p class="text-sm font-medium">Owner(s):</p>
                     <p class="text-sm text-gray-600">
                         {% if finding.owner.exists %}
-                            {% for owner in finding.owner.all %}{{ owner.email }}{% if not forloop.last %}, {% endif %}{% endfor %}
+                            {% for owner in finding.owner.all %}{{ owner }}{% if not forloop.last %}, {% endif %}{% endfor %}
                         {% else %}
                             N/A
                         {% endif %}

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -16328,7 +16328,7 @@ class FindingsAssessmentViewSet(BaseModelViewSet):
         findings = (
             Finding.objects.filter(findings_assessment_id=pk)
             .select_related("folder")
-            .prefetch_related("applied_controls", "evidences")
+            .prefetch_related("applied_controls", "evidences", actor_prefetch("owner"))
             .order_by("ref_id")
         )
         metrics = findings_assessment.get_findings_metrics()


### PR DESCRIPTION
## What & why

The findings assessment PDF report printed empty Authors, Reviewers and Owner(s) lines: the template read `.email` on Actor objects, which have no such attribute, and Django renders that as an empty string. Actors now render through `str()`, like the markdown export already does. The dead "Owners" block on the assessment header is removed since FindingsAssessment lost that field in #3255.

The summary table also cut observations at 100 characters. The truncation is removed so the table shows the full text.

The PDF view prefetches finding owners so rendering names does not add a query per owner.

Reported by a customer on the findings tracking feature.

## Test plan

- New tests in `backend/app_tests/api/test_api_findings.py`: author, reviewer and owner names appear in the rendered report, the observation is not truncated, and the PDF endpoint returns 200 with a PDF content type.
- The three template tests fail on the previous template and pass with this change.

## Checklist

- [x] PR title follows Conventional Commits (`!` set if this is a breaking change)
- [x] One focused change, branched off `main`

### Backend — if you touched `backend/`

- [x] `ruff format` run, no new linter errors
- [x] Migrations generated with `makemigrations` and committed (or none needed)

### Tests & documentation — definition of done

- [x] Tests added or updated and passing locally — backend `uv run pytest`
- [x] Regression test added for bug fixes _(if relevant)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Findings assessment PDFs now display author, reviewer, and owner names consistently.
  - Full finding observations are shown without truncation.
  - Assessment owner details are no longer displayed in the assessment information section.
  - Findings assessment PDF responses are validated for reliable generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->