### PR TITLE
[campaigns][TPRM] Fix campaign framework detail link (/undefined/<uuid>)

### DIFF
--- a/frontend/src/lib/utils/crud.ts
+++ b/frontend/src/lib/utils/crud.ts
@@ -2987,7 +2987,7 @@ export const URL_MODEL_MAP: ModelMap = {
 		selectFields: [{ field: 'status' }, { field: 'kind' }],
 		foreignKeyFields: [
 			{ field: 'folder', urlModel: 'folders', urlParams: 'content_type=DO&content_type=GL' },
-			{ field: 'framework', urlModel: 'frameworks' },
+			{ field: 'frameworks', urlModel: 'frameworks' },
 			{ field: 'perimeters', urlModel: 'perimeters' },
 			{ field: 'entities', urlModel: 'entities' }
 		],


### PR DESCRIPTION
Fixes https://github.com/intuitem/ciso-assistant-community/issues/4783

## Summary
- Campaign detail **frameworks** links went to `/undefined/<uuid>` because `URL_MODEL_MAP.campaigns.foreignKeyFields` used `framework` (singular) while the API and `detailViewFields` use `frameworks`.
- One-line map fix so DetailView resolves `urlModel: 'frameworks'`.
- Affects internal and third-party campaigns (same object). Third-party launch (`_launch_third_party`) is unchanged.

## Test plan
- [ ] Open `/campaigns?kind=third_party`, create a campaign with a framework, open the record
- [ ] Framework name in the detail fields links to `/frameworks/<uuid>` (not `/undefined/...`)
- [ ] Same check on an internal campaign
- [ ] Creating a third-party campaign with entities still builds entity assessments (unrelated path)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected campaign framework links to use the proper plural field name, ensuring related framework information is referenced consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->