### PR TITLE
fix(backend/frontend): hash not shown in detailed view of evidences

### DIFF
--- a/backend/core/migrations/0187_backfill_evidencerevision_attachment_hash.py
+++ b/backend/core/migrations/0187_backfill_evidencerevision_attachment_hash.py
@@ -10,9 +10,11 @@ logger = logging.getLogger(__name__)
 def backfill_attachment_hash(apps, schema_editor):
     EvidenceRevision = apps.get_model("core", "EvidenceRevision")
 
-    revisions = EvidenceRevision.objects.exclude(attachment="").exclude(
-        attachment__isnull=True
-    ).filter(attachment_hash__isnull=True)
+    revisions = (
+        EvidenceRevision.objects.exclude(attachment="")
+        .exclude(attachment__isnull=True)
+        .filter(attachment_hash__isnull=True)
+    )
 
     for revision in revisions:
         if not default_storage.exists(revision.attachment.name):

--- a/backend/core/migrations/0187_backfill_evidencerevision_attachment_hash.py
+++ b/backend/core/migrations/0187_backfill_evidencerevision_attachment_hash.py
@@ -1,0 +1,42 @@
+import hashlib
+import logging
+
+from django.core.files.storage import default_storage
+from django.db import migrations
+
+logger = logging.getLogger(__name__)
+
+
+def backfill_attachment_hash(apps, schema_editor):
+    EvidenceRevision = apps.get_model("core", "EvidenceRevision")
+
+    revisions = EvidenceRevision.objects.exclude(attachment="").exclude(
+        attachment__isnull=True
+    ).filter(attachment_hash__isnull=True)
+
+    for revision in revisions:
+        if not default_storage.exists(revision.attachment.name):
+            continue
+        try:
+            hash_obj = hashlib.sha256()
+            with default_storage.open(revision.attachment.name, "rb") as f:
+                for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                    hash_obj.update(chunk)
+            revision.attachment_hash = hash_obj.hexdigest()
+            revision.save(update_fields=["attachment_hash"])
+        except Exception as e:
+            logger.warning(
+                "Failed to backfill attachment hash",
+                revision_id=revision.pk,
+                error=str(e),
+            )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0186_commitment_remove_comment_comment_exactly_one_parent_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_attachment_hash, migrations.RunPython.noop),
+    ]

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -458,6 +458,7 @@
 	"closingDateHelpText": "Actual date the objective was closed or completed",
 	"endDate": "End Date",
 	"attachment": "Attachment",
+	"attachmentHash": "Attachment hash",
 	"observation": "Observation",
 	"observationHelpText": "Additional notes and comments in markdown format",
 	"noObservation": "No observation",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -525,6 +525,7 @@
 	"dueDate": "Date d'échéance",
 	"scheduledDate": "Date initialement prévue",
 	"attachment": "Pièce jointe",
+	"attachmentHash": "Empreinte de la pièce jointe",
 	"observation": "Observation",
 	"observationHelpText": "Notes et commentaires supplémentaires au format markdown",
 	"noObservation": "Aucune observation",


### PR DESCRIPTION
## What & why

The `attachment_hash` field on Evidence Revisions showed up two ways in the detail view:
- the label rendered as the raw `attachment_hash` key instead of a translated label (no i18n message key existed for it)
- the value showed `--` for revisions created before the field was introduced (migration `0124` added the column but never backfilled existing rows)

This adds the missing `attachmentHash` translation key (en/fr) and a data migration that computes the SHA256 hash for existing attachments that don't have one yet, using the same chunked-hashing logic as `EvidenceRevision.save()`.

Closes CA-1849

## Test plan

- Created an `EvidenceRevision` with a real attachment via the Django shell, confirmed the hash is computed and the detail view now shows "Attachment hash" / "Empreinte de la pièce jointe" with the correct value (verified manually in the dev server, both community and enterprise editions — enterprise reuses the same `core` app/migrations).
- `python manage.py makemigrations --check --dry-run core` → no schema drift.
- `pytest core/tests/test_models.py::TestEvidence` → passes.

## Checklist

- [x] PR title follows Conventional Commits (`!` set if this is a breaking change)
- [x] One focused change, branched off `main`

### Backend — if you touched `backend/`

- [x] Migrations generated with `makemigrations` and committed (or none needed)

### Frontend — if you touched `frontend/`

- [x] New/changed UI strings added to `frontend/messages/en.json` (keep keys, preserve `{tokens}`)
- [x] `pnpm run lint` and `pnpm run format` run (prettier check passes on changed files)
<img width="3252" height="1702" alt="image" src="https://github.com/user-attachments/assets/c9320e05-f9b0-478d-af11-db3adb5e8f43" />

## Tests & documentation — definition of done

- [ ] No tests or docs needed for this change — why: fixes a translation key and backfills data via a Django data migration; existing model tests (`TestEvidence`) already cover `attachment_hash` computation and still pass. No migration-test convention exists elsewhere in the repo to follow for the backfill itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Localization**
  - Added French and English labels for attachment fingerprints.
  - Added English messages for date-format settings, confirmations, errors, and unexpected server responses.

- **User Experience**
  - Updated the X-rays empty state.
  - Added an error message for failed X-rays loading.

- **Data Improvements**
  - Existing attachment records can now display computed fingerprint information when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->