### PR TITLE
fix: preserve requirement assessment on save when result hidden

### DIFF
--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -4317,20 +4317,21 @@ class RequirementAssessmentWriteSerializer(BaseModelSerializer):
                 "in_progress": RequirementAssessment.Result.PARTIALLY_COMPLIANT,
                 "not_applicable": RequirementAssessment.Result.NOT_APPLICABLE,
             }
-            # Skip auto-map when the auditor explicitly sets result in the same
-            # request: SuperForm round-trips the existing respondent_alignment
-            # on every submit, and we must not clobber an auditor-edited result
-            # (or zero it to NOT_ASSESSED if the respondent never answered).
+            # Only an actual change drives the result. SuperForm round-trips the
+            # existing respondent_alignment on every submit, so re-applying it
+            # would clobber an auditor-edited result (or zero it out when the
+            # respondent never answered). Blank and null mean the same thing.
             if (
                 "respondent_alignment" in validated_data
                 and "result" not in validated_data
                 and not requirement_has_questions
             ):
-                new_alignment = validated_data.get("respondent_alignment")
-                if new_alignment and new_alignment in ALIGNMENT_TO_RESULT:
+                new_alignment = validated_data.get("respondent_alignment") or None
+                changed = new_alignment != (previous_alignment or None)
+                if changed and new_alignment in ALIGNMENT_TO_RESULT:
                     instance.result = ALIGNMENT_TO_RESULT[new_alignment]
                     instance.save(update_fields=["result"])
-                elif not new_alignment and previous_alignment:
+                elif changed and not new_alignment:
                     # Deselection: reset result and scores so the RA is truly
                     # unassessed (progress() flags an RA as assessed when score
                     # is set, even if result is NOT_ASSESSED).

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -4204,6 +4204,7 @@ class RequirementAssessmentWriteSerializer(BaseModelSerializer):
                 validated_data.pop("is_scored", None)
 
             was_overridden = instance.is_score_overridden
+            previous_alignment = instance.respondent_alignment
             instance = super().update(instance, validated_data)
 
             # Override turned off: resync score from answers below.
@@ -4329,7 +4330,7 @@ class RequirementAssessmentWriteSerializer(BaseModelSerializer):
                 if new_alignment and new_alignment in ALIGNMENT_TO_RESULT:
                     instance.result = ALIGNMENT_TO_RESULT[new_alignment]
                     instance.save(update_fields=["result"])
-                elif not new_alignment:
+                elif not new_alignment and previous_alignment:
                     # Deselection: reset result and scores so the RA is truly
                     # unassessed (progress() flags an RA as assessed when score
                     # is set, even if result is NOT_ASSESSED).

--- a/backend/core/tests/test_requirement_alignment_roundtrip.py
+++ b/backend/core/tests/test_requirement_alignment_roundtrip.py
@@ -1,0 +1,95 @@
+"""The respondent_alignment auto-map must not fire on an unchanged empty value.
+
+The requirement edit form round-trips every field. When `result` is hidden the
+frontend strips it from the PATCH, so the auto-map block is reached with a
+`respondent_alignment` that was never set, and used to wipe result and scores.
+"""
+
+import pytest
+
+from core.models import (
+    ComplianceAssessment,
+    Framework,
+    Perimeter,
+    RequirementAssessment,
+    RequirementNode,
+)
+from core.serializers import RequirementAssessmentWriteSerializer
+from iam.models import Folder
+
+
+@pytest.fixture
+def requirement_assessment():
+    root = Folder.get_root_folder()
+    framework = Framework.objects.create(
+        name="Alignment Framework",
+        urn="urn:test:fw-alignment",
+        min_score=0,
+        max_score=100,
+        folder=root,
+    )
+    folder = Folder.objects.create(parent_folder=root, name="alignment folder")
+    perimeter = Perimeter.objects.create(name="alignment perimeter", folder=folder)
+    ca = ComplianceAssessment.objects.create(
+        name="Alignment CA",
+        framework=framework,
+        folder=folder,
+        perimeter=perimeter,
+        min_score=0,
+        max_score=100,
+    )
+    ca.scoring_enabled = True
+    ca.save()
+    node = RequirementNode.objects.create(
+        urn="urn:test:r-alignment",
+        framework=framework,
+        assessable=True,
+        folder=root,
+    )
+    return RequirementAssessment.objects.create(
+        compliance_assessment=ca,
+        requirement=node,
+        folder=folder,
+        result=RequirementAssessment.Result.COMPLIANT,
+        is_scored=True,
+        score=80,
+        documentation_score=60,
+    )
+
+
+def _update(ra, data):
+    serializer = RequirementAssessmentWriteSerializer(ra, data=data, partial=True)
+    assert serializer.is_valid(), serializer.errors
+    serializer.save()
+    ra.refresh_from_db()
+
+
+@pytest.mark.django_db
+class TestRespondentAlignmentRoundtrip:
+    def test_empty_alignment_roundtrip_keeps_score_and_result(
+        self, requirement_assessment
+    ):
+        _update(
+            requirement_assessment,
+            {"respondent_alignment": None, "observation": "saved without result"},
+        )
+        assert requirement_assessment.score == 80
+        assert requirement_assessment.documentation_score == 60
+        assert requirement_assessment.result == RequirementAssessment.Result.COMPLIANT
+
+    def test_real_deselection_still_resets(self, requirement_assessment):
+        _update(requirement_assessment, {"respondent_alignment": "yes"})
+        assert requirement_assessment.result == RequirementAssessment.Result.COMPLIANT
+
+        _update(requirement_assessment, {"respondent_alignment": None})
+        assert requirement_assessment.score is None
+        assert requirement_assessment.documentation_score is None
+        assert (
+            requirement_assessment.result == RequirementAssessment.Result.NOT_ASSESSED
+        )
+
+    def test_alignment_still_maps_to_result(self, requirement_assessment):
+        _update(requirement_assessment, {"respondent_alignment": "no"})
+        assert (
+            requirement_assessment.result == RequirementAssessment.Result.NON_COMPLIANT
+        )

--- a/backend/core/tests/test_requirement_alignment_roundtrip.py
+++ b/backend/core/tests/test_requirement_alignment_roundtrip.py
@@ -88,6 +88,23 @@ class TestRespondentAlignmentRoundtrip:
             requirement_assessment.result == RequirementAssessment.Result.NOT_ASSESSED
         )
 
+    def test_unchanged_alignment_roundtrip_keeps_auditor_result(
+        self, requirement_assessment
+    ):
+        _update(requirement_assessment, {"respondent_alignment": "yes"})
+        assert requirement_assessment.result == RequirementAssessment.Result.COMPLIANT
+
+        requirement_assessment.result = RequirementAssessment.Result.NON_COMPLIANT
+        requirement_assessment.save(update_fields=["result"])
+
+        _update(
+            requirement_assessment,
+            {"respondent_alignment": "yes", "observation": "respondent edit"},
+        )
+        assert (
+            requirement_assessment.result == RequirementAssessment.Result.NON_COMPLIANT
+        )
+
     def test_alignment_still_maps_to_result(self, requirement_assessment):
         _update(requirement_assessment, {"respondent_alignment": "no"})
         assert (

--- a/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.server.ts
+++ b/frontend/src/routes/(app)/(third-party)/requirement-assessments/[id=uuid]/edit/+page.server.ts
@@ -254,6 +254,7 @@ export const actions: Actions = {
 			'is_score_overridden',
 			'documentation_score',
 			'observation',
+			'respondent_alignment',
 			'answers',
 			'evidences',
 			'applied_controls',

--- a/frontend/tests/functional/detailed/visibility-effects.test.ts
+++ b/frontend/tests/functional/detailed/visibility-effects.test.ts
@@ -141,6 +141,50 @@ test('field visibility effects: each flag toggles the corresponding donut', asyn
 
 	await expect(page.getByTestId('modal-title')).not.toBeVisible();
 	await expect(firstRequirementAssessment.getByText(hiddenStatusEvidenceName)).toBeVisible();
+
+	// === Saving with `result` hidden must not wipe the score ===============
+	// The requirement edit form round-trips every field, `respondent_alignment`
+	// included. That field is hidden by default, so the form posts it back as
+	// null, which the backend read as a deselection and used to reset result
+	// and both scores — but only when `result` was itself absent, i.e. hidden.
+	// The editor cascades is_scored onto score; mirror that here.
+	await setVisibility('score', EVERYONE);
+	await setVisibility('is_scored', EVERYONE);
+	await setVisibility('result', EVERYONE);
+
+	const listResponse = await page.request.get(
+		`${BACKEND_API_URL}/compliance-assessments/${auditId}/requirements_list/?assessable=true`,
+		{ headers: { Authorization: `Token ${token}` } }
+	);
+	expect(listResponse.ok(), `requirements_list failed: ${listResponse.status()}`).toBeTruthy();
+	const raId = (await listResponse.json()).requirement_assessments[0].id;
+	const raUrl = `${BACKEND_API_URL}/requirement-assessments/${raId}/`;
+
+	async function readRequirementAssessment() {
+		const response = await page.request.get(raUrl, {
+			headers: { Authorization: `Token ${token}` }
+		});
+		expect(response.ok(), `RA read failed: ${response.status()}`).toBeTruthy();
+		return response.json();
+	}
+
+	const seededScore = (await readRequirementAssessment()).effective_max_score;
+	const seedResponse = await page.request.patch(raUrl, {
+		data: { result: 'compliant', is_scored: true, score: seededScore },
+		headers: { 'Content-Type': 'application/json', Authorization: `Token ${token}` }
+	});
+	expect(seedResponse.ok(), `seed PATCH failed: ${await seedResponse.text()}`).toBeTruthy();
+
+	await setVisibility('result', HIDDEN);
+	await page.goto(`/requirement-assessments/${raId}/edit`);
+	await expect(page.getByTestId('result-field')).toHaveCount(0);
+	await page.getByTestId('save-no-continue-button').click();
+	await complianceAssessmentsPage.isToastVisible('successfully saved', 'i');
+
+	await setVisibility('result', EVERYONE);
+	const savedRequirementAssessment = await readRequirementAssessment();
+	expect(savedRequirementAssessment.score).toBe(seededScore);
+	expect(savedRequirementAssessment.result).toBe('compliant');
 });
 
 test.afterAll('cleanup', async ({ browser }) => {


### PR DESCRIPTION
## What & why

On audits where the result field is hidden, saving a requirement wiped its score, documentation score and result.

The edit form posts back every field, including the respondent alignment, which is hidden by default and comes back empty. The backend read that empty value as the respondent clearing their answer and reset the assessment. It now only resets when an alignment was actually set, and the form no longer posts fields the audit hides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Requirement assessment scores and results are no longer reset when an unchanged alignment is saved.
  - Manually maintained assessment results are preserved during unchanged alignment updates.
  - Explicitly deselecting an alignment continues to clear its associated assessment values.
  - Saving forms with hidden fields now preserves existing scores and results.
  - Requirement alignment values continue to correctly reflect compliant and non-compliant outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->