### PR TITLE
fix: remove unwanted comment from zip export

### DIFF
--- a/backend/core/templates/snippets/req_node.html
+++ b/backend/core/templates/snippets/req_node.html
@@ -35,8 +35,11 @@
           {{ node.assessments.requirement.get_description_translated }}
         </div>
       {% endif %}
-      {# Driven by questions_dict, which is ordered by Question.order, unlike
-         answers_dict, whose order comes from an unordered Answer queryset. #}
+
+      {% comment %}
+      Driven by questions_dict, which is ordered by Question.order, unlike
+      answers_dict, whose order comes from an unordered Answer queryset.
+      {% endcomment %}
       {% if node.questions_dict %}
         <div class="text-left w-full">
           {% for key, question in node.questions_dict.items %}


### PR DESCRIPTION
## What & why

A comment in the html template was getting rendered because it was multiline and not treated as so.

<img width="1342" height="159" alt="image" src="https://github.com/user-attachments/assets/46b7986a-559d-4be2-a3c4-2c641e0f7c8a" />

## Test plan

1. Create an audit
2. Export it in .zip
3. The HTML page in it should not contain any comment. 

## Checklist

- [X] PR title follows Conventional Commits (`!` set if this is a breaking change)
- [X] One focused change, branched off `main`

### Tests & documentation — definition of done

- [X] No tests or docs needed for this change — why: quick fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reformatted an internal template comment for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->